### PR TITLE
GP2-959: fix backlink in lesson pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed bugs
 
+- GP2-959 - Backlink from lessons needs to go to module without going via topic redirect
 - GP2-681 - HR colour in product finder
 - GP2-434 - Dashboard routing blocks align
 - GP2-952 - Update tertiary button hover/active styles

--- a/learn/templates/learn/detail_page.html
+++ b/learn/templates/learn/detail_page.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     <div class="lesson-page">
-        <a href="{{page.get_parent.url}}" class="learn__back-link learn__back-link--top h-m">
+        <a href="{{page.get_parent.get_parent.url}}" class="learn__back-link learn__back-link--top h-m">
             <i class="fas fa-arrow-left"></i>
             <span class="visually-hidden">Back</span>
         </a>
@@ -21,7 +21,7 @@
                                 {% if topic_title %}
                                 <p class="body-l-b m-v-0">{{topic_title}}</p>
                                 {% endif %}
-                                <a href="{{page.get_parent.url}}" class="button button--secondary button--small m-t-xs">View all lessons</a>
+                                <a href="{{page.get_parent.get_parent.url}}" class="button button--secondary button--small m-t-xs">View all lessons</a>
                             </div>
                         </div>
                         <div class="c-1-2">
@@ -153,7 +153,7 @@
                     </div>
                 </div>
             {% endif %}
-            <a href="{{page.get_parent.url}}" class="learn__back-link learn__back-link--bottom h-m">
+            <a href="{{page.get_parent.get_parent.url}}" class="learn__back-link learn__back-link--bottom h-m">
                 <i class="fas fa-arrow-left"></i>
                 <span class="visually-hidden">Back</span>
             </a>


### PR DESCRIPTION
Since the topics refactor DetailPage.get_parent() no longer points to the CuratedListPage, but to a TopicPage instead. This 'works' in that a TopicPage redirects to the CuratedListPage when it's loaded, but it's better/faster to go straight to the CuratedListPage (ie the parent of the parent)

## To do (delete all that do not apply):
 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/GP2-959 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added.

 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
