### PR TITLE
GP2-1284: Update Wagtail page config to limit what can be a child of the homepage

### DIFF
--- a/domestic/models.py
+++ b/domestic/models.py
@@ -409,6 +409,9 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
 
 class ArticlePage(cms_panels.ArticlePagePanels, BaseContentPage):
 
+    parent_page_types = [
+        'domestic.CountryGuidePage',
+    ]
     subpage_types = []
 
     type_of_article = models.TextField(choices=ARTICLE_TYPES, null=True)
@@ -491,6 +494,10 @@ class ArticlePage(cms_panels.ArticlePagePanels, BaseContentPage):
 
 class ArticleListingPage(cms_panels.ArticleListingPagePanels, BaseContentPage):
 
+    parent_page_types = [
+        'domestic.CountryGuidePage',
+    ]
+
     subpage_types = [
         'domestic.ArticlePage',
     ]
@@ -524,6 +531,9 @@ class ArticleListingPage(cms_panels.ArticleListingPagePanels, BaseContentPage):
 class CampaignPage(cms_panels.CampaignPagePanels, BaseContentPage):
 
     subpage_types = []
+    parent_page_types = [
+        'domestic.CountryGuidePage',
+    ]
 
     campaign_heading = models.CharField(max_length=255)
     campaign_hero_image = models.ForeignKey(


### PR DESCRIPTION
This mini changeset cleans up the options when adding a child page to the homepage in Magna - some of the page types available were not relevant.

This is an add-on/defect fix for GP2-1284 so doesn't have a changelog entry.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [-] Explains how to test locally, including how to set up appropriate data
- [X] Includes screenshot(s) - ideally before and after, but at least after

BEFORE
<img width="748" alt="Screenshot 2021-01-19 at 18 32 05" src="https://user-images.githubusercontent.com/101457/105082219-25704200-5a8b-11eb-9be9-717d96e51378.png">

AFTER
<img width="471" alt="Screenshot 2021-01-19 at 19 15 12" src="https://user-images.githubusercontent.com/101457/105082224-273a0580-5a8b-11eb-9ac9-55fbab33ca75.png">

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
