### PR TITLE
GP2-726: Redirect unauthenticated users on CMS pages to the sign-in page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,11 @@
 - GP2-315 - route to market backend integration
 
 ### Implemented enhancements
+- GP2-726 - Redirect unauthenticated users on CMS pages to the sign-in page
 - GP2-736 - Support lesson placeholders
 - GP2-443 - scroll to new route market
 - GP2-732 - marketing approach styling and content update
-- GP2-759 - Product search no-header 
+- GP2-759 - Product search no-header
 - GP2-759 - Product-search No results + feature flag to allow UR
 - GP2-755 - Add objectives section title
 - GP2-299 - Step by step reduce image size

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -45,4 +45,5 @@ class AnonymousUserRequired:
 
 
 class AuthenticatedUserRequired:
+    # used by core.wagtail_hooks.authenticated_user_required
     authenticated_user_required_redirect_url = constants.LOGIN_URL

--- a/core/models.py
+++ b/core/models.py
@@ -205,7 +205,13 @@ class TimeStampedModel(models.Model):
 
 # Content models
 
-class CMSGenericPage(PersonalisablePageMixin, mixins.EnableTourMixin, mixins.ExportPlanMixin, Page):
+class CMSGenericPage(
+    PersonalisablePageMixin,
+    mixins.EnableTourMixin,
+    mixins.ExportPlanMixin,
+    mixins.AuthenticatedUserRequired,
+    Page
+):
     """
     Generic page, freely inspired by Codered page
     """

--- a/tests/unit/core/factories.py
+++ b/tests/unit/core/factories.py
@@ -40,6 +40,15 @@ class LandingPageFactory(wagtail_factories.PageFactory):
         django_get_or_create = ['slug', 'parent']
 
 
+class InterstitialPageFactory(wagtail_factories.PageFactory):
+    title = 'Interstitial page'
+    template = 'learn/interstitial.html'
+
+    class Meta:
+        model = models.InterstitialPage
+        django_get_or_create = ['slug', 'parent']
+
+
 class ListPageFactory(wagtail_factories.PageFactory):
     title = 'List page'
     live = True

--- a/tests/unit/core/test_middleware.py
+++ b/tests/unit/core/test_middleware.py
@@ -43,13 +43,15 @@ def test_stores_user_location_anon_user(mock_store_user_location, rf):
 
 
 @pytest.mark.django_db
-def test_user_specific_redirect_middleware(domestic_site, client):
+def test_user_specific_redirect_middleware(domestic_site, client, user, patch_export_plan):
     learn_page = factories.LandingPageFactory(parent=domestic_site.root_page, slug='learn')
     introduction_page = factories.ListPageFactory(
         parent=learn_page, slug='introduction', template='learn/automated_list_page.html'
     )
     categories_page = factories.CuratedListPageFactory(parent=learn_page, slug='categories')
     # Given the user has gone to /learn/introduction/
+
+    client.force_login(user)  # because unauthed users get redirected
     response = client.get(introduction_page.url)
 
     assert response.status_code == 200

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -12,6 +12,7 @@ from wagtail.images.tests.utils import get_test_image_file
 from wagtail.tests.utils import WagtailPageTests, WagtailTestUtils
 from wagtail_factories import ImageFactory
 
+from core.mixins import AuthenticatedUserRequired
 from core.models import (
     AbstractObjectHash,
     CuratedListPage,
@@ -80,7 +81,13 @@ def test_detail_page_anon_user_not_marked_as_read(client, domestic_homepage, dom
 
 
 @pytest.mark.django_db
-def test_curated_list_page_has_link_in_context_back_to_parent(client, domestic_homepage, domestic_site):
+def test_curated_list_page_has_link_in_context_back_to_parent(
+    client,
+    domestic_homepage,
+    domestic_site,
+    user,
+    patch_export_plan
+):
 
     list_page = factories.ListPageFactory(
         parent=domestic_homepage,
@@ -94,6 +101,8 @@ def test_curated_list_page_has_link_in_context_back_to_parent(client, domestic_h
 
     expected_url = list_page.url
     assert expected_url == '/example-learning-homepage/'
+
+    client.force_login(user)  # because unauthed users get redirected
 
     resp = client.get(curated_list_page.url)
 
@@ -416,6 +425,44 @@ class DetailPageTests(WagtailPageTests):
                 hero=[('Image', ImageFactory()), ('Image', ImageFactory())]
             )
             self.assert_(detail_page, None)
+
+
+@pytest.mark.django_db
+def test_redirection_for_unauthenticated_user(
+    client,
+    domestic_homepage,
+    domestic_site,
+    patch_export_plan,
+    user
+):
+
+    landing_page = factories.LandingPageFactory(parent=domestic_homepage)
+    interstitial_page = factories.InterstitialPageFactory(parent=landing_page)
+    list_page = factories.ListPageFactory(parent=domestic_homepage)
+    curated_list_page = factories.CuratedListPageFactory(parent=list_page)
+    detail_page = factories.DetailPageFactory(parent=curated_list_page)
+
+    pages = [
+        landing_page,
+        interstitial_page,
+        list_page,
+        curated_list_page,
+        detail_page,
+    ]
+
+    for page in pages:
+        assert isinstance(page, AuthenticatedUserRequired)
+
+    for page in pages:
+        response = client.get(page.url, follow=False)
+        assert response.status_code == 302
+        assert response._headers['location'] == ('Location', '/login/')
+
+    # Show an authenticated user can still get in there
+    client.force_login(user)
+    for page in pages:
+        response = client.get(page.url, follow=False)
+        assert response.status_code == 200
 
 
 class TestImageAltRendition(TestCase, WagtailTestUtils):


### PR DESCRIPTION
This changeset adds`mixins.AuthenticatedUserRequired` to the base page used for most CMS pages (`CMSGenericPage`) so that, if the user is unauthenticated, they are redirected to the login page.

This also has the (requested/desired) side effect that the existing behaviour upon logout (kill session and reload the same page) now causes a redirect when the page is reloaded. Ideally we'd skip the reload, but given this is is a temporary change, I think it's fine for now)

Note that when a user is redirected to signin, we don't remember where they wanted to go originally. This is not ideal, but tolerable within the AC for this piece.

 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/GP2-726 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added.
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
