### PR TITLE
GP2-816: Fix setting of lesson readtime so that it gets set if a lesson is immediately published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 ### Fixed bugs
 - GP2-1024 - Fix capability back button positioning
 - GP2-956 - Dashboard spacing
+
+- GP2-816 - Set readtime on initial page publish, not only on subsequent publish
 - GP2-922 - Various styling and behaviour fixes to country selector
 - GP2-1021 - Fix missing image in next-lesson panel when next lesson is in the same module
 - GP2-959 - Backlink from lessons needs to go to module without going via topic redirect

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -77,19 +77,27 @@ def login_required_signup_wizard(page, request, serve_args, serve_kwargs):
             return redirect(url)
 
 
-def _update_data_for_appropriate_version(page: Page, data_to_update: dict) -> None:
+def _update_data_for_appropriate_version(
+    page: Page,
+    force_page_update: bool,
+    data_to_update: dict
+) -> None:
     """For a given Page instance, use the provided data to update either:
-        * its latest revision ONLY, if there are unpublished changes (ie, its a Draft)
+        * its latest revision ONLY, if there are ONLY unpublished changes
+        (ie, its a Draft)
         or
-        * the latest revision AND the live page, if the revision is the one that became
-        the live page. (We update the revision for consistency and history.)
-    """
+        * the latest revision AND the live page, if the revision is the one
+        that became the live page (ie the Live page does NOT have unpublished
+        changes)
+        or
+        * we're forcing updates to the actual Page and not its revision JSON
+        (eg, because the Live page has just been created so has no
+        unpublished changes, but we still want to update it with data_to_update)
 
