### PR TITLE
Gp2-434 Dashboard routing blocks align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - no ticket - Dependencies upgrade
 
 ### Fixed bugs
+- GP2-434 - Dashboard routing blocks alignment
 - GP2-681 - HR colour in product finder 
 - GP2-957 - Remove territories from marklety selector
 - GP2-963 - Pressing 'return' in market modal search, reloads page 

--- a/core/templates/core/includes/routing_bar.html
+++ b/core/templates/core/includes/routing_bar.html
@@ -29,6 +29,7 @@ As seen at the top of the domestic dashboard.
       {% endfor %}
   </div>
   <script>
+    // set the blocks in the routing bar to the height of the largest
     (() => {
       const blockList = document.body.querySelectorAll('#pre-journey-routing-component .dashboard__routing-block .g-card')
       const fixHeights = () => {
@@ -41,9 +42,10 @@ As seen at the top of the domestic dashboard.
           block.style.height = height+'px';
         })
       }
-
-      window.addEventListener('resize', fixHeights)
-      fixHeights();
+      if(blockList.length > 1) { // no point if there is only one
+        window.addEventListener('resize', fixHeights)
+        fixHeights();
+      }
     })()
   </script>
 {% endif %}

--- a/core/templates/core/includes/routing_bar.html
+++ b/core/templates/core/includes/routing_bar.html
@@ -28,4 +28,22 @@ As seen at the top of the domestic dashboard.
           </article>
       {% endfor %}
   </div>
+  <script>
+    (() => {
+      const blockList = document.body.querySelectorAll('#pre-journey-routing-component .dashboard__routing-block .g-card')
+      const fixHeights = () => {
+        let height = 0;
+        blockList.forEach((block) => {
+          block.style.height = 'auto';
+          height = Math.max(height,block.offsetHeight);
+        })
+        blockList.forEach((block) => {
+          block.style.height = height+'px';
+        })
+      }
+
+      window.addEventListener('resize', fixHeights)
+      fixHeights();
+    })()
+  </script>
 {% endif %}


### PR DESCRIPTION
The dashboard routing blocks are CMS driven, and so can have varying heights.  This PR is a little inline script to straighten them out. 

 - [x] Ticket exists in Jira  https://uktrade.atlassian.net/browse/TICKET_ID_HERE 
 - [x] Jira ticket has the correct status.
 - [x] [Changelog](CHANGELOG.md) entry added.
 - [x] (if is a UI change) Includes screenshot(s) - ideally before and after, but at least after
 
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
