### PR TITLE
GP2-500: Include video duration in read time for the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,3 +221,4 @@
 - GP2-420 - get topic details
 - GP2-540 - EP-make-fields-optional
 - GP2-545 - remove airtable
+- GP2-500 - include video duration in read time for the page

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,3 +1,5 @@
 SERVICE_NAME = 'great-cms'
 DASHBOARD_URL = '/dashboard/'
 LOGIN_URL = '/login/'
+
+VIDEO_DURATION_DATA_ATTR_NAME = 'data-v-duration'

--- a/core/templatetags/personalised_blocks.py
+++ b/core/templatetags/personalised_blocks.py
@@ -9,6 +9,14 @@ register = template.Library()
 
 @register.simple_tag
 def render_video_block(block):
+    """Renders a video specifically added via a PersonalisedStructBlock
+
+    Note that the viewing time is NOT added to the <video> node as a custom
+    attribute, unlike what happens in video_tags.render_video(). This is
+    because we don't count viewing time of personalised content in estimated
+    reads, so there's no need for it.
+    """
+
     if not block:
         return ''
     sources = format_html_join('\n', '<source{0}>', [[flatatt(source)] for source in block['video'].sources])

--- a/core/templatetags/video_tags.py
+++ b/core/templatetags/video_tags.py
@@ -3,17 +3,33 @@ from django.forms.utils import flatatt
 
 from django.utils.html import format_html_join, format_html
 
+from core.constants import VIDEO_DURATION_DATA_ATTR_NAME
+
 register = template.Library()
 
 
 @register.simple_tag
 def render_video(block):
+    """Renders a non-personalised video block (eg a hero video)
+
+    Includes a custom attribute on the video element so we can estimate
+    page view time in our post-save hook, without clashing with the automatically
+    added `duration` attribute that a browser may add to <video>.
+
+    This attribute is NOT present on a video used in a PersonalisedStructBlock – see
+    personalised_blocks.render_video_block()
+    """
+
     if not block:
         return ''
