### PR TITLE
GP2-1514: Fix markets topic page ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - GP2-1411 - Refactor ArticlePage to use a StreamField with new PullQuoteBlock
 
 ### Fixed bugs
-
+- GP2-1514 - Fix ordering when selecting most recently updatet on MarketsTopicPage
 - GP2-1482 - Handle errors in product clasification request.
 - GP2-1361 - Compare markets - align cookies to user.
 - GP2-1397 - Render HTML definitions in product classifier.

--- a/domestic/migrations/0008_drop_markdownfield_usage.py
+++ b/domestic/migrations/0008_drop_markdownfield_usage.py
@@ -80,7 +80,7 @@ class Migration(migrations.Migration):
             model_name='countryguidepage',
             name='section_one_body',
             field=wagtail.core.fields.RichTextField(
-                help_text='Use H2s for the 3 subheadings', null=True, verbose_name='3 unique selling points markdown'
+                help_text='Use H2s for the 3 subheadings', null=True, verbose_name='3 unique selling points'
             ),
         ),
     ]

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -403,7 +403,7 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
     section_one_body = RichTextField(
         features=RICHTEXT_FEATURES__REDUCED,
         null=True,
-        verbose_name='3 unique selling points markdown',
+        verbose_name='3 unique selling points',
         help_text='Use H2s for the 3 subheadings',
     )
     section_one_image = models.ForeignKey(

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -212,6 +212,9 @@ class MarketsTopicLandingPage(
     REGION_QUERYSTRING_NAME = 'region'
     SECTOR_QUERYSTRING_NAME = 'sector'
 
+    SORTBY_OPTION_TITLE = 'title'
+    SORTBY_OPTION_LAST_PUBLISHED = 'last_published_at'
+
     template = 'domestic/topic_landing_pages/markets.html'
 
     subpage_types = [
@@ -224,8 +227,8 @@ class MarketsTopicLandingPage(
         # default-sorted by 'heading' instead. Therefore this may need amending
         # if the resulting behaviour isn't _quite_ what we're expecting.
         options = [
-            {'value': 'title', 'label': 'Market A-Z'},
-            {'value': 'last_published_at', 'label': 'Recently updated'},
+            {'value': self.SORTBY_OPTION_TITLE, 'label': 'Market A-Z'},
+            {'value': self.SORTBY_OPTION_LAST_PUBLISHED, 'label': 'Recently updated'},
         ]
         return options
 
@@ -242,6 +245,10 @@ class MarketsTopicLandingPage(
     def sort_results(self, request, pages):
 
         sort_option = self._get_sortby(request)
+
+        # Sorting by last_published_at needs to be DESC not ASC
+        if sort_option == self.SORTBY_OPTION_LAST_PUBLISHED:
+            sort_option = '-' + sort_option
 
         return pages.order_by(sort_option)
 


### PR DESCRIPTION
This changeset fixes two small things with the Markets page ported from V1:
* **Fix ordering of markets page results** 

  Previously, when the markets page was sorted by last updated, it was actually returning pages ordered the least-recently updated because the default ordering of `last_published_at` is ascending not descending.

  This fixes that by amending the relevant selected value before it is passed to the ORM.

  Note that a better querystring name for date ordering would be clearer, but we need to keep the pattern in use on V1 for now

* **Fix verbose title of field not to mention markdown**

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1514
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
