### PR TITLE
GP2-744 and GP2-745: Improve validation of Case Study body streamfield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,3 +263,4 @@
 - GP2-667 - appropriately scoped configuration for Wagtail Transfer when deployed
 - GP2-656 - Make transcript field mandatory for GreatMedia
 - GP2-709 - BE Country add required country signal
+- GP2-744 and GP2-744 - tighten up validation for CaseStudy.body StreamField

--- a/core/models.py
+++ b/core/models.py
@@ -683,13 +683,14 @@ def _high_level_validation(value, error_messages):
     TEXT_BLOCK = 'text'  # noqa N806
     MEDIA_BLOCK = 'media'  # noqa N806
 
-    if set([node.block_type for node in value]) != {
-        TEXT_BLOCK, MEDIA_BLOCK
-    }:
+    # we need to be strict about presence and ordering of these nodes
+    if [node.block_type for node in value] != [
+        MEDIA_BLOCK, TEXT_BLOCK
+    ]:
         error_messages.append(
             (
                 'This block must contain one Media section (with one or '
-                'two items in it) and one Text section.'
+                'two items in it), then one Text section following it.'
             )
         )
 

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -291,7 +291,13 @@ _case_study_video_order_error_message = 'The video must come before a still imag
         ([('media', ('video',))], _case_study_top_level_error_message),
         ([], None),
         (['text', 'text'], _case_study_top_level_error_message),
+        (['text', ('media', ('video', 'image'))], _case_study_top_level_error_message),
         ([('media', ('video',)), ('media', ('video',))], _case_study_top_level_error_message),
+        (['text', ('media', ('video', 'image')), 'text'], _case_study_top_level_error_message),
+        (
+            [('media', ('video', 'image')), 'text', ('media', ('video', 'image'))],
+            _case_study_top_level_error_message
+        ),
         ([('media', ('video', 'image')), 'text'], None),
         ([('media', ('video',)), 'text'], None),
         ([('media', ('image',)), 'text'], None),
@@ -310,14 +316,17 @@ _case_study_video_order_error_message = 'The video must come before a still imag
         '2. Top-level check: media node only: not fine',
         '3. Top-level check: no nodes: fine - requirement is done at a higher level',
         '4. Top-level check: two text nodes: not fine',
-        '5. Top-level check: two media nodes: not fine',
+        '5. Top-level check: text before media: not fine',
+        '6. Top-level check: two media nodes: not fine',
+        '7. Top-level check: text, media, text: not fine',
+        '8. Top-level check: media, text, media: not fine',
 
-        '6. media node (video and image) and text node: fine',
-        '7. media node (video only) and text node: fine',
-        '8. media node (image only) and text node: fine',
-        '9. media node (two images) and text node: fine',
-        '10. media node (image before video) and text node: not fine',
-        '11. media node (two videos) and text node: not fine',
+        '9. media node (video and image) and text node: fine',
+        '10. media node (video only) and text node: fine',
+        '11. media node (image only) and text node: fine',
+        '12. media node (two images) and text node: fine',
+        '13. media node (image before video) and text node: not fine',
+        '14. media node (two videos) and text node: not fine',
     )
 )
 def test_case_study_body_validation(block_type_values, exception_message):


### PR DESCRIPTION
* Fix bug where max of two elements in media block was not being enforced
* Improve validation to ensure that a Media node HAS to precede a Text node

 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/GP2-744 https://uktrade.atlassian.net/browse/GP2-745 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added.

 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
