### PR TITLE
GP2-1360 Personalisation bar on form pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 
 - GP2-1408 - Fix date formatting of articles on article list page template
 - GP2-1407 - Ensure ArticlePage is rendered correctly as a child of TopicLandingPage
+- GP2-1360 - Personalisation bar population on form pages
 - GP2-1375 - Fix image-types for advice and markets hero
 - GP2-1365 - Add bulleted list styles to rich text block
 - GP2-1364 - Fix extra spacing for first element in rich text block

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -21,8 +21,8 @@
     <script type="text/javascript" src="{% static 'magna.js' %}"></script>
 
     <script type="text/javascript">
-      var product = '{{ export_plan.export_commodity_codes.0.commodity_code }}';
-      var country = '{{ export_plan.export_countries.0.country_name }}';
+      var product = '{{ request.user.export_plan.export_commodity_codes.0.commodity_code }}';
+      var country = '{{ request.user.export_plan.export_countries.0.country_name }}';
       var dataLayer = window.dataLayer || []
       dataLayer.push({
         'productAdded': product || "False",
@@ -115,8 +115,8 @@
           signup: false,
         },
         exportPlan:{
-          products: {{export_plan.export_commodity_codes|to_json}},
-          markets: {{export_plan.export_countries|to_json }}
+          products: {{request.user.export_plan.export_commodity_codes|to_json}},
+          markets: {{request.user.export_plan.export_countries|to_json }}
         },
       })
 

--- a/core/templates/core/compare_countries.html
+++ b/core/templates/core/compare_countries.html
@@ -50,8 +50,8 @@ This page helps you compare country data to make the right decision.{% endblock 
     </div>
     {% if data_tabs_enabled %}
       <div id="open-product-finder" class="m-v-l"
-        data-productname="{{ export_plan.export_commodity_codes.0.commodity_name }}"
-        data-productcode="{{ export_plan.export_commodity_codes.0.commodity_code }}"
+        data-productname="{{ request.user.export_plan.export_commodity_codes.0.commodity_name }}"
+        data-productcode="{{ request.user.export_plan.export_commodity_codes.0.commodity_code }}"
         data-tabs="{{ data_tabs_enabled }}">
       </div>
 

--- a/core/templates/core/includes/personalisation_bar.html
+++ b/core/templates/core/includes/personalisation_bar.html
@@ -1,7 +1,7 @@
 
 {% load wagtailimages_tags %}
 {% load routablepageurl from wagtailroutablepage_tags %}
-{% with product=export_plan.export_commodity_codes.0 market=export_plan.export_countries.0 %}
+{% with product=request.user.export_plan.export_commodity_codes.0 market=request.user.export_plan.export_countries.0 %}
   <nav class="p-v-xs p-h-xs bg-blue-deep-80 c-full-width text-white" id="personalisation-bar">
       <span class="m-f-xs m-r-xxs">I want to export</span>
       <span id="set-product-button">


### PR DESCRIPTION
On form pages (specifically the upload logo page) the personalization bar was not being populated.
The bar requires the redux store being populated, which in turn required a certain mixin to add the export plan to the page context. The get_context method overridden in the mixin was not called in FormViews, only TemplateViews.
A much simpler (and more reliable) way though is to access the export plan directly from the templates using the request.user context provided by Django on all pages.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1360
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
