### PR TITLE
GP2-1368: Wire up link from country_guide.html to /advice/ slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Implemented enhancements
 
+- GP2-1368 - Wire up link from country_guide.html to /advice/ slug
 - GP2-1376 - Use relative links to Magna-hosted Markets and Advice pages
 - GP2-1348 - Compare markets - economy/population tab enhancements
 - GP2-1332 - Markets homepage

--- a/domestic/templates/domestic/content/country_guide.html
+++ b/domestic/templates/domestic/content/country_guide.html
@@ -138,7 +138,7 @@
     <div class="grid-row">
       <div class="column-full column-half-l column-third-xl margin-bottom-30 margin-bottom-0-xl">
         {% static 'images/country-guide-advice.png' as need_help_image_url %}
-        {% url 'advice' as advice_url %}
+        {% slugurl 'advice' as advice_url %}
         {% include 'components/cta_card.html' with with_arrow=True image_url=need_help_image_url text="Read more advice about doing business abroad" url=advice_url %}
       </div>
       {% if page.duties_and_custom_procedures_cta_link %}


### PR DESCRIPTION
Before it was trying to reverse URL which didn't exist in Django

I know that using `slugurl` isn't much different from using a hard-coded URL, that it still depends on a fixed value _somewhere_ in the system, but Advice is a section we know will 100% exist, and we have to make the link somewhere, so here is at least clearer than using context processors, etc, now that we no longer need to.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1368
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
