### PR TITLE
GP2-661: Support S3-to-S3 copying for Wagtail Transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 - GP2-901 - Add Case Study view support to CMS
 - GP2-1033 - Country chooser mobile
 - GP2-1051 - Compare markets feature flag
+- GP2-661 - Main work to support S3-to-S3 copying when using Wagtail Transfer
 - GP2-984 - Compare markets selector and redux global state managememt
 - GP2-1034 - Update lesson progress bar wording
 - GP2-979 - Mobile learning module page

--- a/core/constants.py
+++ b/core/constants.py
@@ -9,3 +9,14 @@ RICHTEXT_FEATURES__MINIMAL = ()
 
 LESSON_BLOCK = 'lesson'
 PLACEHOLDER_BLOCK = 'placeholder'
+
+AWS_S3_MAIN_HOSTNAME_OPTIONS = [
+    # https://docs.aws.amazon.com/general/latest/gr/s3.html
+    's3.amazonaws.com',  # most likely
+    's3.eu-west-2.amazonaws.com',   # London
+    's3.dualstack.eu-west-2.amazonaws.com',  # London IPv4 + IPv6
+    # 'account-id.s3-control.eu-west-2.amazonaws.com',  # inviable for us
+    # 'account-id.s3-control.dualstack.eu-west-2.amazonaws.com',   # inviable for us
+    's3-accesspoint.eu-west-2.amazonaws.com',
+    's3-accesspoint.dualstack.eu-west-2.amazonaws.com',
+]

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -1,25 +1,37 @@
 import datetime
 import json
-
-from datetime import timedelta
-
-from bs4 import BeautifulSoup
+import logging
 import readtime
 
+from urllib.parse import urlparse
+
+import boto3
+from bs4 import BeautifulSoup
 from great_components.helpers import add_next
-from wagtail.core import hooks
-from wagtail.core.models import Page
 
-
-from django.urls import reverse
+from django.conf import settings
+from django.core.files.storage import DefaultStorage
 from django.core.serializers.json import DjangoJSONEncoder
+from django.db import models as django_models
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
+from django.urls import reverse
+
+from wagtail.core import hooks
+from wagtail.core.models import Page
+from wagtail_transfer.files import File as WTFile, FileTransferError
+from wagtail_transfer.field_adapters import FieldAdapter
+from wagtail_transfer.models import ImportedFile
 
 from core import constants, mixins, views
 
+logger = logging.getLogger(__name__)
+
 SESSION_KEY_LESSON_PAGE_SHOW_GENERIC_CONTENT = 'LESSON_PAGE_SHOW_GENERIC_CONTENT'
 exportplan_templates = ['exportplan/automated_list_page.html', 'exportplan/dashboard_page.html']
+
+# Make an S3 API available to us
+s3 = boto3.resource('s3')
 
 
 @hooks.register('before_serve_page')
@@ -40,7 +52,7 @@ def authenticated_user_required(page, request, serve_args, serve_kwargs):
 def login_required_signup_wizard(page, request, serve_args, serve_kwargs):
     if page.template == 'learn/detail_page.html' and request.user.is_anonymous:
 
-        # opting out of personalised content "forever" - not just this request.
+        # opting out of personalised content 'forever' - not just this request.
         if 'show-generic-content' in request.GET:
             request.session[SESSION_KEY_LESSON_PAGE_SHOW_GENERIC_CONTENT] = True
 
