### PR TITLE
GP2-1411: Allow ArticlePages to have no selected type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Implemented enhancements
 
+- GP2-1411 - Allow type of article in ArticlePage to be blank, not just null
 - GP2-1333 - Add filtering behaviour to MarketsTopicLandingPage (ported from BAU)
 - GP2-1402 - Update content for Funding and Credit section
 - GP2-1407 - Rename AdviceTopicLandingPage to just TopicLandingPage

--- a/domestic/migrations/0006_articlelistingpage_articlepage_campaignpage_countryguidepage.py
+++ b/domestic/migrations/0006_articlelistingpage_articlepage_campaignpage_countryguidepage.py
@@ -42,6 +42,7 @@ class Migration(migrations.Migration):
                             ('Campaign', 'Campaign'),
                         ],
                         null=True,
+                        blank=True,
                     ),
                 ),
                 ('article_title', models.TextField()),

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -616,7 +616,11 @@ class ArticlePage(
     ]
     subpage_types = []
 
-    type_of_article = models.TextField(choices=ARTICLE_TYPES, null=True)
+    type_of_article = models.TextField(
+        choices=ARTICLE_TYPES,
+        null=True,
+        blank=True,
+    )
 
     article_title = models.TextField()
     article_subheading = models.TextField(


### PR DESCRIPTION
The field was nullable, but the Wagtail UI wasn't allowing the field to be blank.

Retrospective tweak to original migration done, because blank=True doesn't affect the DB schema (unlike null=True|False)

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [X] Includes screenshot(s) - ideally before and after, but at least after

Before:

<img width="317" alt="Screenshot 2021-02-01 at 09 48 39" src="https://user-images.githubusercontent.com/101457/106442024-b32c3400-6472-11eb-9687-438d12e828fb.png">


After:

<img width="393" alt="Screenshot 2021-02-01 at 09 38 29" src="https://user-images.githubusercontent.com/101457/106441881-837d2c00-6472-11eb-974f-2d6344f70c96.png">


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
