### PR TITLE
Added related pages to Case Study listing view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Implemented enhancements
 
 - GP2-1368 - Wire up link from country_guide.html to /advice/ slug
+- GP2- 1342 - Added related pages to CaseStudy listing view
 - GP2-1376 - Use relative links to Magna-hosted Markets and Advice pages
 - GP2-1348 - Compare markets - economy/population tab enhancements
 - GP2-1332 - Markets homepage

--- a/cms_extras/modeladmin.py
+++ b/cms_extras/modeladmin.py
@@ -1,3 +1,4 @@
+from django.utils.html import format_html_join
 from wagtail.contrib.modeladmin.helpers import ButtonHelper
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
@@ -31,7 +32,7 @@ class CaseStudyAdmin(ModelAdmin):
     button_helper_class = CaseStudyAdminButtonHelper
     exclude_from_explorer = False
     menu_icon = 'fa-book'
-    list_display = ('__str__', 'associated_hs_code_tags', 'associated_country_code_tags')
+    list_display = ('__str__', 'associated_hs_code_tags', 'associated_country_code_tags', 'get_related_pages')
     # list_filter = (  # DISABLED BECAUSE SLOWING DOWN THE PAGE TOO MUCH
     #     'hs_code_tags',
     #     'country_code_tags',
@@ -48,6 +49,18 @@ class CaseStudyAdmin(ModelAdmin):
 
     def associated_country_code_tags(self, obj):
         return [str(x) for x in obj.country_code_tags.all()]
+
+    def get_related_pages(self, obj):
+        page_mapping = {
+            'curatedlistpage': 'MODULE',
+            'topicpage': 'TOPIC',
+            'detailpage': 'LESSON',
+        }
+        return format_html_join(
+            '',
+            '<strong>{}: </strong> {}<br>',  # noqa
+            ((page_mapping.get(x.page.specific._meta.model_name), x.page) for x in obj.related_pages.all()),
+        )
 
 
 modeladmin_register(CaseStudyAdmin)

--- a/tests/unit/cms_extra/test_modeladmin.py
+++ b/tests/unit/cms_extra/test_modeladmin.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from cms_extras.modeladmin import CaseStudyAdmin, CaseStudyAdminButtonHelper
-from core.models import CaseStudy
+from core.models import CaseStudy, CaseStudyRelatedPages
 from tests.unit.core import factories
 
 
@@ -11,12 +11,24 @@ from tests.unit.core import factories
 def test_case_study_modeladmin_list_display_methods():
     admin = CaseStudyAdmin()
     obj = factories.CaseStudyFactory()
+    detail_page = factories.DetailPageFactory()
+    topic_page = factories.TopicPageFactory()
+    module_page = factories.CuratedListPageFactory()
 
     obj.country_code_tags.add('Europe', 'FR')
     obj.hs_code_tags.add('HS1234', 'HS123456')
 
+    # Adding related pages to case study
+    CaseStudyRelatedPages.objects.create(page=detail_page, case_study=obj)
+    CaseStudyRelatedPages.objects.create(page=topic_page, case_study=obj)
+    CaseStudyRelatedPages.objects.create(page=module_page, case_study=obj)
+
     assert sorted(admin.associated_country_code_tags(obj)) == ['Europe', 'FR']
     assert sorted(admin.associated_hs_code_tags(obj)) == ['HS1234', 'HS123456']
+    assert (
+        admin.get_related_pages(obj)
+        == '<strong>LESSON: </strong> Detail page<br><strong>TOPIC: </strong> Topic page<br><strong>MODULE: </strong> Curated List Page<br>'  # noqa
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This changeset adds related pages to CaseStudy Listing view
### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1342
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

![Screenshot from 2021-01-25 12-13-38](https://user-images.githubusercontent.com/717254/105707244-8aec8480-5f0a-11eb-8e8f-589341208370.png)

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