+
+    video_duration = getattr(block['video'], 'duration', 0)
+    # The default, above, _should_ never be needed because field is mandatory in the CMS
+
     sources = format_html_join('\n', '<source{0}>', [[flatatt(source)] for source in block['video'].sources])
     return format_html(
         f"""
-            <video controls>
+            <video controls {VIDEO_DURATION_DATA_ATTR_NAME}="{video_duration}">
                 {sources}
                 Your browser does not support the video tag.
             </video>

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -65,7 +65,7 @@ def _update_data_for_appropriate_version(page: Page, data_to_update: dict) -> No
     latest_revision = page.get_latest_revision()
     latest_revision_json = json.loads(latest_revision.content_json)
 
-    # 1. Update the revision, whether it's for the latest Draft or the
+    # 1. Update the revision, whether it's for the latest Draft or the
     # revision which created the current Live page
     for key, value in data_to_update.items():
         # We need to watch out for the timedelta, because it serialises to
@@ -110,6 +110,7 @@ def set_read_time(request, page):
             page=page,
             data_to_update={'estimated_read_duration': timedelta(seconds=seconds)}
         )
+
 
 @hooks.register('after_edit_page')
 def set_lesson_pages_topic_id(request, page):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -32,20 +32,24 @@ def reload_urlconf(urlconf=None):
 
 
 def make_test_video(
+    title="Test file",
     content=b'An example movie file',
     filename='movie.mp4',
     duration=120,
     transcript=None,
     collection_name='Root'
 ):
-
     fake_file = ContentFile(content)
     fake_file.name = filename
-    root_collection = Collection.objects.create(name=collection_name, depth=0)
+    root_collection, _ = Collection.objects.get_or_create(
+        name=collection_name,
+        depth=0
+    )
     media_model = wagtailmedia_models.get_media_model()
     media = media_model(collection=root_collection)
-
+    media.title = title
     media.file = File(fake_file)
+    media.duration=duration
     media.transcript = transcript
 
     return media

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,7 +4,12 @@ import sys
 import requests
 
 from django.conf import settings
+from django.core.files import File
+from django.core.files.base import ContentFile
 from django.urls import clear_url_caches
+
+from wagtail.core.models import Collection
+from wagtailmedia import models as wagtailmedia_models
 
 
 def create_response(json_body={}, status_code=200, content=None):
@@ -23,3 +28,24 @@ def reload_urlconf(urlconf=None):
         reload(sys.modules[urlconf])
     else:
         import_module(urlconf)
+
+
+
+def make_test_video(
+    content=b'An example movie file',
+    filename='movie.mp4',
+    duration=120,
+    transcript=None,
+    collection_name='Root'
+):
+
+    fake_file = ContentFile(content)
+    fake_file.name = filename
+    root_collection = Collection.objects.create(name=collection_name, depth=0)
+    media_model = wagtailmedia_models.get_media_model()
+    media = media_model(collection=root_collection)
+
+    media.file = File(fake_file)
+    media.transcript = transcript
+
+    return media

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -30,9 +30,8 @@ def reload_urlconf(urlconf=None):
         import_module(urlconf)
 
 
-
 def make_test_video(
-    title="Test file",
+    title='Test file',
     content=b'An example movie file',
     filename='movie.mp4',
     duration=120,
@@ -49,7 +48,7 @@ def make_test_video(
     media = media_model(collection=root_collection)
     media.title = title
     media.file = File(fake_file)
-    media.duration=duration
+    media.duration = duration
     media.transcript = transcript
 
     return media

--- a/tests/unit/core/factories.py
+++ b/tests/unit/core/factories.py
@@ -3,7 +3,7 @@ import factory.fuzzy
 import wagtail_factories
 import wagtail_personalisation.models
 
-from core import models, rules
+from core import blocks, models, rules
 from tests.unit.domestic.factories import DomesticHomePageFactory
 
 
@@ -123,3 +123,10 @@ class TourFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = models.Tour
+
+
+class SimpleVideoBlockFactory(wagtail_factories.StructBlockFactory):
+    video = None
+
+    class Meta:
+        model = blocks.SimpleVideoBlock

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -2,14 +2,12 @@ from unittest import mock
 
 import pytest
 from django.core.exceptions import ValidationError
-from django.core.files import File
 from django.test import TestCase
 from wagtail.core.models import Collection
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.tests.utils import WagtailPageTests, WagtailTestUtils
 from wagtail_factories import ImageFactory
-from wagtailmedia import models
 
 from core.models import (
     AbstractObjectHash,
@@ -156,7 +154,7 @@ class TestGreatMedia(TestCase):
         }])
 
     def test_sources_mp4_with_transcript(self):
-        media = make_test_video(transcript = 'A test transcript text')
+        media = make_test_video(transcript='A test transcript text')
 
         self.assertEqual(media.sources, [{
             'src': '/media/movie.mp4',

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 from django.core.exceptions import ValidationError
 from django.core.files import File
-from django.core.files.base import ContentFile
 from django.test import TestCase
 from wagtail.core.models import Collection
 from wagtail.images import get_image_model
@@ -23,6 +22,7 @@ from core.models import (
 from domestic.models import DomesticDashboard, DomesticHomePage
 from exportplan.models import ExportPlanDashboardPage
 from tests.unit.core import factories
+from tests.helpers import make_test_video
 from .factories import DetailPageFactory
 
 
@@ -148,13 +148,7 @@ class TestImageAltRendition(TestCase, WagtailTestUtils):
 
 class TestGreatMedia(TestCase):
     def test_sources_mp4_with_no_transcript(self):
-        fake_file = ContentFile(b'An example movie file')
-        fake_file.name = 'movie.mp4'
-        root_collection = Collection.objects.create(name='Root', depth=0)
-        media_model = models.get_media_model()
-        media = media_model(collection=root_collection)
-
-        media.file = File(fake_file)
+        media = make_test_video()
         self.assertEqual(media.sources, [{
             'src': '/media/movie.mp4',
             'type': 'video/mp4',
@@ -162,14 +156,7 @@ class TestGreatMedia(TestCase):
         }])
 
     def test_sources_mp4_with_transcript(self):
-        fake_file = ContentFile(b'An example movie file')
-        fake_file.name = 'movie.mp4'
-        root_collection = Collection.objects.create(name='Root', depth=0)
-        media_model = models.get_media_model()
-        media = media_model(collection=root_collection)
-
-        media.file = File(fake_file)
-        media.transcript = 'A test transcript text'
+        media = make_test_video(transcript = 'A test transcript text')
 
         self.assertEqual(media.sources, [{
             'src': '/media/movie.mp4',

--- a/tests/unit/core/test_wagtail_hooks.py
+++ b/tests/unit/core/test_wagtail_hooks.py
@@ -15,13 +15,13 @@ from tests.unit.exportplan.factories import (
 from tests.unit.learn.factories import LessonPageFactory
 
 LOREM_IPSUM = (
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-    "Verum hoc loco sumo verbis his eandem certe vim voluptatis "
-    "Epicurum nosse quam ceteros. Consequentia exquirere, quoad sit "
-    "id, quod volumus, effectum. Et quidem saepe quaerimus verbum "
-    "Latinum par Graeco et quod idem valeat; Quam illa ardentis "
-    "amores excitaret sui! Cur tandem? Nihil est enim, de quo aliter "
-    "tu sentias atque ego, modo commutatis verbis ipsas res conferamus. "
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '
+    'Verum hoc loco sumo verbis his eandem certe vim voluptatis '
+    'Epicurum nosse quam ceteros. Consequentia exquirere, quoad sit '
+    'id, quod volumus, effectum. Et quidem saepe quaerimus verbum '
+    'Latinum par Graeco et quod idem valeat; Quam illa ardentis '
+    'amores excitaret sui! Cur tandem? Nihil est enim, de quo aliter '
+    'tu sentias atque ego, modo commutatis verbis ipsas res conferamus. '
 )
 
 
@@ -210,18 +210,18 @@ def test_estimated_read_time_calculation(rf, domestic_homepage):
     request = rf.get('/')
     request.user = AnonymousUser()
 
-    READING_CONTENT = f'<p>{ LOREM_IPSUM * 10}</p>'
+    reading_content = f'<p>{ LOREM_IPSUM * 10}</p>'
 
     detail_page = factories.DetailPageFactory(
         parent=domestic_homepage,
-        template="learn/detail_page.html",
+        template='learn/detail_page.html',
         hero=[],
         body=[],
         objective=[
-          ('paragraph', RichText(READING_CONTENT))
+            ('paragraph', RichText(reading_content))
         ],
     )
-    # Every real-world page will have a revision, so the test needs one, too
+    # Every real-world page will have a revision, so the test needs one, too
     revision = detail_page.save_revision()
     revision.publish()
 
@@ -248,16 +248,16 @@ def test_estimated_read_time_calculation__checks_text_and_video(rf, domestic_hom
     video_for_hero = make_test_video(duration=123)
     video_for_hero.save()
 
-    READING_CONTENT = f'<p>{ LOREM_IPSUM * 10}</p>'
+    reading_content = f'<p>{ LOREM_IPSUM * 10}</p>'
 
     detail_page = factories.DetailPageFactory(
         parent=domestic_homepage,
-        template="learn/detail_page.html",
+        template='learn/detail_page.html',
         hero=[
             ('Video', factories.SimpleVideoBlockFactory(video=video_for_hero)),
         ],
         objective=[
-          ('paragraph', RichText(READING_CONTENT))
+            ('paragraph', RichText(reading_content))
         ],
         body=[
             # For now, the body ONLY contains PersonalisedStructBlocks, which don't
@@ -266,11 +266,11 @@ def test_estimated_read_time_calculation__checks_text_and_video(rf, domestic_hom
             # time for if/when we need to.
         ],
     )
-    # Every real-world page will have a revision, so the test needs one, too
+    # Every real-world page will have a revision, so the test needs one, too
     revision = detail_page.save_revision()
     revision.publish()
 
-    expected_duration = timedelta(seconds=155 + 123)  # reading + watching
+    expected_duration = timedelta(seconds=155 + 123)  # reading + watching
 
     detail_page.refresh_from_db()
     assert detail_page.estimated_read_duration != expected_duration
@@ -295,7 +295,7 @@ def test_estimated_read_time_calculation__checks_video(rf, domestic_homepage):
 
     detail_page = factories.DetailPageFactory(
         parent=domestic_homepage,
-        template="learn/detail_page.html",
+        template='learn/detail_page.html',
         hero=[
             ('Video', factories.SimpleVideoBlockFactory(video=video_for_hero)),
         ],
@@ -307,11 +307,11 @@ def test_estimated_read_time_calculation__checks_video(rf, domestic_homepage):
             # time for if/when we need to.
         ],
     )
-    # Every real-world page will have a revision, so the test needs one, too
+    # Every real-world page will have a revision, so the test needs one, too
     revision = detail_page.save_revision()
     revision.publish()
 
-    expected_duration = timedelta(seconds=6 + 123)  # reading + watching
+    expected_duration = timedelta(seconds=6 + 123)  # reading + watching
 
     detail_page.refresh_from_db()
     assert detail_page.estimated_read_duration != expected_duration
@@ -323,7 +323,6 @@ def test_estimated_read_time_calculation__checks_video(rf, domestic_homepage):
 
     detail_page.refresh_from_db()
     assert detail_page.estimated_read_duration == expected_duration
-
 
 
 @pytest.mark.django_db

--- a/tests/unit/core/test_wagtail_hooks.py
+++ b/tests/unit/core/test_wagtail_hooks.py
@@ -1,12 +1,28 @@
-import pytest
+from datetime import timedelta
 
+import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.middleware import SessionMiddleware
+from wagtail.core.rich_text import RichText
 
 from core import wagtail_hooks
-from tests.unit.learn.factories import LessonPageFactory
-from tests.unit.exportplan.factories import ExportPlanPageFactory, ExportPlanDashboardPageFactory
+from tests.helpers import make_test_video
 from tests.unit.core import factories
+from tests.unit.exportplan.factories import (
+    ExportPlanDashboardPageFactory,
+    ExportPlanPageFactory,
+)
+from tests.unit.learn.factories import LessonPageFactory
+
+LOREM_IPSUM = (
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+    "Verum hoc loco sumo verbis his eandem certe vim voluptatis "
+    "Epicurum nosse quam ceteros. Consequentia exquirere, quoad sit "
+    "id, quod volumus, effectum. Et quidem saepe quaerimus verbum "
+    "Latinum par Graeco et quod idem valeat; Quam illa ardentis "
+    "amores excitaret sui! Cur tandem? Nihil est enim, de quo aliter "
+    "tu sentias atque ego, modo commutatis verbis ipsas res conferamus. "
+)
 
 
 @pytest.mark.django_db
@@ -194,12 +210,120 @@ def test_estimated_read_time_calculation(rf, domestic_homepage):
     request = rf.get('/')
     request.user = AnonymousUser()
 
-    detail_page = factories.DetailPageFactory(parent=domestic_homepage)
-    response = wagtail_hooks.set_read_time(
+    READING_CONTENT = f'<p>{ LOREM_IPSUM * 10}</p>'
+
+    detail_page = factories.DetailPageFactory(
+        parent=domestic_homepage,
+        template="learn/detail_page.html",
+        hero=[],
+        body=[],
+        objective=[
+          ('paragraph', RichText(READING_CONTENT))
+        ],
+    )
+    # Every real-world page will have a revision, so the test needs one, too
+    revision = detail_page.save_revision()
+    revision.publish()
+
+    expected_duration = timedelta(seconds=154)
+
+    detail_page.refresh_from_db()
+    assert detail_page.estimated_read_duration != expected_duration
+
+    wagtail_hooks.set_read_time(
         page=detail_page,
         request=request
     )
-    assert response > 0
+
+    detail_page.refresh_from_db()
+    assert detail_page.estimated_read_duration == expected_duration
+
+
+@pytest.mark.django_db
+def test_estimated_read_time_calculation__checks_text_and_video(rf, domestic_homepage):
+
+    request = rf.get('/')
+    request.user = AnonymousUser()
+
+    video_for_hero = make_test_video(duration=123)
+    video_for_hero.save()
+
+    READING_CONTENT = f'<p>{ LOREM_IPSUM * 10}</p>'
+
+    detail_page = factories.DetailPageFactory(
+        parent=domestic_homepage,
+        template="learn/detail_page.html",
+        hero=[
+            ('Video', factories.SimpleVideoBlockFactory(video=video_for_hero)),
+        ],
+        objective=[
+          ('paragraph', RichText(READING_CONTENT))
+        ],
+        body=[
+            # For now, the body ONLY contains PersonalisedStructBlocks, which don't
+            # count towards page read or view time.
+            # WARNING: These is a fiddle to set up in tests, so estimate appropriate
+            # time for if/when we need to.
+        ],
+    )
+    # Every real-world page will have a revision, so the test needs one, too
+    revision = detail_page.save_revision()
+    revision.publish()
+
+    expected_duration = timedelta(seconds=155 + 123)  # reading + watching
+
+    detail_page.refresh_from_db()
+    assert detail_page.estimated_read_duration != expected_duration
+
+    wagtail_hooks.set_read_time(
+        page=detail_page,
+        request=request
+    )
+
+    detail_page.refresh_from_db()
+    assert detail_page.estimated_read_duration == expected_duration
+
+
+@pytest.mark.django_db
+def test_estimated_read_time_calculation__checks_video(rf, domestic_homepage):
+
+    request = rf.get('/')
+    request.user = AnonymousUser()
+
+    video_for_hero = make_test_video(duration=123)
+    video_for_hero.save()
+
+    detail_page = factories.DetailPageFactory(
+        parent=domestic_homepage,
+        template="learn/detail_page.html",
+        hero=[
+            ('Video', factories.SimpleVideoBlockFactory(video=video_for_hero)),
+        ],
+        objective=[],
+        body=[
+            # For now, the body ONLY contains PersonalisedStructBlocks, which don't
+            # count towards page read or view time.
+            # WARNING: These is a fiddle to set up in tests, so estimate appropriate
+            # time for if/when we need to.
+        ],
+    )
+    # Every real-world page will have a revision, so the test needs one, too
+    revision = detail_page.save_revision()
+    revision.publish()
+
+    expected_duration = timedelta(seconds=6 + 123)  # reading + watching
+
+    detail_page.refresh_from_db()
+    assert detail_page.estimated_read_duration != expected_duration
+
+    wagtail_hooks.set_read_time(
+        page=detail_page,
+        request=request
+    )
+
+    detail_page.refresh_from_db()
+    assert detail_page.estimated_read_duration == expected_duration
+
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_templatetags.py
+++ b/tests/unit/test_templatetags.py
@@ -4,7 +4,7 @@ from core.templatetags.personalised_blocks import render_video_block
 from core.templatetags.video_tags import render_video
 
 
-def test_render_video_block_tag():
+def test_render_personalised_video_block_tag():
     video_mock = mock.Mock(
         sources=[{'src': '/media/foo.mp4', 'type': 'video/mp4'}]
     )
@@ -20,16 +20,17 @@ def test_render_video_block_tag():
     assert 'Your browser does not support the video tag.' in html
 
 
-def test_render_video_tag():
+def test_general_render_video_tag():
     video_mock = mock.Mock(
-        sources=[{'src': '/media/foo.mp4', 'type': 'video/mp4'}]
+        sources=[{'src': '/media/foo.mp4', 'type': 'video/mp4'}],
+        duration=120,
     )
     block = dict(
         video=video_mock
     )
     html = render_video(block)
 
-    assert '<video controls>' in html
+    assert '<video controls data-v-duration="120">' in html
     assert '<source src="/media/foo.mp4" type="video/mp4">' in html
     assert 'Your browser does not support the video tag.' in html
 


### PR DESCRIPTION
This changeset adds counting of video duration in the read time of a page.

Given we're already rendering and parsing the HTML page, the most effective solution was simply to annotate the `<video>` blocks with a custom, non-clashing data attribute, which we then pull out of the HTML with BeautifulSoup and add to our `readtime` calculation.

 - [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-500 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added.
 - [X] How to test locally, including how to set up appropriate data

* Have at least one lesson in place - note what the current readtime of it is.
* Add a video to the Media section of the CMS, including a duration in seconds - eg 120
* Edit a lesson and add a video as the Hero block (videos and text in the Personalised content section are ignored for readtime purposes)
* Save that page AS DRAFT.
* Preview the draft and confirm the readtime has generally increased by the equivalent number of minutes
* View the live page and confirm the readtime is still the original value there (ie, we've not updated the live page yet)
* Publish your draft page
* Re-view the live page and confirm the readtime is still now the updated value

Bonus: check direct-to-live change
* In the Media section of the CMS, pick the same video and double its duration
* Edit the lesson page again and simply re-publish it (ie, create a new live version with no other content changes apart from what you've changed for the Video duration over in the media panel)
* View the live page and confirm the readtime has increased by the appropriate amount.

Caveats: 
* If you update the duration on a media file, you need to re-publish the page that features it to be able to update its readtime. Product (Miranda) knows this and seems fine with the limitation
* We still say 'X mins read' on the page, rather than 'X mins' - at least for now, until UX has a clear decision on it


Notes:
* This is my first PR here, and I'm very open to all the feedback I can get on it, to help me get in tune with the team. Don't hold back!
* It's taken longer than hoped, but I may still try to slide in some more tests if you agree they are worthwhile.


 
