### PR TITLE
GP2-1408: Fix date formatting of articles on article list page template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 
 ### Fixed bugs
 
+- GP2-1408 - Fix date formatting of articles on article list page template
 - GP2-1407 - Ensure ArticlePage is rendered correctly as a child of TopicLandingPage
 - GP2-1375 - Fix image-types for advice and markets hero
 - GP2-1365 - Add bulleted list styles to rich text block

--- a/domestic/templates/domestic/content/article_listing_page.html
+++ b/domestic/templates/domestic/content/article_listing_page.html
@@ -36,7 +36,7 @@
             {% for article in page.specific.get_articles %}
               <li class="article">
                 <a href="{{ article.url }}" class="heading-medium link" id="{{ article.meta.slug }}-link">{{ article.article_title }}</a>
-                <p class="subheading">Last updated {{ article.last_published_at }}</p>
+                <p class="subheading">Last updated {{ article.last_published_at|date:'j F Y' }}</p>
               </li>
             {% endfor %}
           {% endblock %}


### PR DESCRIPTION
The listing page lacked custom date formatting for articles listed in it.

Before
`Last updated 28 Jan 2021, 2:19 p.m.`

After
`Last updated 28 January 2021`.


<img width="774" alt="Screenshot 2021-01-28 at 14 38 58" src="https://user-images.githubusercontent.com/101457/106154211-46195580-6177-11eb-8982-c8303ae4934f.png">


### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [X] Includes screenshot(s) - ideally before and after, but at least after


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
