### PR TITLE
GP2-901: Attempt to fix unexpected redirect to Django Admin for Case Study preview

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -27,8 +27,8 @@ if settings.ENFORCE_STAFF_SSO_ENABLED:
 urlpatterns += [
     path('django-admin/', admin.site.urls),
     path('admin/wagtail-transfer/', include(wagtailtransfer_urls)),  # Has to come before main /admin/ else will fail
+    path('admin/cms-extras/', include(cms_extras.urls, namespace='cms_extras')),
     path('admin/', include(wagtailadmin_urls)),
-    path('cms-extras/', include(cms_extras.urls, namespace='cms_extras')),
     path('documents/', include(wagtaildocs_urls)),
     path('sso/', include(sso.urls)),
     path('', include(core.urls, namespace='core')),

--- a/tests/unit/cms_extra/test_modeladmin.py
+++ b/tests/unit/cms_extra/test_modeladmin.py
@@ -36,7 +36,7 @@ def test_casestudyadminbuttonhelper(rf, django_user_model):
 
     mock_view = mock.Mock(name='mock_view')
     mock_view.model = CaseStudy
-    mock_view.url_helper.get_action_url.return_value = '/mock-url/path/'
+    mock_view.url_helper.get_action_url.return_value = '/admin/mock-url/path/'
 
     helper = CaseStudyAdminButtonHelper(
         request=mock_request,
@@ -47,7 +47,7 @@ def test_casestudyadminbuttonhelper(rf, django_user_model):
         'classname': 'button button-small icon icon-doc',
         'label': 'View case study',
         'title': 'View case study',
-        'url': f'/cms-extras/case-study/{obj.id}/',
+        'url': f'/admin/cms-extras/case-study/{obj.id}/',
     }
 
     assert helper.get_buttons_for_obj(obj) == [
@@ -55,24 +55,24 @@ def test_casestudyadminbuttonhelper(rf, django_user_model):
             'classname': 'button',
             'label': 'Inspect',
             'title': 'Inspect this case study',
-            'url': '/mock-url/path/'
+            'url': '/admin/mock-url/path/'
         },
         {
             'classname': 'button',
             'label': 'Edit',
             'title': 'Edit this case study',
-            'url': '/mock-url/path/'
+            'url': '/admin/mock-url/path/'
         },
         {
             'classname': 'button no',
             'label': 'Delete',
             'title': 'Delete this case study',
-            'url': '/mock-url/path/'
+            'url': '/admin/mock-url/path/'
         },
         {
             'classname': 'button button-small icon icon-doc',
             'label': 'View case study',
             'title': 'View case study',
-            'url': f'/cms-extras/case-study/{obj.id}/'
+            'url': f'/admin/cms-extras/case-study/{obj.id}/'
         },
     ]

--- a/tests/unit/cms_extra/test_views.py
+++ b/tests/unit/cms_extra/test_views.py
@@ -51,4 +51,6 @@ def test_case_study_view__access(django_user_model, client, is_staff):
         assert resp.status_code == 200
     else:
         assert resp.status_code == 302
-        assert resp._headers['location'][1] == f'/django-admin/login/?next=/cms-extras/case-study/{case_study.id}/'
+        assert resp._headers['location'][1] == (
+            f'/django-admin/login/?next=/admin/cms-extras/case-study/{case_study.id}/'
+        )


### PR DESCRIPTION
* Just changes the cms_extras app to be clearly below `/admin/` in case it's middleware that's hijacking the request. (Can't replicate locally)


 - [X] Ticket exists in Jira  https://uktrade.atlassian.net/browse/TICKET_ID_HERE 
 - [X] Jira ticket has the correct status.
 - [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
 
