### PR TITLE
GP2-1021: Bugfix - show current module's masthead image in next lesson panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed bugs
 
+- GP2-1021 - Fix missing image in next-lesson panel when next lesson is in the same module
 - GP2-959 - Backlink from lessons needs to go to module without going via topic redirect
 - GP2-681 - HR colour in product finder
 - GP2-434 - Dashboard routing blocks align

--- a/core/utils.py
+++ b/core/utils.py
@@ -38,7 +38,7 @@ class PageTopicHelper:
         self.page = page
         # This is slightly assumptive of the hierarchy, but we can't
         # import CuratedListPage here:
-        self.module = self.page.get_parent().get_parent()
+        self.module = self.page.get_parent().get_parent().specific
         self.page_topic = self.get_page_topic()
         self.module_topics = self.get_module_topics()
         self.module_lessons = get_all_lessons(self.module)


### PR DESCRIPTION

We needed to ensure we get the specific CuratedListPage instance when gettin the module for a lesson page, not just the Page superclass instance

 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/TICKET_ID_HERE 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added.
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
