### PR TITLE
GP2-1376: Link Advice and Markets nav items to Magna pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Implemented enhancements
 
+- GP2-1376 - Use relative links to Magna-hosted Markets and Advice pages
 - GP2-1348 - Compare markets - economy/population tab enhancements
 - GP2-1332 - Markets homepage
 - GP2-1336 - Advice homepage

--- a/core/templates/components/header_footer/domestic_header_nav.html
+++ b/core/templates/components/header_footer/domestic_header_nav.html
@@ -1,14 +1,15 @@
 {% load i18n %}
+{% load wagtailcore_tags %}
 
 <div class="main-nav-container {{ device_type }}">
   <nav id="{{ id }}" class="main-nav {{ device_type }} expanded" aria-label="{% trans 'Main menu' %}">
     <ul class="grid-row nav-list">
       <li class="menu-item" data-js-menu-item-container>
-        <a href="{{ header_footer_urls.advice }}" class="link-heading" id="header-advice-{{ device_type }}" {% if js_tag %}data-js-menu-index=0{% endif %}>Advice</a>
+        <a href="{% slugurl 'advice' %}" class="link-heading" id="header-advice-{{ device_type }}" {% if js_tag %}data-js-menu-index=0{% endif %}>Advice</a>
       </li>
 
       <li class="menu-item" data-js-menu-item-container>
-        <a href="{{ header_footer_urls.markets }}" class="link-heading" id="header-markets-{{ device_type }}" {% if js_tag %}data-js-menu-index=1{% endif %}>Markets</a>
+        <a href="{% slugurl 'markets' %}" class="link-heading" id="header-markets-{{ device_type }}" {% if js_tag %}data-js-menu-index=1{% endif %}>Markets</a>
       </li>
 
       <li class="menu-item" data-js-menu-item-container>


### PR DESCRIPTION
... rather than use BAU-specific URLs from `header_footer_urls`


### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1376
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
