### PR TITLE
GP2-164: Show topic progress beside list of lessons in a module page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 ### Implemented enhancements
 - GP2-751 - Add link back to module, featuring topic name
 - GP2-955 - Target-market-page - disable and coming soon
+- GP2-164 - Add topic-level progress counters to module page (one per topic block)
 - GP2-913 - Target_market_page - trigger product selector
 - GP2-917 - Target_market_page
 - GP2-868 - Update coming soon modal copy

--- a/core/templates/core/curated_topic.html
+++ b/core/templates/core/curated_topic.html
@@ -1,10 +1,19 @@
 {% load wagtailcore_tags %}
 {% load format_timedelta from content_tags %}
+{% load get_lesson_progress_for_topic from content_tags %}
+
+{% comment %} `lesson_completion_data` is the lesson completion data FOR THE TOPIC BEING RENDERED HERE {% endcomment %}
+
 <div class="grid" id="{{topic_id}} test_container">
 
     <div class="learn__topic-item-details c-1-3-l">
         <h2 class="learn__topic-item-title h-m p-b-xxs p-t-0">{{ value.title }}</h2>
-        <!-- <p class="body-m-b m-t-xxs m-b-0">1 / 23 lessons complete</p> -->
+        {% get_lesson_progress_for_topic lesson_completion_data value.lessons_and_placeholders as topic_progress_data %}
+        {% if topic_progress_data %}
+        <p class="body-m-b m-t-xxs m-b-0">
+            {{topic_progress_data.lessons_completed}} / {{topic_progress_data.lessons_available}} lessons complete
+        </p>
+        {% endif %}
     </div>
     <ul class="learn__lessons-list c-2-3-l">
         {% for item in value.lessons_and_placeholders %}

--- a/core/templates/core/curated_topic.html
+++ b/core/templates/core/curated_topic.html
@@ -3,7 +3,8 @@
 <div class="grid" id="{{topic_id}} test_container">
 
     <div class="learn__topic-item-details c-1-3-l">
-        <h2 class="learn__topic-item-title h-m p-t-0">{{ value.title }}</h2>
+        <h2 class="learn__topic-item-title h-m p-b-xxs p-t-0">{{ value.title }}</h2>
+        <!-- <p class="body-m-b m-t-xxs m-b-0">1 / 23 lessons complete</p> -->
     </div>
     <ul class="learn__lessons-list c-2-3-l">
         {% for item in value.lessons_and_placeholders %}

--- a/core/templatetags/content_tags.py
+++ b/core/templatetags/content_tags.py
@@ -75,3 +75,24 @@ def get_topic_title_for_lesson(detail_page: DetailPage) -> str:
                     return topic_block.value.get('title')
 
     return ''
+
+
+@register.simple_tag
+def get_lesson_progress_for_topic(lesson_completion_data, lessons_and_placeholders) -> dict:
+    # Computes simple stats from the data structures passed in, doing a light safety check along the way
+    lesson_ids = [
+        x.value.id for x in lessons_and_placeholders
+        if x.block_type == LESSON_BLOCK
+    ]
+
+    # Watch out for zany data, such as more items completed than currently available
+    if lesson_completion_data and not lesson_completion_data.issubset(set(lesson_ids)):
+        return {}
+
+    lessons_completed = len(lesson_completion_data) if lesson_completion_data else 0
+    lessons_available = len(lesson_ids)
+
+    return {
+        'lessons_completed': lessons_completed,
+        'lessons_available': lessons_available
+    }


### PR DESCRIPTION
This changeset adds topic-level progress counters beside each topic on a module page / CuratedListPage.

It has to do a bit of extra work to re-count the lessons in the topic, but I thought that was less of a mess than refactoring a chain of two helper functions to pass down the additional data for use in a single place. Say if you disagree! 😄 

 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/GP2-164 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added.

 - [X] (if is a UI change) Includes screenshot(s) - ideally before and after, but at least after

![Screenshot 2020-10-29 at 16 22 13](https://user-images.githubusercontent.com/101457/97603956-da530f80-1a04-11eb-9400-d04362af7f3a.png)
 
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