+    """
     latest_revision = page.get_latest_revision()
     latest_revision_json = json.loads(latest_revision.content_json)
 
-    # 1. Update the revision, whether it's for the latest Draft or the
-    # revision which created the current Live page
     for key, value in data_to_update.items():
         # We need to watch out for the timedelta, because it serialises to
         # a different format (PxDTxxHxxMxxS) by default
@@ -100,19 +108,26 @@ def _update_data_for_appropriate_version(page: Page, data_to_update: dict) -> No
     latest_revision.content_json = json.dumps(latest_revision_json, cls=DjangoJSONEncoder)
     latest_revision.save()
 
-    if not page.has_unpublished_changes:
-        # 2. The live version is based on the latest revision, which means
-        # we also need to update the live page, because it won't automatically
-        # reflect the chages we made to that revision.
-
+    if force_page_update or (not page.has_unpublished_changes):
         # This update()-based approach is awkward but we want to update the
         # Page record without any side effects via save() etc
         queryset_for_page = type(page).objects.filter(id=page.id)
         queryset_for_page.update(**data_to_update)
 
 
+@hooks.register('after_create_page')
+def set_read_time__after_create_page(request, page):
+    # Runs after a page is created, whether draft or published
+    _set_read_time(request, page, is_post_creation=True)
+
+
 @hooks.register('after_edit_page')
-def set_read_time(request, page):
+def set_read_time__after_edit_page(request, page):
+    # Runs after a page is edited, whether draft or published
+    _set_read_time(request, page)
+
+
+def _set_read_time(request, page, is_post_creation=False):
     if hasattr(page, 'estimated_read_duration'):
         html = render_to_string(page.template, {'page': page, 'request': request})
         soup = BeautifulSoup(html, 'html.parser')
@@ -132,5 +147,6 @@ def set_read_time(request, page):
 
         _update_data_for_appropriate_version(
             page=page,
+            force_page_update=is_post_creation,
             data_to_update={'estimated_read_duration': timedelta(seconds=seconds)}
         )

--- a/tests/unit/core/test_wagtail_hooks.py
+++ b/tests/unit/core/test_wagtail_hooks.py
@@ -1,5 +1,6 @@
 import json
 
+from unittest import mock
 from datetime import timedelta
 
 import pytest
@@ -218,7 +219,7 @@ def test_estimated_read_time_calculation(rf, domestic_homepage):
     detail_page.refresh_from_db()
     assert detail_page.estimated_read_duration != expected_duration
 
-    wagtail_hooks.set_read_time(
+    wagtail_hooks._set_read_time(
         page=detail_page,
         request=request
     )
@@ -269,7 +270,7 @@ def test_estimated_read_time_calculation__checks_text_and_video(rf, domestic_hom
     detail_page.refresh_from_db()
     assert detail_page.estimated_read_duration != expected_duration
 
-    wagtail_hooks.set_read_time(
+    wagtail_hooks._set_read_time(
         page=detail_page,
         request=request
     )
@@ -316,7 +317,7 @@ def test_estimated_read_time_calculation__checks_video(rf, domestic_homepage):
     detail_page.refresh_from_db()
     assert detail_page.estimated_read_duration != expected_duration
 
-    wagtail_hooks.set_read_time(
+    wagtail_hooks._set_read_time(
         page=detail_page,
         request=request
     )
@@ -329,8 +330,6 @@ def test_estimated_read_time_calculation__checks_video(rf, domestic_homepage):
 def test_estimated_read_time_calculation__updates_only_draft_if_appropriate(
     rf, domestic_homepage
 ):
-    # This test ensures that all paths are walked for
-    # wagtail_hooks._update_data_for_appropriate_version()
 
     # IF THIS TEST FAILS BASED ON OFF-BY-ONE-SECOND DURATIONS... check whether
     # your changeset has slightly increased the size of the HTML page, which
@@ -364,7 +363,7 @@ def test_estimated_read_time_calculation__updates_only_draft_if_appropriate(
 
     detail_page.refresh_from_db()
 
-    wagtail_hooks.set_read_time(
+    wagtail_hooks._set_read_time(
         page=detail_page,
         request=request
     )
@@ -388,7 +387,7 @@ def test_estimated_read_time_calculation__updates_only_draft_if_appropriate(
 
     detail_page.refresh_from_db()
 
-    wagtail_hooks.set_read_time(
+    wagtail_hooks._set_read_time(
         page=detail_page,
         request=request
     )
@@ -400,6 +399,148 @@ def test_estimated_read_time_calculation__updates_only_draft_if_appropriate(
     # of the published page CAN BE calculated as slightly longer than the draft.
     # This may be in part due to the page having a very small amount of content.
     assert detail_page.estimated_read_duration == timedelta(seconds=4)
+
+
+@pytest.mark.django_db
+def test_estimated_read_time_calculation__forced_update_of_live(
+    rf, domestic_homepage
+):
+    # This test is a variant of test_estimated_read_time_calculation__updates_only_draft_if_appropriate
+
+    # IF THIS TEST FAILS BASED ON OFF-BY-ONE-SECOND DURATIONS... check whether
+    # your changeset has slightly increased the size of the HTML page, which
+    # may have slightly pushed up the default/empty-page readtime (either in
+    # real terms or just in terms of elements that affect the calculation). If
+    # so, pushing up the expected time variables in the test is OK to do.
+
+    request = rf.get('/')
+    request.user = AnonymousUser()
+
+    video_for_hero = make_test_video(duration=124)
+    video_for_hero.save()
+
+    detail_page = factories.DetailPageFactory(
+        parent=domestic_homepage,
+        template='learn/detail_page.html',
+        body=[],
+    )
+    assert detail_page.live is True
+
+    original_live_read_duration = detail_page.estimated_read_duration
+    assert original_live_read_duration is None
+
+    # Make a revision, so we have both draft and live in existence
+    revision = detail_page.save_revision()
+    assert json.loads(revision.content_json)['estimated_read_duration'] == original_live_read_duration
+
+    detail_page.refresh_from_db()
+
+    wagtail_hooks._set_read_time(
+        page=detail_page,
+        request=request,
+        is_post_creation=True  # THIS will mean the live page is updated at the same time as the draft
+    )
+
+    detail_page.refresh_from_db()
+
+    expected_duration = timedelta(seconds=4)  # NB just the read time of a skeleton DetailPage
+
+    # show the live version is updated yet
+    assert detail_page.estimated_read_duration == expected_duration
+    assert detail_page.has_unpublished_changes is True
+
+    # and the draft is updated too
+    latest_rev = detail_page.get_latest_revision()
+    assert revision == latest_rev
+    assert json.loads(latest_rev.content_json)['estimated_read_duration'] == str(expected_duration)
+
+
+@pytest.mark.parametrize('is_post_creation_val', (True, False))
+@pytest.mark.django_db
+def test__set_read_time__passes_through_is_post_creation(
+    rf,
+    domestic_homepage,
+    is_post_creation_val,
+):
+    request = rf.get('/')
+    detail_page = factories.DetailPageFactory(
+        parent=domestic_homepage,
+        template='learn/detail_page.html',
+        body=[],
+    )
+    with mock.patch(
+        'core.wagtail_hooks._update_data_for_appropriate_version'
+    ) as mocked_update_data_for_appropriate_version:
+
+        wagtail_hooks._set_read_time(request, detail_page, is_post_creation=is_post_creation_val)
+
+    expected_seconds = 4
+    mocked_update_data_for_appropriate_version.assert_called_once_with(
+        page=detail_page,
+        force_page_update=is_post_creation_val,
+        data_to_update={'estimated_read_duration': timedelta(seconds=expected_seconds)}
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('force_update', (False, True))
+def test__update_data_for_appropriate_version(domestic_homepage, rf, force_update):
+    request = rf.get('/')
+    request.user = AnonymousUser()
+
+    detail_page = factories.DetailPageFactory(
+        parent=domestic_homepage,
+        template='learn/detail_page.html',
+        body=[],
+    )
+    assert detail_page.live is True
+    # Make a revision, so we have both draft and live in existence
+    revision = detail_page.save_revision()
+    assert detail_page.get_latest_revision() == revision
+
+    assert detail_page.title != 'Dummy Title'
+    assert json.loads(revision.content_json)['title'] == detail_page.title
+
+    wagtail_hooks._update_data_for_appropriate_version(
+        page=detail_page,
+        force_page_update=force_update,
+        data_to_update={'title': 'Dummy Title'}
+    )
+
+    revision.refresh_from_db()
+    assert json.loads(revision.content_json)['title'] == 'Dummy Title'
+
+    detail_page.refresh_from_db()
+    if force_update:
+        assert detail_page.title == 'Dummy Title'
+    else:
+        assert detail_page.title != 'Dummy Title'
+
+
+@pytest.mark.django_db
+def test_set_read_time__after_create_page(domestic_homepage, rf):
+    request = rf.get('/')
+    detail_page = factories.DetailPageFactory(
+        parent=domestic_homepage,
+        template='learn/detail_page.html',
+        body=[],
+    )
+    with mock.patch('core.wagtail_hooks._set_read_time') as mock__set_read_time:
+        wagtail_hooks.set_read_time__after_create_page(request, detail_page)
+    mock__set_read_time.assert_called_once_with(request, detail_page, is_post_creation=True)
+
+
+@pytest.mark.django_db
+def test_set_read_time__after_edit_page(domestic_homepage, rf):
+    request = rf.get('/')
+    detail_page = factories.DetailPageFactory(
+        parent=domestic_homepage,
+        template='learn/detail_page.html',
+        body=[],
+    )
+    with mock.patch('core.wagtail_hooks._set_read_time') as mock__set_read_time:
+        wagtail_hooks.set_read_time__after_edit_page(request, detail_page)
+    mock__set_read_time.assert_called_once_with(request, detail_page)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The issue was that we were only acting on the `after_edit_page` hook and not also the `after_create_page` hook.

Also added broader test coverage.

 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/TICKET_ID_HERE 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added. 
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
