### PR TITLE
HOTFIX: reinstate document-link as rich-text field option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Pre-release
+### Fixed bugs
+- NO TICKET - add document-link back in as rich-text option
 
 ### Implemented enhancements
 
@@ -12,8 +14,6 @@
 - GP2-1424 - Cost and pricing page - local taxes section
 - GP2-1423 - Cost and pricing page - content change
 - GP2-1411 - Refactor ArticlePage to use a StreamField with new PullQuoteBlock
-### Fixed bugs
-
 
 ## [1.2.0](https://github.com/uktrade/great-cms/releases/tag/1.2.0)
 

--- a/core/constants.py
+++ b/core/constants.py
@@ -20,6 +20,7 @@ RICHTEXT_FEATURES__REDUCED = (
     'ul',
     'hr',
     'link',
+    'document-link',  #  to allow links to Wagtail-held documents
     # 'blockquote', # NOT used - use a PullQuoteBlock in a StreamField, or similar
 )
 

--- a/domestic/migrations/0016_switch_article_body_text_to_streamfield.py
+++ b/domestic/migrations/0016_switch_article_body_text_to_streamfield.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
                     (
                         'text',
                         wagtail.core.blocks.RichTextBlock(
-                            features=('h2', 'h3', 'h4', 'bold', 'italic', 'ol', 'ul', 'hr', 'link')
+                            features=('h2', 'h3', 'h4', 'bold', 'italic', 'ol', 'ul', 'hr', 'link', 'document-link')
                         ),
                     ),
                     (


### PR DESCRIPTION
HOTFIX: reinstate document-link as rich-text field option

Original migration was retrospectively edited, but that is OK because it is not a change that amends the DB-level schema, only software-defined StreamField schema

![Screenshot 2021-02-17 at 14 17 55](https://user-images.githubusercontent.com/101457/108219449-a9225a80-712d-11eb-99bf-fe5b6865ecfa.png)



### Workflow

- [X] NO Ticket
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [ ] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
