### PR TITLE
GP2-741: Bump Wagtail Transfer to latest version + update config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 
 ### Implemented enhancements
 
+- GP2-741 - Update Wagtail-Transfer version and configuration
 - GP2-914 - Responsive header
 - GP2-978 - Mobile learning homepage
 - GP2-934 - Contact us success page

--- a/config/settings.py
+++ b/config/settings.py
@@ -494,14 +494,39 @@ WAGTAILTRANSFER_SECRET_KEY = env.str('WAGTAILTRANSFER_SECRET_KEY')
 WAGTAILTRANSFER_UPDATE_RELATED_MODELS = [
     'wagtailimages.image',
     'wagtaildocs',
-    'wagtailmedia',
+    'wagtailmedia.media',
     'taggit',
     'core.AltTextImage',
+    'core.GreatMedia',
+    'core.PersonalisationHSCodeTag',
+    'core.PersonalisationCountryTag',
+    'core.CountryTaggedCaseStudy',
+    'core.HSTaggedCaseStudy',
     'core.CaseStudy',
     'core.ContentModule',
     'core.Tour',
     'core.TourStep',
 ]
+
+# Give W-T a little more time than the default 5 secs to do things
+WAGTAILTRANSFER_CHOOSER_API_PROXY_TIMEOUT = env.int(
+    'WAGTAILTRANSFER_CHOOSER_API_PROXY_TIMEOUT',
+    10
+)
+
+WAGTAILTRANSFER_FOLLOWED_REVERSE_RELATIONS = [
+    # (model, reverse_relationship_name, track_deletions)
+    ('wagtailimages.image', 'tagged_items', True),
+    ('core.alttextimage', 'tagged_items', True),
+    ('wagtailmedia.media', 'tagged_items', True),  # MTI Base of core.GreatMedia
+    ('core.greatmedia', 'tagged_items', True),
+]
+
+WAGTAILTRANSFER_LOOKUP_FIELDS = {
+    'taggit.tag': ['slug'],
+    'core.personalisationhscodetag': ['slug'],
+    'core.personalisationcountrytag': ['slug'],
+}
 
 # dit_helpdesk
 DIT_HELPDESK_URL = env.str('DIT_HELPDESK_URL')

--- a/config/utils.py
+++ b/config/utils.py
@@ -31,31 +31,34 @@ def get_wagtail_transfer_configuration() -> dict:
     if active_environment == DEV:
         # Dev needs to know about Staging and Beta to import FROM them
         config.update({
-            BETA: {
-                'BASE_URL': env.str('WAGTAILTRANSFER_BASE_URL_BETA'),
-                'SECRET_KEY': env.str('WAGTAILTRANSFER_SECRET_KEY_BETA')
-            },
+            # TEMPORARILY DISABLED until we're fully rolled out
+            # BETA: {
+            #     'BASE_URL': env.str('WAGTAILTRANSFER_BASE_URL_BETA'),
+            #     'SECRET_KEY': env.str('WAGTAILTRANSFER_SECRET_KEY_BETA')
+            # },
             STAGING: {
                 'BASE_URL': env.str('WAGTAILTRANSFER_BASE_URL_STAGING'),
                 'SECRET_KEY': env.str('WAGTAILTRANSFER_SECRET_KEY_STAGING')
             },
         })
