### PR TITLE
GP2-960: EP links to lesson pages (post-refactor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@
 - GP2-923 - Target-market-page - Empty state
 - GP2-919 - Target-market-page - Remove markets
 - GP2-922 - Target-market-page - Select markets to compare
+- GP2-960 - Fix up links from EP to lessons, post-refactor
 - GP2-962 - Data migration for topics restructure
 - GP2-884 - Model-layer updates for topics restructure
 - GP2-955 - Target-market-page - disable and coming soon

--- a/exportplan/helpers.py
+++ b/exportplan/helpers.py
@@ -180,7 +180,7 @@ def get_check_duties_link(exportplan):
 
 def get_all_lesson_details():
     lessons = {}
-    for lesson in models.DetailPage.objects.live():
+    for lesson in models.DetailPage.objects.live().specific():
         lessons[lesson.slug] = {
             'topic_name': lesson.topic_title,
             'title': lesson.title,

--- a/exportplan/views.py
+++ b/exportplan/views.py
@@ -174,7 +174,7 @@ class ExportPlanAdaptationForTargetMarketView(FormContextMixin, ExportPlanSectio
         return context
 
 
-class ExportPlanTargetMarketsResearchView(FormContextMixin, ExportPlanSectionView, FormView):
+class ExportPlanTargetMarketsResearchView(LessonDetailsMixin, FormContextMixin, ExportPlanSectionView, FormView):
 
     form_class = forms.ExportPlanTargetMarketsResearchForm
     success_url = reverse_lazy('exportplan:target-markets-research')


### PR DESCRIPTION
This changeset makes a minor change to allow the EP links to the lessons to work after the refactor.
It also contains a bugfix - the ExportPlanTargetMarketsResearchView lacked the mixin to know how to get lesson details, but the template seemed to expect it


 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/TICKET_ID_HERE 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added. 
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