@@ -66,8 +78,8 @@ def _update_data_for_appropriate_version(
         * we're forcing updates to the actual Page and not its revision JSON
         (eg, because the Live page has just been created so has no
         unpublished changes, but we still want to update it with data_to_update)
-
     """
+
     latest_revision = page.get_latest_revision()
     latest_revision_json = json.loads(latest_revision.content_json)
 
@@ -121,5 +133,204 @@ def _set_read_time(request, page, is_post_creation=False):
         _update_data_for_appropriate_version(
             page=page,
             force_page_update=is_post_creation,
-            data_to_update={'estimated_read_duration': timedelta(seconds=seconds)}
+            data_to_update={'estimated_read_duration': datetime.timedelta(seconds=seconds)}
         )
+
+
+class S3WagtailTransferFile(WTFile):
+    """Subclass of File that knows how to transfer() using an
+    S3 to S3 copy"""
+
+    def __init__(self, local_filename, size, hash_, source_url, **kwargs):
+        super().__init__(
+            local_filename=local_filename,
+            size=size,
+            hash=hash_,
+            source_url=source_url
+        )
+
+        self.source_bucket = kwargs['source_bucket']
+        self.source_key = kwargs['source_key']
+
+    def transfer(self):
+
+        # NB: This will only work if the source file is publicly readable
+        copy_source = {
+            'Bucket': self.source_bucket,
+            'Key': self.source_key
+        }
+
+        try:
+            s3.meta.client.copy(
+                copy_source,
+                settings.AWS_STORAGE_BUCKET_NAME,
+                self.local_filename
+            )
+        except (
+            boto3.exceptions.RetriesExceededError,
+            boto3.exceptions.S3UploadFailedError,
+            ValueError,
+            # This may not be exhaustive - we'll have to expand as required
+            # or just catch Exception
+        ) as ex:
+            logger.exception(ex)
+            raise FileTransferError(ex)
+
+        return ImportedFile.objects.create(
+            file=self.local_filename,
+            source_url=self.source_url,
+            hash=self.hash,
+            size=self.size,
+        )
+
+
+class S3FileFieldAdapter(FieldAdapter):
+    """Custom adapter that handles file fields when using AWS S3
+
+    NOTE that this will only work for transfers within the same Region
+    """
+
+    def _get_relevant_s3_meta(self, field_value) -> dict:
+        """Returns relevant metadata from S3 in a single data structure,
+        cleaned up and with one network request."""
+
+        # TODO: cache this? NB: the adapter itself is cached/persisted
+        # so we can't put state on it
+
+        _object_summary = s3.ObjectSummary(
+            field_value.storage.bucket.name,  # bucket
+            field_value.name,  # key
+        )
+        return {
+            'size': _object_summary.size,
+            'hash': self._get_file_hash(_object_summary)
+        }
+
+    def _get_file_hash(self, object_summary) -> str:
+        """Uses the object's eTag as a hash, avoiding the need to
+        download and hash the actual file"""
+
+        # IMPORTANT: The ETag from S3 may not be reliable/consistent
+        # if the file ended up being multi-part uploaded. If that's the
+        # case, we'll get a 'cache miss' and end up doing redundant work
+        #
+        # * https://boto3.amazonaws.com/v1/documentation/api/latest/
+        #       reference/services/s3.html#S3.ObjectSummary.e_tag
+        # * https://boto3.amazonaws.com/v1/documentation/api/latest/
+        #       reference/services/s3.html#S3.Object.initiate_multipart_upload
+        #
+        # Also note that the ETags are wrapped in quotes, as per RFC:
+        # https://tools.ietf.org/html/rfc2616#section-14.19 but we'll drop
+        # them here to avoid noise in our hash
+
+        return object_summary.e_tag.replace('"', '')
+
+    def _get_imported_file_bucket_and_key(self, imported_file_url) -> tuple:
+        """From the URL for the imported file, work out what its
+        S3 bucket and key are, so we can make an API call to copy it.
+
+        Here, we're trusting that our buckets are consistenty configured to be
+        subdomains + constants.AWS_S3_MAIN_HOSTNAME
+        """
+
+        source = urlparse(imported_file_url)
+
+        bucket_name = source.netloc
+
+        for _hostname in constants.AWS_S3_MAIN_HOSTNAME_OPTIONS:
+
+            if _hostname in bucket_name:
+                _target = f'.{_hostname}'
+                bucket_name = bucket_name.replace(_target, '')
+                continue
+
+        key_name = source.path[1:] if source.path.startswith('/') else source.path
+        return bucket_name, key_name
+
+    def serialize(self, instance):
+        value = self.field.value_from_object(instance)
+        if not value:
+            return None
+
+        # This adapter is only used when files are on S3, so there's no need
+        # to prepend MEDIA_URL to `url` (which the default FileAdapter does)
+        url = value.url
+
+        _s3_object_metadata = self._get_relevant_s3_meta(field_value=value)
+
+        return {
+            'download_url': url,
+            'size': _s3_object_metadata['size'],
+            'hash': _s3_object_metadata['hash'],
+        }
+
+    def populate_field(self, instance, value, context):
+        """Check if the field's file needs to be imported, and if so, do so."""
+
+        # `value` is the output of self.serialize() - either a dict or None
+        if not value:
+            return None
+
+        source_file_url = value['download_url']
+        source_file_hash = value['hash']
+        source_file_size = value['size']
+
+        imported_file = context.imported_files_by_source_url.get(source_file_url)
+        if imported_file is None:
+            logger.info('File from %s has not already been imported: reimporting', source_file_url)
+
+            existing_file = self.field.value_from_object(instance)
+            if existing_file:
+                logger.info('File exists. Comparing hashes with source file and existing file')
+                _s3_object_metadata = self._get_relevant_s3_meta(field_value=existing_file)
+                existing_file_hash = _s3_object_metadata['hash']
+                if existing_file_hash == source_file_hash:
+                    # File not changed, so don't bother updating it
+                    logger.info('Matching hashes, so no need to import')
+                    return
+
+            # Generate a safe, new filename for the destination bucket, so avoid overwrites
+            source_bucket, source_key = self._get_imported_file_bucket_and_key(
+                source_file_url
+            )
+
+            target_filename = DefaultStorage().get_available_name(source_key)
+
+            _file = S3WagtailTransferFile(
+                local_filename=target_filename,
+                size=source_file_size,
+                hash_=source_file_hash,
+                source_url=source_file_url,
+                source_bucket=source_bucket,
+                source_key=source_key,
+            )
+            try:
+                logger.info('Attempting to copy file from %s, S3-to-S3', source_file_url)
+                imported_file = _file.transfer()
+            except FileTransferError as ex:
+                logger.exception('Failed to transfer: %s', ex)
+                return None
+
+            context.imported_files_by_source_url[_file.source_url] = imported_file
+
+        # This is standard behaviour from the base FileAdapter:
+        value = imported_file.file.name
+        getattr(instance, self.field.get_attname()).name = value
+
+        logger.info('File copied to destination')
+
+
+@hooks.register('register_field_adapters')
+def register_s3_media_file_adapter():
+    """For all FileFields in our application, use our custom S3 one
+    to handle transfers
+    """
+
+    extra_adapters = {}
+
+    if settings.USER_MEDIA_ON_S3:
+        extra_adapters.update({
+            django_models.FileField: S3FileFieldAdapter,
+        })
+
+    return extra_adapters

--- a/tests/unit/core/test_wagtail_hooks.py
+++ b/tests/unit/core/test_wagtail_hooks.py
@@ -4,11 +4,22 @@ from unittest import mock
 from datetime import timedelta
 
 import pytest
+
+from boto3.exceptions import RetriesExceededError, S3UploadFailedError
+
+from django.db.models import FileField
+from django.test import override_settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.middleware import SessionMiddleware
 from wagtail.core.rich_text import RichText
 
 from core import wagtail_hooks
+from core.wagtail_hooks import (
+    register_s3_media_file_adapter,
+    S3FileFieldAdapter,
+    S3WagtailTransferFile,
+    FileTransferError,
+)
 from tests.helpers import make_test_video
 from tests.unit.core import factories
 from tests.unit.exportplan.factories import (
@@ -540,3 +551,548 @@ def test_set_read_time__after_edit_page(domestic_homepage, rf):
     with mock.patch('core.wagtail_hooks._set_read_time') as mock__set_read_time:
         wagtail_hooks.set_read_time__after_edit_page(request, detail_page)
     mock__set_read_time.assert_called_once_with(request, detail_page)
+
+
+def test_wagtail_transfer_custom_adapter_methods___get_relevant_s3_meta():
+    mock_field = mock.Mock(name='mock_field')
+    adapter = S3FileFieldAdapter(mock_field)
+
+    mock_field_value = mock.Mock(name='mock_field_value')
+    mock_field_value.storage.bucket.name = 'test-bucket-name'
+    mock_field_value.name = 'test-bucket-key'
+    # There are other attributes on the real object, eg 'url'
+
+    mock_objectsummary_instance = mock.Mock(name='mock_objectsummary_instance')
+    mock_objectsummary_instance.size = 1234567
+    mock_objectsummary_instance.e_tag.replace.return_value = 'aabbccddeeff112233445566'
+    # The double quoting is correct - ETags are meant to be double-quoted.
+    # See https://tools.ietf.org/html/rfc2616#section-14.19
+
+    mock_objectsummary_class = mock.Mock(name='mock ObjectSummary')
+    mock_objectsummary_class.return_value = mock_objectsummary_instance
+
+    with mock.patch('core.wagtail_hooks.s3.ObjectSummary', mock_objectsummary_class):
+        meta = adapter._get_relevant_s3_meta(mock_field_value)
+
+    mock_objectsummary_class.assert_called_once_with(
+        'test-bucket-name',
+        'test-bucket-key'
+    )
+    assert meta == {
+        'size': 1234567,
+        'hash': 'aabbccddeeff112233445566'
+    }
+
+
+@pytest.mark.parametrize(
+    'etag_val,expected',
+    (
+        ('"aabbccddeeff112233445566"', 'aabbccddeeff112233445566'),
+        ('aabbccddeeff112233445566', 'aabbccddeeff112233445566'),
+        ("aabbccddeeff112233445566", 'aabbccddeeff112233445566'),  # noqa Q000  - this was deliberate
+    )
+)
+def test_wagtail_transfer_custom_adapter_methods___get_file_hash(etag_val, expected):
+    mock_field = mock.Mock(name='mock_field')
+    adapter = S3FileFieldAdapter(mock_field)
+
+    mock_objectsummary_instance = mock.Mock(name='mock_objectsummary_instance')
+    mock_objectsummary_instance.size = 1234567
+    mock_objectsummary_instance.e_tag = etag_val
+
+    hash_ = adapter._get_file_hash(mock_objectsummary_instance)
+
+    assert hash_ == expected
+
+
+@pytest.mark.parametrize(
+    'file_url,expected',
+    (
+        # See constants.AWS_S3_MAIN_HOSTNAME_OPTIONS
+        (
+            'https://w-t-test-bucket.s3.amazonaws.com/media/path/to/file.mp4',
+            ('w-t-test-bucket', 'media/path/to/file.mp4')
+        ),
+        (
+            'http://w-t-test-bucket.s3.amazonaws.com/media/path/to/file.mp4',
+            ('w-t-test-bucket', 'media/path/to/file.mp4')
+        ),
+        (
+            'https://w-t-test-bucket.s3.eu-west-2.amazonaws.com/media/path/to/file.mp4',
+            ('w-t-test-bucket', 'media/path/to/file.mp4')
+        ),
+        (
+            'https://w-t-test-bucket.s3.dualstack.eu-west-2.amazonaws.com/media/path/to/file.mp4',
+            ('w-t-test-bucket', 'media/path/to/file.mp4')
+        ),
+        (
+            'https://w-t-test-bucket.s3-accesspoint.eu-west-2.amazonaws.com/media/path/to/file.mp4',
+            ('w-t-test-bucket', 'media/path/to/file.mp4')
+        ),
+        (
+            'https://w-t-test-bucket.s3-accesspoint.dualstack.eu-west-2.amazonaws.com/media/path/to/file.mp4',
+            ('w-t-test-bucket', 'media/path/to/file.mp4')
+        ),
+    )
+)
+def test_wagtail_transfer_custom_adapter_methods___get_imported_file_bucket_and_key(
+    file_url,
+    expected
+):
+    mock_field = mock.Mock(name='mock_field')
+    adapter = S3FileFieldAdapter(mock_field)
+    assert adapter._get_imported_file_bucket_and_key(file_url) == expected
+
+
+@override_settings(MEDIA_URL='https://magna-fake-example.s3.amazonaws.com')
+@pytest.mark.parametrize(
+    'url,expected',
+    (
+        ('https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg', {
+            'download_url': 'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+            'size': 123321,
+            'hash': 'aabbccddeeff665544332211',
+        }),
+        (None, None),
+    )
+)
+def test_wagtail_transfer_custom_adapter_methods__serialize(
+    url,
+    expected
+):
+    file_field = FileField()
+
+    if url:
+        mock_field_value = mock.Mock()
+        mock_field_value.url = url
+        # There are other attributes on the real object, but we're only using url here
+    else:
+        mock_field_value = None
+
+    file_field.value_from_object = mock.Mock(return_value=mock_field_value)
+
+    adapter = S3FileFieldAdapter(file_field)
+    instance = mock.Mock()
+
+    mock_get_relevant_s3_meta = mock.Mock(return_value={
+        'download_url': url,
+        'size': 123321,
+        'hash': 'aabbccddeeff665544332211'
+    })
+
+    with mock.patch(
+        'core.wagtail_hooks.S3FileFieldAdapter._get_relevant_s3_meta',
+        mock_get_relevant_s3_meta
+    ):
+        output = adapter.serialize(instance)
+
+    assert output == expected
+
+    file_field.value_from_object.assert_called_once_with(instance)
+
+    if url:
+        mock_get_relevant_s3_meta.assert_called_once_with(
+            field_value=mock_field_value
+        )
+
+####################################################################################################
+# Cases for S3FileFieldAdapter.populate_field
+
+# These following tests are repetitive, but using parametrize() to DRY them up just
+# made them really complex
+
+# 1. File not already imported, source's hash matches hashes with existing file, so no import needed
+# 2. File not already imported, source's hash doesn't match existing file, so we do a fresh import
+# 3. As above, but an exception is raised during file.transfer()
+# 4. File was already imported - no need to re-import
+# 5. Null `value` param, we abandon early
+
+
+def test_wagtail_transfer_custom_adapter_methods__populate_field__case_1():
+    # 1. File not already imported, source's hash matches hashes with existing file, so no import needed
+    file_field = FileField()
+    file_field.get_attname = mock.Mock(return_value='some-filefield')
+
+    mock_field_value = mock.Mock(name='mock_field_value')
+    mock_field_value.storage.bucket.name = 'test-bucket-name'
+    mock_field_value.name = 'test-bucket-key'
+    file_field.value_from_object = mock.Mock(return_value=mock_field_value)
+
+    adapter = S3FileFieldAdapter(file_field)
+
+    fake_value = {
+        'download_url': 'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        'size': 123321,
+        'hash': 'aabbccddeeff665544332211'
+    }
+
+    adapter._get_imported_file_bucket_and_key = mock.Mock(
+        return_value=('magna-fake-example.s3.amazonaws.com', 'path/to/file.jpg')
+    )
+
+    mock_context = mock.Mock()
+    mock_context.imported_files_by_source_url = {}
+
+    mock_imported_file = mock.Mock(name='mock_imported_file')
+
+    mock_get_relevant_s3_meta = mock.Mock(return_value={
+        'download_url': 'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        'size': 123321,
+        'hash': 'aabbccddeeff665544332211'  # same as existing file, so no import will happen
+    })
+
+    mock_s3_file = mock.Mock(name='mock_s3_file')
+    mock_s3_file.source_url = 'MOCK_SOURCE_URL_VALUE'
+    mock_s3_file.transfer.return_value = mock_imported_file
+
+    mock_S3WagtailTransferFile = mock.Mock(return_value=mock_s3_file)  # noqa N806
+
+    mock_instance = mock.Mock()
+
+    with mock.patch(
+        'core.wagtail_hooks.S3FileFieldAdapter._get_relevant_s3_meta',
+        mock_get_relevant_s3_meta
+    ):
+        with mock.patch(
+            'core.wagtail_hooks.S3WagtailTransferFile',
+            mock_S3WagtailTransferFile
+        ):
+            adapter.populate_field(
+                instance=mock_instance,
+                value=fake_value,
+                context=mock_context,
+            )
+
+    assert adapter._get_imported_file_bucket_and_key.call_count == 0
+    mock_get_relevant_s3_meta.assert_called_once_with(field_value=mock_field_value)
+    assert mock_S3WagtailTransferFile.call_count == 0
+    assert mock_s3_file.transfer.call_count == 0
+
+
+def test_wagtail_transfer_custom_adapter_methods__populate_field__case_2():
+    # 2. File not already imported, source's hash DOES NOT match existing file, so we do a fresh import
+    file_field = FileField()
+    file_field.get_attname = mock.Mock(return_value='some-filefield')
+
+    mock_field_value = mock.Mock(name='mock_field_value')
+    mock_field_value.storage.bucket.name = 'test-bucket-name'
+    mock_field_value.name = 'test-bucket-key'
+
+    file_field.value_from_object = mock.Mock(return_value=mock_field_value)
+
+    mock_instance = mock.Mock()
+
+    adapter = S3FileFieldAdapter(file_field)
+
+    fake_value = {
+        'download_url': 'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        'size': 123321,
+        'hash': 'aabbccddeeff665544332211'
+    }
+
+    adapter._get_imported_file_bucket_and_key = mock.Mock(
+        return_value=('magna-fake-example.s3.amazonaws.com', 'path/to/file.jpg')
+    )
+
+    mock_context = mock.Mock()
+    mock_context.imported_files_by_source_url = {}
+
+    mock_imported_file = mock.Mock(name='mock_imported_file')
+
+    mock_get_relevant_s3_meta = mock.Mock(return_value={
+        'download_url': 'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        'size': 123321,
+        'hash': 'bbccddeeff'  # ie, does NOT match
+    })
+
+    mock_s3_file = mock.Mock(name='mock_s3_file')
+    mock_s3_file.source_url = 'MOCK_SOURCE_URL_VALUE'
+    mock_s3_file.transfer.return_value = mock_imported_file
+
+    mock_S3WagtailTransferFile = mock.Mock(return_value=mock_s3_file)  # noqa N806
+
+    with mock.patch(
+        'core.wagtail_hooks.S3FileFieldAdapter._get_relevant_s3_meta',
+        mock_get_relevant_s3_meta
+    ):
+        with mock.patch(
+            'core.wagtail_hooks.S3WagtailTransferFile',
+            mock_S3WagtailTransferFile
+        ):
+            adapter.populate_field(
+                instance=mock_instance,
+                value=fake_value,
+                context=mock_context,
+            )
+
+    # the importer was called
+    mock_get_relevant_s3_meta.assert_called_once_with(field_value=mock_field_value)
+
+    adapter._get_imported_file_bucket_and_key.assert_called_once_with(
+        fake_value['download_url']
+    )
+
+    mock_S3WagtailTransferFile.assert_called_once_with(
+        local_filename='path/to/file.jpg',  # not changed by DefaultStorage in this test
+        size=123321,
+        hash_='aabbccddeeff665544332211',
+        source_url='https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        source_bucket='magna-fake-example.s3.amazonaws.com',
+        source_key='path/to/file.jpg',
+    )
+
+    mock_s3_file.transfer.assert_called_once_with()  # Deliberately no args
+
+    # show the imported file is now in the cache so it won't be re-imported
+    assert mock_context.imported_files_by_source_url[
+        'MOCK_SOURCE_URL_VALUE'
+    ] == mock_imported_file
+
+
+def test_wagtail_transfer_custom_adapter_methods__populate_field__case_3():
+    # 3. As above, but an exception is raised during file.transfer()
+    file_field = FileField()
+    file_field.get_attname = mock.Mock(return_value='some-filefield')
+
+    mock_field_value = mock.Mock(name='mock_field_value')
+    mock_field_value.storage.bucket.name = 'test-bucket-name'
+    mock_field_value.name = 'test-bucket-key'
+
+    file_field.value_from_object = mock.Mock(return_value=mock_field_value)
+
+    mock_instance = mock.Mock()
+
+    adapter = S3FileFieldAdapter(file_field)
+
+    fake_value = {
+        'download_url': 'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        'size': 123321,
+        'hash': 'aabbccddeeff665544332211'
+    }
+
+    adapter._get_imported_file_bucket_and_key = mock.Mock(
+        return_value=('magna-fake-example.s3.amazonaws.com', 'path/to/file.jpg')
+    )
+
+    mock_context = mock.Mock()
+    mock_context.imported_files_by_source_url = {}
+
+    mock_get_relevant_s3_meta = mock.Mock(return_value={
+        'download_url': 'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        'size': 123321,
+        'hash': 'bbccddeeff'  # ie, does NOT match
+    })
+
+    mock_s3_file = mock.Mock(name='mock_s3_file')
+    mock_s3_file.source_url = 'MOCK_SOURCE_URL_VALUE'
+    mock_s3_file.transfer.side_effect = FileTransferError('Faked')
+    mock_S3WagtailTransferFile = mock.Mock(return_value=mock_s3_file)  # noqa N806
+
+    with mock.patch(
+        'core.wagtail_hooks.S3FileFieldAdapter._get_relevant_s3_meta',
+        mock_get_relevant_s3_meta
+    ):
+        with mock.patch(
+            'core.wagtail_hooks.S3WagtailTransferFile',
+            mock_S3WagtailTransferFile
+        ):
+            adapter.populate_field(
+                instance=mock_instance,
+                value=fake_value,
+                context=mock_context,
+            )
+
+    # the importer was called, but dudn't succeed
+    mock_get_relevant_s3_meta.assert_called_once_with(field_value=mock_field_value)
+
+    adapter._get_imported_file_bucket_and_key.assert_called_once_with(
+        fake_value['download_url']
+    )
+
+    mock_S3WagtailTransferFile.assert_called_once_with(
+        local_filename='path/to/file.jpg',  # not changed by DefaultStorage in this test
+        size=123321,
+        hash_='aabbccddeeff665544332211',
+        source_url='https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        source_bucket='magna-fake-example.s3.amazonaws.com',
+        source_key='path/to/file.jpg',
+    )
+
+    mock_s3_file.transfer.assert_called_once_with()  # Deliberately no args
+
+    # show the imported file is NOT in the cache because we failde
+    assert 'MOCK_SOURCE_URL_VALUE' not in mock_context.imported_files_by_source_url
+
+
+def test_wagtail_transfer_custom_adapter_methods__populate_field__case_4():
+    # 4. File was already imported - no need to re-import
+
+    file_field = FileField()
+    file_field.get_attname = mock.Mock(return_value='some-filefield')
+
+    mock_field_value = mock.Mock(name='mock_field_value')
+    mock_field_value.storage.bucket.name = 'test-bucket-name'
+    mock_field_value.name = 'test-bucket-key'
+
+    file_field.value_from_object = mock.Mock(return_value=mock_field_value)
+
+    mock_instance = mock.Mock()
+
+    adapter = S3FileFieldAdapter(file_field)
+
+    fake_value = {
+        'download_url': 'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        'size': 123321,
+        'hash': 'aabbccddeeff665544332211'
+    }
+
+    adapter._get_imported_file_bucket_and_key = mock.Mock()
+
+    mock_imported_file = mock.Mock(name='mock_imported_file')
+    mock_context = mock.Mock()
+    mock_context.imported_files_by_source_url = {
+        'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg': mock_imported_file
+    }
+
+    mock_get_relevant_s3_meta = mock.Mock()
+    mock_S3WagtailTransferFile = mock.Mock()  # noqa N806
+
+    with mock.patch(
+        'core.wagtail_hooks.S3FileFieldAdapter._get_relevant_s3_meta',
+        mock_get_relevant_s3_meta
+    ):
+        with mock.patch(
+            'core.wagtail_hooks.S3WagtailTransferFile',
+            mock_S3WagtailTransferFile
+        ):
+            adapter.populate_field(
+                instance=mock_instance,
+                value=fake_value,
+                context=mock_context,
+            )
+
+    assert adapter._get_imported_file_bucket_and_key.call_count == 0
+    assert mock_get_relevant_s3_meta.call_count == 0
+    assert mock_S3WagtailTransferFile.call_count == 0
+
+
+def test_wagtail_transfer_custom_adapter_methods__populate_field__case_5():
+    # 5. Null `value` param, we abandon early
+
+    file_field = FileField()
+    file_field.get_attname = mock.Mock(return_value='some-filefield')
+
+    file_field.value_from_object = mock.Mock()
+
+    mock_instance = mock.Mock()
+
+    adapter = S3FileFieldAdapter(file_field)
+
+    fake_value = {}
+
+    adapter._get_imported_file_bucket_and_key = mock.Mock()
+
+    mock_context = mock.Mock()
+    mock_get_relevant_s3_meta = mock.Mock()
+    mock_S3WagtailTransferFile = mock.Mock()  # noqa N806
+
+    with mock.patch(
+        'core.wagtail_hooks.S3FileFieldAdapter._get_relevant_s3_meta',
+        mock_get_relevant_s3_meta
+    ):
+        with mock.patch(
+            'core.wagtail_hooks.S3WagtailTransferFile',
+            mock_S3WagtailTransferFile
+        ):
+            adapter.populate_field(
+                instance=mock_instance,
+                value=fake_value,
+                context=mock_context,
+            )
+
+    assert file_field.value_from_object.call_count == 0
+    assert adapter._get_imported_file_bucket_and_key.call_count == 0
+    assert mock_get_relevant_s3_meta.call_count == 0
+    assert mock_S3WagtailTransferFile.call_count == 0
+
+####################################################################################################
+
+
+@override_settings(AWS_STORAGE_BUCKET_NAME='magna-fake-bucket-2')
+@mock.patch('core.wagtail_hooks.s3.meta.client.copy')
+@mock.patch('core.wagtail_hooks.ImportedFile.objects.create')
+def test_s3wagtailtransferfile__transfer(
+    mock_importedfile_objects_create,
+    mock_s3_client_copy,
+):
+
+    file = S3WagtailTransferFile(
+        local_filename='path/to/file.jpg',  # not changed by DefaultStorage in this test
+        size=123321,
+        hash_='aabbccddeeff665544332211',
+        source_url='https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        source_bucket='magna-fake-bucket-1.s3.amazonaws.com',
+        source_key='path/to/file.jpg',
+    )
+
+    assert file.local_filename == 'path/to/file.jpg'
+    assert file.size == 123321
+    assert file.hash == 'aabbccddeeff665544332211'
+    assert file.source_url == 'https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg'
+    assert file.source_bucket == 'magna-fake-bucket-1.s3.amazonaws.com'
+    assert file.source_key == 'path/to/file.jpg'
+
+    assert not mock_s3_client_copy.called
+
+    file.transfer()
+
+    mock_s3_client_copy.assert_called_once_with(
+        {
+            'Bucket': file.source_bucket,
+            'Key': file.source_key
+        },
+        'magna-fake-bucket-2',
+        file.local_filename,
+    )
+
+    mock_importedfile_objects_create.assert_called_once_with(
+        file=file.local_filename,
+        source_url=file.source_url,
+        hash=file.hash,
+        size=file.size,
+    )
+
+
+@pytest.mark.parametrize(
+    'exception_class', (
+        RetriesExceededError,
+        S3UploadFailedError,
+        ValueError,
+    )
+)
+@mock.patch('core.wagtail_hooks.s3.meta.client.copy')
+def test_s3wagtailtransferfile__transfer__covered_exceptions(mock_s3_client_copy, exception_class):
+    file = S3WagtailTransferFile(
+        local_filename='path/to/file.jpg',  # not changed by DefaultStorage in this test
+        size=123321,
+        hash_='aabbccddeeff665544332211',
+        source_url='https://magna-fake-example.s3.amazonaws.com/path/to/file.jpg',
+        source_bucket='magna-fake-bucket-1.s3.amazonaws.com',
+        source_key='path/to/file.jpg',
+    )
+    mock_s3_client_copy.side_effect = exception_class('Faked')
+
+    with pytest.raises(FileTransferError):
+        file.transfer()
+
+
+@pytest.mark.parametrize(
+    'user_media_on_s3,expected',
+    (
+        (True, {FileField: S3FileFieldAdapter}),
+        (False, {}),
+    )
+)
+def test_register_s3_media_file_adapter(user_media_on_s3, expected):
+    with override_settings(USER_MEDIA_ON_S3=user_media_on_s3):
+        assert register_s3_media_file_adapter() == expected


### PR DESCRIPTION
Takes the approach of a custom FileAdapter that is only used if all assets are on S3.

Key points:

* Uses the hash of the file from the S3 ETag rather than load and hash the entire file - saves time. See the comments re the use of the ETag as a hash: there are some limitations.
* Uses S3's client.copy() API to do the copying legwork, rather than "download, stream accross, upload" - saves time
* ONLY works if the source file is publicly readable
* ONLY works within the same AWS Region (according to the docs - untested)

## To do (delete all that do not apply):


 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/GP2-661 
 - [X] Jira ticket has the correct status.
 - [x] [Changelog](CHANGELOG.md) entry added.
 
 - [ ] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
