### PR TITLE
GP2-1419 Fix ex-ops blow-up on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - GP2-1411 - Refactor ArticlePage to use a StreamField with new PullQuoteBlock
 
 ### Fixed bugs
+- GP2-1419 - Fix ex-ops induced blow-up on dashboard.
 - GP2-1397 - Render HTML definitions in product classifier.
 
 

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -36,7 +36,6 @@ def _date_format(string):
 
 
 def parse_opportunities(results):
-
     return [
         {
             'title': result['title'],

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -29,10 +29,14 @@ class CompanySerializer(serializers.Serializer):
 
 
 def _date_format(string):
-    return datetime.strptime(string[0:10], '%Y-%m-%d').strftime('%d %b %Y')
+    try:
+        return datetime.strptime(string[0:10], '%Y-%m-%d').strftime('%d %b %Y')
+    except Exception:
+        return ''
 
 
 def parse_opportunities(results):
+
     return [
         {
             'title': result['title'],


### PR DESCRIPTION
The dashboard is blowing up on dev for certain users.
It appears that the problem is that the ex-ops request is returning a list of opportunities, but at least one date is 'None'
As it's impossible to reproduce this locally - the simplest fix is just to throw a try-catch around the formatter.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1419
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
