### PR TITLE
GP2-1549: Change label shown to child Performance Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - GP2-1411 - Refactor ArticlePage to use a StreamField with new PullQuoteBlock
 
 ### Fixed bugs
+- GP2-1549 - Change text/field used for links to child Performance Dashboards
 - GP2-1446 - Increase input clear button size
 - GP2-1514 - Fix ordering when selecting most recently updatet on MarketsTopicPage
 - GP2-1482 - Handle errors in product clasification request.

--- a/domestic/templates/domestic/performance_dashboard_page.html
+++ b/domestic/templates/domestic/performance_dashboard_page.html
@@ -52,7 +52,7 @@ Performance dashboard - great.gov.uk
         {% for child_dashboard in page.get_child_dashboards %}
         <li>
             <a class="link" href="{{child_dashboard.url}}">
-              {{child_dashboard.title}}
+              {{child_dashboard.heading}}
             </a>
         </li>
         {% endfor %}


### PR DESCRIPTION
This one-liner changes the name used for child links displayed on the main/landing Performance Dashboard 

Previously it showed the page's full title

<img width="476" alt="Screenshot 2021-02-12 at 20 12 42" src="https://user-images.githubusercontent.com/101457/107818214-300eb600-6d6f-11eb-87d7-a099f0f0606a.png">

But now it shows the shortened name, which is actually the same of the service it is for


<img width="524" alt="Screenshot 2021-02-12 at 20 11 15" src="https://user-images.githubusercontent.com/101457/107818215-313fe300-6d6f-11eb-929e-bc9b89dc2755.png">

 


_Tick or delete as appropriate:_

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1549
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [X] Includes screenshot(s) - ideally before and after, but at least after


### Merging

- [x] This PR can be merged by reviewers. 
