### PR TITLE
GP2-901: Case study preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 ### Implemented enhancements
 - GP2-1047 - page structure and components for costs and pricing page  
 - GP2-1028 - Target-market routing feature
+- GP2-901 - Add Case Study view support to CMS
 - GP2-1033 - Country chooser mobile
 - GP2-1051 - Compare markets feature flag
 - GP2-984 - Compare markets selector and redux global state managememt

--- a/cms_extras/admin.py
+++ b/cms_extras/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/cms_extras/admin.py
+++ b/cms_extras/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/cms_extras/apps.py
+++ b/cms_extras/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class CmsExtrasConfig(AppConfig):
+    name = 'cms_extras'
+
+    def ready(self):
+        from cms_extras import modeladmin  # noqa F401

--- a/cms_extras/modeladmin.py
+++ b/cms_extras/modeladmin.py
@@ -12,7 +12,7 @@ class CaseStudyAdminButtonHelper(ButtonHelper):
     view_button_classnames = ['button-small', 'icon', 'icon-doc']
 
     def view_button(self, obj):
-        "Button to trigger a standalone view of the relevant CaseStudy"
+        """Button to trigger a standalone view of the relevant CaseStudy"""
         text = f'View {self.verbose_name}'
         return {
             'classname': self.finalise_classname(self.view_button_classnames),

--- a/cms_extras/modeladmin.py
+++ b/cms_extras/modeladmin.py
@@ -1,0 +1,37 @@
+from wagtail.contrib.modeladmin.options import (
+    ModelAdmin,
+    modeladmin_register
+)
+
+from core.models import CaseStudy
+
+
+class CaseStudyAdmin(ModelAdmin):
+    model = CaseStudy
+    add_to_settings_menu = False
+    exclude_from_explorer = False
+    menu_icon = 'fa-book'
+    list_display = (
+        '__str__',
+        'associated_hs_code_tags',
+        'associated_country_code_tags'
+    )
+    # list_filter = (  # DISABLED BECAUSE SLOWING DOWN THE PAGE TOO MUCH
+    #     'hs_code_tags',
+    #     'country_code_tags',
+    # )
+    search_fields = (
+        'title',
+        'company_name',
+        'country_code_tags__name',
+        'hs_code_tags__name',
+    )
+
+    def associated_hs_code_tags(self, obj):
+        return [str(x) for x in obj.hs_code_tags.all()]
+
+    def associated_country_code_tags(self, obj):
+        return [str(x) for x in obj.country_code_tags.all()]
+
+
+modeladmin_register(CaseStudyAdmin)

--- a/cms_extras/modeladmin.py
+++ b/cms_extras/modeladmin.py
@@ -1,3 +1,4 @@
+from wagtail.contrib.modeladmin.helpers import ButtonHelper
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin,
     modeladmin_register
@@ -6,9 +7,33 @@ from wagtail.contrib.modeladmin.options import (
 from core.models import CaseStudy
 
 
+class CaseStudyAdminButtonHelper(ButtonHelper):
+
+    view_button_classnames = ['button-small', 'icon', 'icon-doc']
+
+    def view_button(self, obj):
+        "Button to trigger a standalone view of the relevant CaseStudy"
+        text = f'View {self.verbose_name}'
+        return {
+            'classname': self.finalise_classname(self.view_button_classnames),
+            'label': text,
+            'title': text,
+            'url': obj.get_cms_standalone_view_url(),
+        }
+
+    def get_buttons_for_obj(self, obj, exclude=None, classnames_add=None, classnames_exclude=None):
+        btns = super().get_buttons_for_obj(obj, exclude, classnames_add, classnames_exclude)
+        if 'view' not in (exclude or []):
+            btns.append(
+                self.view_button(obj)
+            )
+        return btns
+
+
 class CaseStudyAdmin(ModelAdmin):
     model = CaseStudy
     add_to_settings_menu = False
+    button_helper_class = CaseStudyAdminButtonHelper
     exclude_from_explorer = False
     menu_icon = 'fa-book'
     list_display = (

--- a/cms_extras/models.py
+++ b/cms_extras/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/cms_extras/models.py
+++ b/cms_extras/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+from django.db import models  # noqa F401
 
 # Create your models here.

--- a/cms_extras/templates/view_case_study.html
+++ b/cms_extras/templates/view_case_study.html
@@ -1,0 +1,51 @@
+{% extends 'core/base.html' %}
+
+{% load static wagtailcore_tags %}
+
+{% block head_title %}Viewing Case Study: {{case_study.title}}{% endblock head_title %}
+
+{% block head_css %}
+    {{ block.super }}
+    <link href="{% static 'styles.css' %}" media="all" rel="stylesheet" />
+{% endblock %}
+
+{% block head_js %}
+    {{ block.super }}
+    <script type="text/javascript" src="{% static 'magna.js' %}"></script>
+{% endblock %}
+
+{% block body_header %}
+{% endblock %}
+
+{% block content %}
+
+<div class='bg-white'>
+    <div class="lesson-page">
+        <div class="container">
+            <div class="p-s">
+                <h2>
+                    Viewing
+                    <span class="body-l-b">
+                        {{case_study.title}}
+                    </span>
+                </h2>
+                <a href="{{backlink}}">Back to list</a>
+            </div>
+            <div class="grid">
+                <div class="c-1-4 hide-on-mobile">
+                    <span>&nbsp;</span>
+                </div>
+                <div class="c-1-2 lesson-body-blocks">
+                    {% include 'core/case_study_block.html' with case_study=case_study only %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock content %}
+
+{% block cookie_notice %}{% endblock %}
+
+{% block body_footer %}
+{% endblock %}

--- a/cms_extras/tests.py
+++ b/cms_extras/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/cms_extras/tests.py
+++ b/cms_extras/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/cms_extras/urls.py
+++ b/cms_extras/urls.py
@@ -1,0 +1,16 @@
+from django.contrib.admin.views.decorators import staff_member_required
+
+from django.urls import path
+
+from cms_extras.views import case_study as case_study_view
+
+app_name = 'cms_extra'
+
+
+urlpatterns = [
+    path(
+        'case-study/<int:case_study_id>/',
+        staff_member_required(case_study_view),
+        name='case-study-view'
+    ),
+]

--- a/cms_extras/views.py
+++ b/cms_extras/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/cms_extras/views.py
+++ b/cms_extras/views.py
@@ -4,8 +4,8 @@ from core.models import CaseStudy
 from cms_extras.modeladmin import CaseStudyAdmin
 
 
-def case_study(request, case_study_id, template="view_case_study.html"):
-    "Allows a CaseStudy to be rendered standalone, within the CMS admin"
+def case_study(request, case_study_id, template='view_case_study.html'):
+    """Allows a CaseStudy to be rendered standalone, within the CMS admin"""
 
     case_study = get_object_or_404(CaseStudy, id=case_study_id)
     backlink = CaseStudyAdmin().url_helper.get_action_url('index')

--- a/cms_extras/views.py
+++ b/cms_extras/views.py
@@ -1,3 +1,20 @@
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 
-# Create your views here.
+from core.models import CaseStudy
+from cms_extras.modeladmin import CaseStudyAdmin
+
+
+def case_study(request, case_study_id, template="view_case_study.html"):
+    "Allows a CaseStudy to be rendered standalone, within the CMS admin"
+
+    case_study = get_object_or_404(CaseStudy, id=case_study_id)
+    backlink = CaseStudyAdmin().url_helper.get_action_url('index')
+
+    return render(
+        request=request,
+        context={
+            'backlink': backlink,
+            'case_study': case_study
+        },
+        template_name=template
+    )

--- a/config/settings.py
+++ b/config/settings.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
 
     'sso',
     'core.apps.CoreConfig',
+    'cms_extras.apps.CmsExtrasConfig',
     'domestic',
     'exportplan.apps.ExportPlanConfig',
     'users.apps.UsersConfig',

--- a/config/urls.py
+++ b/config/urls.py
@@ -10,6 +10,7 @@ from wagtail.documents import urls as wagtaildocs_urls
 from wagtail_transfer import urls as wagtailtransfer_urls
 
 import sso.urls
+import cms_extras.urls
 import core.urls
 import exportplan.urls
 
@@ -27,6 +28,7 @@ urlpatterns += [
     path('django-admin/', admin.site.urls),
     path('admin/wagtail-transfer/', include(wagtailtransfer_urls)),  # Has to come before main /admin/ else will fail
     path('admin/', include(wagtailadmin_urls)),
+    path('cms-extras/', include(cms_extras.urls, namespace='cms_extras')),
     path('documents/', include(wagtaildocs_urls)),
     path('sso/', include(sso.urls)),
     path('', include(core.urls, namespace='core')),

--- a/core/models.py
+++ b/core/models.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.fields import CreationDateTimeField, ModificationDateTimeField
@@ -1002,6 +1003,9 @@ class CaseStudy(ClusterableModel):
             getattr(self, 'update_modified', True)
         )
         super().save(**kwargs)
+
+    def get_cms_standalone_view_url(self):
+        return reverse('cms_extras:case-study-view', args=[self.id])
 
     class Meta:
         verbose_name_plural = 'Case studies'

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -10,43 +10,16 @@ from great_components.helpers import add_next
 from wagtail.core import hooks
 from wagtail.core.models import Page
 
-from wagtail.contrib.modeladmin.options import (
-    ModelAdmin,
-    modeladmin_register
-)
 
 from django.urls import reverse
 from django.core.serializers.json import DjangoJSONEncoder
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 
-from core import constants, mixins, views, models
+from core import constants, mixins, views
 
 SESSION_KEY_LESSON_PAGE_SHOW_GENERIC_CONTENT = 'LESSON_PAGE_SHOW_GENERIC_CONTENT'
 exportplan_templates = ['exportplan/automated_list_page.html', 'exportplan/dashboard_page.html']
-
-
-class CaseStudyAdmin(ModelAdmin):
-    model = models.CaseStudy
-    add_to_settings_menu = False
-    exclude_from_explorer = False
-    menu_icon = 'fa-book'
-    list_display = (
-        '__str__',
-        'associated_hs_code_tags',
-        'associated_country_code_tags'
-    )
-    list_filter = ('hs_code_tags', 'country_code_tags',)
-    search_fields = ('title', 'company_name',)
-
-    def associated_hs_code_tags(self, obj):
-        return [str(x) for x in obj.hs_code_tags.all()]
-
-    def associated_country_code_tags(self, obj):
-        return [str(x) for x in obj.country_code_tags.all()]
-
-
-modeladmin_register(CaseStudyAdmin)
 
 
 @hooks.register('before_serve_page')

--- a/tests/unit/cms_extra/test_modeladmin.py
+++ b/tests/unit/cms_extra/test_modeladmin.py
@@ -1,8 +1,11 @@
+from unittest import mock
+
 import pytest
 
-from tests.unit.core import factories
 
-from cms_extras.modeladmin import CaseStudyAdmin
+from cms_extras.modeladmin import CaseStudyAdmin, CaseStudyAdminButtonHelper
+from core.models import CaseStudy
+from tests.unit.core import factories
 
 
 @pytest.mark.django_db
@@ -15,3 +18,61 @@ def test_case_study_modeladmin_list_display_methods():
 
     assert sorted(admin.associated_country_code_tags(obj)) == ['Europe', 'FR']
     assert sorted(admin.associated_hs_code_tags(obj)) == ['HS1234', 'HS123456']
+
+
+@pytest.mark.django_db
+def test_casestudyadminbuttonhelper(rf, django_user_model):
+
+    obj = factories.CaseStudyFactory()
+
+    user = django_user_model.objects.create_user(
+        username='username',
+        password='password',
+        is_staff=True
+    )
+
+    mock_request = rf.get('/')
+    mock_request.user = user
+
+    mock_view = mock.Mock(name='mock_view')
+    mock_view.model = CaseStudy
+    mock_view.url_helper.get_action_url.return_value = '/mock-url/path/'
+
+    helper = CaseStudyAdminButtonHelper(
+        request=mock_request,
+        view=mock_view,
+    )
+
+    assert helper.view_button(obj) == {
+        'classname': 'button button-small icon icon-doc',
+        'label': 'View case study',
+        'title': 'View case study',
+        'url': f'/cms-extras/case-study/{obj.id}/',
+    }
+
+    assert helper.get_buttons_for_obj(obj) == [
+        {
+            'classname': 'button',
+            'label': 'Inspect',
+            'title': 'Inspect this case study',
+            'url': '/mock-url/path/'
+        },
+        {
+            'classname': 'button',
+            'label': 'Edit',
+            'title': 'Edit this case study',
+            'url': '/mock-url/path/'
+        },
+        {
+            'classname': 'button no',
+            'label': 'Delete',
+            'title': 'Delete this case study',
+            'url': '/mock-url/path/'
+        },
+        {
+            'classname': 'button button-small icon icon-doc',
+            'label': 'View case study',
+            'title': 'View case study',
+            'url': f'/cms-extras/case-study/{obj.id}/'
+        },
+    ]

--- a/tests/unit/cms_extra/test_modeladmin.py
+++ b/tests/unit/cms_extra/test_modeladmin.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tests.unit.core import factories
+
+from cms_extras.modeladmin import CaseStudyAdmin
+
+
+@pytest.mark.django_db
+def test_case_study_modeladmin_list_display_methods():
+    admin = CaseStudyAdmin()
+    obj = factories.CaseStudyFactory()
+
+    obj.country_code_tags.add('Europe', 'FR')
+    obj.hs_code_tags.add('HS1234', 'HS123456')
+
+    assert sorted(admin.associated_country_code_tags(obj)) == ['Europe', 'FR']
+    assert sorted(admin.associated_hs_code_tags(obj)) == ['HS1234', 'HS123456']

--- a/tests/unit/cms_extra/test_views.py
+++ b/tests/unit/cms_extra/test_views.py
@@ -1,0 +1,54 @@
+import pytest
+
+from django.urls import reverse
+
+from tests.unit.core.factories import CaseStudyFactory
+
+
+@pytest.mark.django_db
+def test_case_study_view(client, django_user_model):
+
+    user = django_user_model.objects.create_user(
+        username='username',
+        password='password',
+        is_staff=True
+    )
+    client.login(username='username', password='password')
+
+    assert user.is_authenticated and user.is_active and user.is_staff
+
+    case_study = CaseStudyFactory()
+
+    url = reverse('cms_extras:case-study-view', args=[case_study.id])
+    resp = client.get(url)
+
+    assert resp.status_code == 200
+    assert resp.context['case_study'] == case_study
+    assert resp.context['backlink'] == '/admin/core/casestudy/'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('is_staff', (True, False))
+def test_case_study_view__access(django_user_model, client, is_staff):
+
+    user = django_user_model.objects.create_user(
+        username='username',
+        password='password',
+    )
+    user.is_staff = is_staff
+    user.save()
+
+    client.login(username='username', password='password')
+
+    assert user.is_authenticated and user.is_active and user.is_staff == is_staff
+
+    case_study = CaseStudyFactory()
+
+    url = reverse('cms_extras:case-study-view', args=[case_study.id])
+    resp = client.get(url)
+
+    if is_staff:
+        assert resp.status_code == 200
+    else:
+        assert resp.status_code == 302
+        assert resp._headers['location'][1] == f'/django-admin/login/?next=/cms-extras/case-study/{case_study.id}/'

--- a/tests/unit/core/test_wagtail_hooks.py
+++ b/tests/unit/core/test_wagtail_hooks.py
@@ -9,7 +9,6 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from wagtail.core.rich_text import RichText
 
 from core import wagtail_hooks
-from core.wagtail_hooks import CaseStudyAdmin
 from tests.helpers import make_test_video
 from tests.unit.core import factories
 from tests.unit.exportplan.factories import (
@@ -541,15 +540,3 @@ def test_set_read_time__after_edit_page(domestic_homepage, rf):
     with mock.patch('core.wagtail_hooks._set_read_time') as mock__set_read_time:
         wagtail_hooks.set_read_time__after_edit_page(request, detail_page)
     mock__set_read_time.assert_called_once_with(request, detail_page)
-
-
-@pytest.mark.django_db
-def test_case_study_modeladmin_list_display_methods():
-    admin = CaseStudyAdmin()
-    obj = factories.CaseStudyFactory()
-
-    obj.country_code_tags.add('Europe', 'FR')
-    obj.hs_code_tags.add('HS1234', 'HS123456')
-
-    assert sorted(admin.associated_country_code_tags(obj)) == ['Europe', 'FR']
-    assert sorted(admin.associated_hs_code_tags(obj)) == ['HS1234', 'HS123456']


### PR DESCRIPTION
This changeset adds a way to view a case study to the CMS, so that you editors can view them in isolation, without having to create a suitable user in order to match the Case Study's HS or country codes.

* Custom button on the ModelAdmin list page for Case Study that opens that view.
* View renders page which renders only the Case Study component for the selected Case Study - uses official CSS and JS from public site and the same template partial

 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/GP2-901 
 - [X] Jira ticket has the correct status.
 - [X] [Changelog](CHANGELOG.md) entry added.
 - [X] (if is a UI change) Includes screenshot(s) - ideally before and after, but at least after
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
**List view has a new button**
![Screenshot 2020-11-20 at 15 34 29](https://user-images.githubusercontent.com/101457/99840533-9fa44900-2b64-11eb-933a-2018ca911a05.png)

**CS view starts collapsed and has back-link to list**
![Screenshot 2020-11-20 at 15 34 40](https://user-images.githubusercontent.com/101457/99840535-a03cdf80-2b64-11eb-9cc2-c0abac7ada40.png)

**Case study expands/behaves as in the main lesson**
(note that my example image to the right is the wrong size - that's just dummy/test data, not a code bug)

![Screenshot 2020-11-20 at 15 34 51](https://user-images.githubusercontent.com/101457/99840539-a03cdf80-2b64-11eb-833e-ddfefc46d80c.png)

