### PR TITLE
Added missing population url to base template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Fixed bugs
 
+- No ticket - Added missing population url
 - GP2-1310 - Data not loading for if made more than one country is compared
 - GP2-1067 - Fixed LessonCompleted component
 - no-ticket - Prettify, lint and cleanup of product-finder and config boilerplate

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -52,6 +52,7 @@
           apiComTradeDataUrl: '{% url "core:api-comtrade-data" %}',
           removeSectorUrl: '{% url "exportplan:api-remove-sector" %}',
           countryAgeGroupDataUrl: '{% url "exportplan:api-target-age-country-population-data" %}',
+          populationByCountryUrl: '{% url "exportplan:api-population-data-by-country" %}',
           countryOptions: {{ javascript_components.country_choices|safe }},
           csrfToken: '{{ csrf_token }}',
           dashboardUrl: '{% url_map "dashboard" %}',


### PR DESCRIPTION
Suddenly this URL disappeared from base.html. I've readded.

### Workflow

- [x] [Changelog](CHANGELOG.md) entry added.
- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
