### PR TITLE
GP2-884: Cleanup old use of lessons_and_topics streamfield

### DIFF
--- a/core/blocks.py
+++ b/core/blocks.py
@@ -43,6 +43,7 @@ class LessonPlaceholderBlock(blocks.StructBlock):
         template = 'learn/_lesson_placeholder.html'
 
 
+# TODO: remove this, because it's deprecated
 class CuratedTopicBlock(blocks.StructBlock):
     title = blocks.CharBlock(max_length=255)
     lessons_and_placeholders = blocks.StreamBlock(

--- a/core/templates/core/curated_topic.html
+++ b/core/templates/core/curated_topic.html
@@ -1,14 +1,14 @@
 {% load wagtailcore_tags %}
 {% load format_timedelta from content_tags %}
-{% load get_lesson_progress_for_topic from content_tags %}
+{% load get_lesson_progress_for_topic is_lesson_page is_placeholder_page from content_tags %}
 
 {% comment %} `completed_lessons` only features lessons FOR THIS PARTIAL'S TOPIC {% endcomment %}
 
-<div class="grid" id="{{topic_id}} test_container">
+<div class="grid" id="{{topic.id}}">
 
     <div class="learn__topic-item-details c-1-3-l">
-        <h2 class="learn__topic-item-title h-m p-b-xxs p-t-0">{{ value.title }}</h2>
-        {% get_lesson_progress_for_topic completed_lessons topic_id as topic_progress_data %}
+        <h2 class="learn__topic-item-title h-m p-b-xxs p-t-0">{{ topic.title }}</h2>
+        {% get_lesson_progress_for_topic completed_lessons topic.id as topic_progress_data %}
         {% if topic_progress_data %}
         <p class="body-m-b m-t-xxs m-b-0">
             {{topic_progress_data.lessons_completed}} / {{topic_progress_data.lessons_available}} lessons complete
@@ -16,13 +16,12 @@
         {% endif %}
     </div>
     <ul class="learn__lessons-list c-2-3-l">
-        {% for item in value.lessons_and_placeholders %}
-            {% if item.block_type == 'lesson' %}
-            {% with item.value as page %}
+        {% for page in topic.get_children.live %}
+            {% if page|is_lesson_page %}
             <li class="learn__lesson-item">
                 <a class="learn__lesson-item-link h-xs" href="{% pageurl page %}" title="{{ page.title }}">
                     <span class="learn__lesson-item-link-text">{{ page.title }}</span>
-                    {% if page.id in lesson_completion_data %}
+                    {% if page.id in completed_lessons %}
                     <span class="button button--quaternary button--small f-r">
                         Completed
                     </span>
@@ -34,9 +33,8 @@
                     {% endif %}
                 </a>
             </li>
-            {% endwith %}
-            {% elif item.block_type == 'placeholder'%}
-                {% include_block item %}
+            {% elif page|is_placeholder_page %}
+                {% include "learn/_lesson_placeholder.html" %}
             {% endif %}
         {% endfor %}
     </ul>

--- a/core/templatetags/content_tags.py
+++ b/core/templatetags/content_tags.py
@@ -7,8 +7,11 @@ import datetime
 from urllib.parse import urlparse
 
 from core.constants import BACKLINK_QUERYSTRING_NAME
-from core.models import DetailPage, TopicPage
-
+from core.models import (
+    DetailPage,
+    LessonPlaceholderPage,
+    TopicPage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -93,3 +96,13 @@ def get_lesson_progress_for_topic(
         'lessons_completed': lessons_completed,
         'lessons_available': lessons_available
     }
+
+
+@register.filter
+def is_lesson_page(page):
+    return isinstance(page.specific, DetailPage)
+
+
+@register.filter
+def is_placeholder_page(page):
+    return isinstance(page.specific, LessonPlaceholderPage)

--- a/learn/templates/learn/_lesson_placeholder.html
+++ b/learn/templates/learn/_lesson_placeholder.html
@@ -1,6 +1,6 @@
-<li class="learn__lesson-item learn__lesson-item--placeholder" data-placeholder-title="{{value.title}}">
-    <a class="learn__lesson-item-link h-xs" href="" title="">
-        <span class="learn__lesson-item-link-text">{{value.title}}</span>
+<li class="learn__lesson-item learn__lesson-item--placeholder" data-placeholder-title="{{page.title}}">
+    <a class="learn__lesson-item-link h-xs" href="" title="Coming soon: {{page.title}}">
+        <span class="learn__lesson-item-link-text">{{page.title}}</span>
         <button class="button button--secondary button--small">Coming soon</button>
     </a>
 </li>

--- a/learn/templates/learn/curated_list_page.html
+++ b/learn/templates/learn/curated_list_page.html
@@ -39,7 +39,7 @@
             {% for topic in page.get_topics %}
                 {% with module_completion_progress.completed_lesson_pages|get_item:topic.id as lesson_completion_data_for_topic %}
                 <li class="learn__topic-item"  id="lesson-{{ topic.slug }}">
-                    {% include_block topic with topic_id=topic.id completed_lessons=lesson_completion_data_for_topic %}
+                    {% include 'core/curated_topic.html' with topic=topic completed_lessons=lesson_completion_data_for_topic %}
                 </li>
                 {% endwith %}
             {% endfor %}

--- a/tests/unit/core/factories.py
+++ b/tests/unit/core/factories.py
@@ -69,13 +69,6 @@ class CuratedListPageFactory(wagtail_factories.PageFactory):
     heading = factory.fuzzy.FuzzyText(length=200)
     template = factory.fuzzy.FuzzyChoice(models.CuratedListPage.template_choices, getter=lambda choice: choice[0])
     parent = factory.SubFactory(ListPageFactory)
-    topics = wagtail_factories.StreamFieldFactory(
-        {
-            'title': wagtail_factories.CharBlockFactory,
-            # lessons_and_placeholders need to be added not via the factory, for now.
-            # See tests.helpers.add_lessons_and_placeholders_to_curated_list_page
-        }
-    )
 
     class Meta:
         model = models.CuratedListPage
@@ -166,15 +159,6 @@ class SimpleVideoBlockFactory(wagtail_factories.StructBlockFactory):
 
     class Meta:
         model = blocks.SimpleVideoBlock
-
-
-class CuratedTopicBlockFactory(wagtail_factories.StructBlockFactory):
-    title = factory.fuzzy.FuzzyText(length=255)
-    # lessons_and_placeholders need to be added via a helper, not via the factory, for
-    # now - see tests.helpers.add_lessons_and_placeholders_to_curated_list_page
-
-    class Meta:
-        model = blocks.CuratedTopicBlock
 
 
 class CaseStudyFactory(factory.django.DjangoModelFactory):

--- a/tests/unit/core/test_templatetags.py
+++ b/tests/unit/core/test_templatetags.py
@@ -5,11 +5,18 @@ import pytest
 from django.template import Context, Template
 from datetime import timedelta
 
-from core.models import DetailPage
+from core.models import (
+    CuratedListPage,
+    DetailPage,
+    LessonPlaceholderPage,
+    TopicPage,
+)
 from core.templatetags.content_tags import (
     get_backlinked_url,
     get_topic_title_for_lesson,
     get_lesson_progress_for_topic,
+    is_lesson_page,
+    is_placeholder_page,
 )
 from core.templatetags.object_tags import get_item
 from core.templatetags.personalised_blocks import render_video_block
@@ -563,3 +570,29 @@ def test_get_lesson_progress_for_topic(
         lesson_completion_data,
         topic_page.id
     ) == expected
+
+
+@pytest.mark.parametrize(
+    'klass,expected',
+    (
+        (DetailPage, True),
+        (LessonPlaceholderPage, False),
+        (CuratedListPage, False),
+        (TopicPage, False),
+    )
+)
+def test_is_lesson_page(klass, expected):
+    assert is_lesson_page(klass()) == expected
+
+
+@pytest.mark.parametrize(
+    'klass,expected',
+    (
+        (DetailPage, False),
+        (LessonPlaceholderPage, True),
+        (CuratedListPage, False),
+        (TopicPage, False),
+    )
+)
+def test_is_placeholder_page(klass, expected):
+    assert is_placeholder_page(klass()) == expected

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -20,8 +20,6 @@ def test_lesson_module(domestic_homepage):
     )
     curated_list_page = factories.CuratedListPageFactory(
         parent=list_page,
-        topics__0__title='Topic 1',
-        topics__1__title='Topic 2'
     )
     topic_one = factories.TopicPageFactory(
         title='Topic 1',
@@ -68,11 +66,10 @@ def test_multiple_modules(domestic_homepage, client, user):
     module_1 = factories.CuratedListPageFactory(
         title='Module 1',
         parent=list_page,
-        topics__0__title='Topic 1',
-        topics__1__title='Topic 2',
     )
     module_2 = factories.CuratedListPageFactory(
-        title='Module 2', parent=list_page, topics__0__title='Topic 21'
+        title='Module 2',
+        parent=list_page,
     )
 
     topic_1 = factories.TopicPageFactory(
@@ -152,11 +149,10 @@ def test_placeholders_do_not_get_counted(domestic_homepage, client, user):
     module_1 = factories.CuratedListPageFactory(
         title='Module 1',
         parent=list_page,
-        topics__0__title='Topic 1',
-        topics__1__title='Topic 2',
     )
     module_2 = factories.CuratedListPageFactory(
-        title='Module 2', parent=list_page, topics__0__title='Topic 21'
+        title='Module 2',
+        parent=list_page,
     )
     topic_1 = factories.TopicPageFactory(
         title='Topic 1',

--- a/tests/unit/domestic/test_helpers.py
+++ b/tests/unit/domestic/test_helpers.py
@@ -14,7 +14,7 @@ from tests.unit.core.factories import (
 
 @pytest.mark.django_db
 @mock.patch('sso.helpers.get_lesson_completed')
-def test_get_lesson_completion_status__correct_config(mock_get_lesson_completed):
+def test_get_lesson_completion_status(mock_get_lesson_completed):
 
     clp_correct_config = CuratedListPageFactory.create()
 


### PR DESCRIPTION
This changeset cleans up use of the `lessons_and_topics` StreamField within the `CuratedListPage.topics` `CuratedTopicBlock`

Still leaving the field on the CuratedListPage because we haven't migrated data yet, but removed from the test factories, because no tests touch CuratedListPage.topics any more \o/

UNSTABLE CODEBASE - MID-REFACTOR

 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/GP2-884 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added.
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
