### PR TITLE
Remove redundant CircleCI step setup remote docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,6 @@ jobs:
       - image: circleci/python:3.6.6-node-browsers
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - restore_cache:
           key: v1-deps-{{ checksum "requirements_test.txt" }}
       - run:
@@ -39,8 +37,6 @@ jobs:
       - image: circleci/python:3.6.6-node-browsers
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - restore_cache:
           key: v1-deps-{{ checksum "requirements_test.txt" }}
       - run:
@@ -142,8 +138,6 @@ jobs:
     - image: circleci/python:3.6.6
     steps:
     - checkout
-    - setup_remote_docker:
-        docker_layer_caching: true
     - run:
         name: Run flake8
         command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,4 @@
 - MVP-360 - muliple markets
 - MVP-382 - add product modal to lesson page
 - MVP-350 - Capabilities learn how to export carousel
+- no ticket - rm redundant CircleCI step setup_remote_docker


### PR DESCRIPTION
This change makes every job in our workflow 15s faster.
We can safely remove it as we don't use `docker` or `docker-compose` commands in any of our jobs.
https://circleci.com/docs/2.0/building-docker-images/#overview

No ticket.
 - [x] Changelog entry added.