### PR TITLE
GP2-884: Refactor topic modelling -  part five - minor cleanup

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -417,7 +417,7 @@ class CuratedListPage(CMSGenericPage):
     ]
 
     def get_topics(self, live=True) -> models.QuerySet:
-        qs = TopicPage.objects.descendant_of(self)
+        qs = TopicPage.objects.live().specific().descendant_of(self)
         if live:
             qs = qs.live()
         return qs
@@ -430,7 +430,7 @@ class CuratedListPage(CMSGenericPage):
     def count_detail_pages(self):
         count = 0
         for topic in self.get_topics():
-            count += DetailPage.objects.descendant_of(topic).count()
+            count += DetailPage.objects.live().descendant_of(topic).count()
         return count
 
     def get_context(self, request, *args, **kwargs):
@@ -669,7 +669,7 @@ class DetailPage(CMSGenericPage):
     @cached_property
     def module(self):
         """Gets the learning module this lesson belongs to"""
-        return CuratedListPage.objects.ancestor_of(self).specific().first()
+        return CuratedListPage.objects.live().specific().ancestor_of(self).first()
 
     @cached_property
     def _export_plan_url_map(self):
@@ -723,6 +723,8 @@ class DetailPage(CMSGenericPage):
             context['backlink_title'] = self._get_backlink_title(_backlink)
 
         if isinstance(self.get_parent(), TopicPage):
+            # In a conditional because a DetailPage currently MAY be used as
+            # a child of another page type...
             page_topic_helper = PageTopicHelper(self)
             next_lesson = page_topic_helper.get_next_lesson()
             context['current_module'] = page_topic_helper.module

--- a/core/utils.py
+++ b/core/utils.py
@@ -7,7 +7,7 @@ def get_all_lessons(module):
     @returns: QuerySet of DetailPage objects (lessons)
     """
     from core.models import DetailPage
-    return DetailPage.objects.descendant_of(module).specific()
+    return DetailPage.objects.live().specific().descendant_of(module)
 
 
 def get_first_lesson(module):
@@ -37,7 +37,7 @@ class PageTopicHelper:
 
     def get_page_topic(self):
         from core.models import TopicPage
-        return TopicPage.objects.ancestor_of(self.page).specific().first()
+        return TopicPage.objects.live().ancestor_of(self.page).specific().first()
 
     def get_module_topics(self):
         return self.module.get_topics()

--- a/domestic/helpers.py
+++ b/domestic/helpers.py
@@ -24,7 +24,7 @@ def build_route_context(user, context={}):
 
 def get_ancestor(page, ancestor_class):
     # Seek up the tree to find a page matching class
-    return ancestor_class.objects.ancestor_of(page).specific().first()
+    return ancestor_class.objects.live().ancestor_of(page).specific().first()
 
 
 def module_has_lesson_configured_in_topic(
@@ -32,16 +32,16 @@ def module_has_lesson_configured_in_topic(
     lesson_page: DetailPage
 ) -> bool:
     lesson_topic_page = lesson_page.get_parent().specific
-    for topic_page in module_page.get_topics():
+    for topic_page in module_page.get_topics().live():
         if topic_page == lesson_topic_page:
             return True
     return False
 
 
 def get_lesson_completion_status(user, context={}):
-    """Gets all lesson pages (DetailPages and uses the parental tree to get a list
-    of modules (CuratedListPages), with some filtering-out of DetailPages which
-    are not associated with a CuratedListPage.topics field
+    """Gets all lesson pages (DetailPages) and uses the parental tree to get a list
+    of modules (CuratedListPages), with some grouping of DetailPages by their parent
+    TopicPage (which itself is a child of CuratedListPage)
 
     Example output:
     {

--- a/tests/unit/core/test_templatetags.py
+++ b/tests/unit/core/test_templatetags.py
@@ -400,7 +400,7 @@ def test_get_topic_title_for_lesson(domestic_homepage, domestic_site):
     assert get_topic_title_for_lesson(detail_page_4) == 'Topic 3'
 
 
-def _build_lessons_and_placeholders(data, topic_page):
+def _build_lesson_and_placeholder_spec(data, topic_page):
     for lesson_id in range(data['lessons_to_create']):
         factories.DetailPageFactory.create(
             parent=topic_page,
@@ -455,7 +455,7 @@ def _build_lesson_completion_data(spec, topic_page):  # noqa C901  # is less co
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    'lesson_completion_data_spec,lessons_and_placeholders_data,expected',
+    'lesson_completion_data_spec,lesson_and_placeholder_spec_data,expected',
     (
         (
             'subset',
@@ -534,25 +534,25 @@ def _build_lesson_completion_data(spec, topic_page):  # noqa C901  # is less co
         'no lessons, none completed',
         (
             'bad data: two lessons completed but not '
-            'mentioned in lessons_and_placeholders'
+            'mentioned in lesson_and_placeholder_spec'
         ),
         (
             'bad data: two lessons completed but not a '
-            'subset of those in lessons_and_placeholders - partial overlap'
+            'subset of those in lesson_and_placeholder_spec - partial overlap'
         ),
     )
 )
 def test_get_lesson_progress_for_topic(
     lesson_completion_data_spec,
-    lessons_and_placeholders_data,
+    lesson_and_placeholder_spec_data,
     expected
 ):
     topic_page = factories.TopicPageFactory(
         title='test-topic'
     )
 
-    _build_lessons_and_placeholders(
-        lessons_and_placeholders_data,
+    _build_lesson_and_placeholder_spec(
+        lesson_and_placeholder_spec_data,
         topic_page
     )
 
@@ -562,7 +562,7 @@ def test_get_lesson_progress_for_topic(
     )
 
     # Uncomment these lines to help if you're refactoring/extending these tests
-    # print('\nlessons_and_placeholders_data', lessons_and_placeholders_data)
+    # print('\nlesson_and_placeholder_spec_data', lesson_and_placeholder_spec_data)
     # print('lesson_completion_data', lesson_completion_data)
     # print('actual page IDs', DetailPage.objects.all().values_list('id', flat=True))
 


### PR DESCRIPTION
Just some small bits of cleaning up - this is the last change before adding a data migration. After the data migration there will be a changeset to drop redundant fields from CuratedListPag 

 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/GP2-884 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added.

 
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