-    elif active_environment == STAGING:
-        # Staging needs to know about Beta, to import FROM it
-        config.update({
-            BETA: {
-                'BASE_URL': env.str('WAGTAILTRANSFER_BASE_URL_BETA'),
-                'SECRET_KEY': env.str('WAGTAILTRANSFER_SECRET_KEY_BETA')
-            }
-        })
-    elif active_environment == BETA:
-        # Beta needs to know about Staging, to import FROM it
-        config.update({
-            STAGING: {
-                'BASE_URL': env.str('WAGTAILTRANSFER_BASE_URL_STAGING'),
-                'SECRET_KEY': env.str('WAGTAILTRANSFER_SECRET_KEY_STAGING')
-            }
-        })
+    # TEMPORARILY DISABLED until we're fully rolled out
+    # elif active_environment == STAGING:
+    #     # Staging needs to know about Beta, to import FROM it
+    #     config.update({
+    #         BETA: {
+    #             'BASE_URL': env.str('WAGTAILTRANSFER_BASE_URL_BETA'),
+    #             'SECRET_KEY': env.str('WAGTAILTRANSFER_SECRET_KEY_BETA')
+    #         }
+    #     })
+    # TEMPORARILY DISABLED until we're fully rolled out
+    # elif active_environment == BETA:
+    #     # Beta needs to know about Staging, to import FROM it
+    #     config.update({
+    #         STAGING: {
+    #             'BASE_URL': env.str('WAGTAILTRANSFER_BASE_URL_STAGING'),
+    #             'SECRET_KEY': env.str('WAGTAILTRANSFER_SECRET_KEY_STAGING')
+    #         }
+    #     })
 
     elif (
         active_environment == LOCAL and env.bool('WAGTAIL_TRANSFER_LOCAL_DEV', default=False)
@@ -64,7 +67,7 @@ def get_wagtail_transfer_configuration() -> dict:
         for env_suffix in [
             DEV,
             STAGING,
-            BETA,
+            # BETA,  # TEMPORARILY DISABLED until full rollout
         ]:
             url_var_name = f'WAGTAILTRANSFER_BASE_URL_{env_suffix}'
             key_var_name = f'WAGTAILTRANSFER_SECRET_KEY_{env_suffix}'

--- a/config/utils.py
+++ b/config/utils.py
@@ -60,6 +60,23 @@ def get_wagtail_transfer_configuration() -> dict:
     elif (
         active_environment == LOCAL and env.bool('WAGTAIL_TRANSFER_LOCAL_DEV', default=False)
     ):
+        # Local needs to know about Dev and Staging and Beta to import FROM them
+        for env_suffix in [
+            DEV,
+            STAGING,
+            BETA,
+        ]:
+            url_var_name = f'WAGTAILTRANSFER_BASE_URL_{env_suffix}'
+            key_var_name = f'WAGTAILTRANSFER_SECRET_KEY_{env_suffix}'
+
+            if env.str(url_var_name, None) and env.str(key_var_name, None):
+                config.update({
+                    env_suffix: {
+                        'BASE_URL': env.str(url_var_name),
+                        'SECRET_KEY': env.str(key_var_name)
+                    }
+                })
+
         config.update({
             # Safe to hard-code these ones for local dev
             'local_one_on_8020': {  # ie, `make webserver`

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ wagtail-personalisation==0.14.*
 wagtail-cache==1.0.*
 wagtailmedia==0.5.0
 wagtailfontawesome==1.2.1
-wagtail-transfer==0.5.1
+wagtail-transfer==0.6.0
 
 # Prod tools
 # ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 airtable-python-wrapper==0.13.0  # via -r requirements.in
 alabaster==0.7.12         # via sphinx
 attrs==20.3.0             # via jsonschema
-babel==2.8.0              # via sphinx
+babel==2.9.0              # via sphinx
 beautifulsoup4==4.8.2     # via great-components, readtime, wagtail
 boto3==1.11.17            # via -r requirements.in, django-storages
 botocore==1.14.17         # via boto3, s3transfer
@@ -80,7 +80,7 @@ pytz==2020.1              # via babel, directory-validators, django, django-mode
 readtime==1.1.1           # via -r requirements.in
 redis==3.5.3              # via django-redis
 requests-oauthlib==1.3.0  # via django-staff-sso-client
-requests==2.24.0          # via airtable-python-wrapper, directory-api-client, directory-client-core, geoip2, requests-oauthlib, sphinx, wagtail
+requests==2.25.0          # via airtable-python-wrapper, directory-api-client, directory-client-core, geoip2, requests-oauthlib, sphinx, wagtail
 s3transfer==0.3.3         # via boto3
 sentry-sdk==0.13.5        # via -r requirements.in
 sigauth==4.3.0            # via directory-client-core
@@ -101,7 +101,7 @@ w3lib==1.22.0             # via directory-client-core
 wagtail-cache==1.0.1      # via -r requirements.in
 wagtail-factories==2.0.1  # via -r requirements.in
 wagtail-personalisation==0.14.0  # via -r requirements.in
-wagtail-transfer==0.5.1   # via -r requirements.in
+wagtail-transfer==0.6.0   # via -r requirements.in
 wagtail==2.10.2           # via -r requirements.in, wagtail-cache, wagtail-factories, wagtail-personalisation, wagtailfontawesome, wagtailmedia
 wagtailfontawesome==1.2.1  # via -r requirements.in, wagtail-personalisation
 wagtailmedia==0.5.0       # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,9 +10,10 @@ airtable-python-wrapper==0.13.0  # via -r requirements.in
 alabaster==0.7.12         # via sphinx
 allure-pytest==2.8.19     # via -r requirements_test.in
 allure-python-commons==2.8.19  # via allure-pytest
+appnope==0.1.0            # via ipython
 astroid==2.4.2            # via pylint
 attrs==20.3.0             # via allure-python-commons, jsonschema, pytest
-babel==2.8.0              # via sphinx
+babel==2.9.0              # via sphinx
 backcall==0.2.0           # via ipython
 beautifulsoup4==4.8.2     # via -r requirements_test.in, great-components, readtime, wagtail
 boto3==1.11.17            # via -r requirements.in, django-storages
@@ -134,7 +135,7 @@ readtime==1.1.1           # via -r requirements.in
 redis==3.5.3              # via django-redis
 requests-mock==1.8.0      # via -r requirements_test.in
 requests-oauthlib==1.3.0  # via django-staff-sso-client
-requests==2.24.0          # via airtable-python-wrapper, codecov, directory-api-client, directory-client-core, geoip2, locust, requests-mock, requests-oauthlib, sphinx, wagtail
+requests==2.25.0          # via airtable-python-wrapper, codecov, directory-api-client, directory-client-core, geoip2, locust, requests-mock, requests-oauthlib, sphinx, wagtail
 s3transfer==0.3.3         # via boto3
 selenium==3.141.0         # via -r requirements_test.in
 sentry-sdk==0.13.5        # via -r requirements.in
@@ -160,7 +161,7 @@ w3lib==1.22.0             # via directory-client-core
 wagtail-cache==1.0.1      # via -r requirements.in
 wagtail-factories==2.0.1  # via -r requirements.in
 wagtail-personalisation==0.14.0  # via -r requirements.in
-wagtail-transfer==0.5.1   # via -r requirements.in
+wagtail-transfer==0.6.0   # via -r requirements.in
 wagtail==2.10.2           # via -r requirements.in, wagtail-cache, wagtail-factories, wagtail-personalisation, wagtailfontawesome, wagtailmedia
 wagtailfontawesome==1.2.1  # via -r requirements.in, wagtail-personalisation
 wagtailmedia==0.5.0       # via -r requirements.in

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -14,31 +14,36 @@ from config.utils import get_wagtail_transfer_configuration
         (
             'beta',  # can pull from staging,
             False,
-            {
-                'staging': {
-                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_STAGING',
-                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_STAGING',
-                },
-            }
+            # TEMPORARILY DISABLED until we're fully rolled out
+            # {
+            #     'staging': {
+            #         'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_STAGING',
+            #         'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_STAGING',
+            #     },
+            # }
+            {}
         ),
         (
             'staging',  # can pull from beta
             False,
-            {
-                'beta': {
-                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_BETA',
-                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_BETA',
-                },
-            }
+            # TEMPORARILY DISABLED until we're fully rolled out
+            # {
+            #     'beta': {
+            #         'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_BETA',
+            #         'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_BETA',
+            #     },
+            # }
+            {}
         ),
         (
             'dev',  # can pull from beta or staging
             False,
             {
-                'beta': {
-                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_BETA',
-                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_BETA',
-                },
+                # TEMPORARILY DISABLED until we're fully rolled out
+                # 'beta': {
+                #     'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_BETA',
+                #     'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_BETA',
+                # },
                 'staging': {
                     'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_STAGING',
                     'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_STAGING',
@@ -46,13 +51,14 @@ from config.utils import get_wagtail_transfer_configuration
             }
         ),
         (
-            'local',  # can pull between local:8020 and local:8030
+            'local',  # can pull between local:8020 and local:8030 and from deployed sites
             True,
             {
-                'beta': {
-                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_BETA',
-                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_BETA',
-                },
+                # TEMPORARILY DISABLED until we're fully rolled out
+                # 'beta': {
+                #     'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_BETA',
+                #     'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_BETA',
+                # },
                 'staging': {
                     'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_STAGING',
                     'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_STAGING',
@@ -79,12 +85,14 @@ from config.utils import get_wagtail_transfer_configuration
         (
             'staging',  # can pull from beta
             True,  # Danger! - or thankfully not... we won't act on this unless the env is `local`
-            {
-                'beta': {
-                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_BETA',
-                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_BETA',
-                },
-            }
+            # TEMPORARILY DISABLED until we're fully rolled out
+            # {
+            #     'beta': {
+            #         'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_BETA',
+            #         'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_BETA',
+            #     },
+            # }
+            {}
         ),
 
     ),

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -46,9 +46,21 @@ from config.utils import get_wagtail_transfer_configuration
             }
         ),
         (
-            'local',  # can from pull between local:8020 and  local:8030
+            'local',  # can pull between local:8020 and local:8030
             True,
             {
+                'beta': {
+                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_BETA',
+                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_BETA',
+                },
+                'staging': {
+                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_STAGING',
+                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_STAGING',
+                },
+                'dev': {
+                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_DEV',
+                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_DEV',
+                },
                 'local_one_on_8020': {
                     'BASE_URL': 'http://greatcms.trade.great:8020/admin/wagtail-transfer/',
                     'SECRET_KEY': 'local-one',
@@ -92,12 +104,12 @@ from config.utils import get_wagtail_transfer_configuration
 def test_get_wagtail_transfer_configuration(env_label, local_transfer_enabled, expected):
     """Show that we return the appropriate configs for the given active env_label"""
 
-    def _env_side_effect(requested_env_key):
+    def _env_side_effect(requested_env_key, default=''):
         # Return the patched APP_ENVIRONMENT value,
         # or just replay the env key with a prefix
         if requested_env_key == 'APP_ENVIRONMENT':
             return env_label
-        return f'value_of_{requested_env_key}'
+        return f'value_of_{requested_env_key.upper()}'
 
     with mock.patch('config.utils.env.str') as mock_env_str:
         with mock.patch('config.utils.env.bool') as mock_env_bool:


### PR DESCRIPTION
This changeset moves us to 0.6, which supports copying objects that use multi-table inheritance, and also handles copying tags on items.

It also reduces the scope of the configuration so that no sites can pull content from Beta, because - for now - we're going to get WT in use up to staging, and then see what extra features we need to support before we can use it to suit our workflows

 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/TICKET_ID_HERE 
 - [x] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added. 
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
