### PR TITLE
GP2-1619: Ensure all pages ported from V1 into Domestic support DataLayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Implemented enhancements
 
+- GP2-1619 - Ensure all pages ported from V1 populate GA360/DataLayer data
 - GP2-1180 - Travel and business policies-page
 - GP2-1404 - Select your product (modal window) - Product and country are not selected
 - GP2-1438 - Random picking for case study if they score same


### PR DESCRIPTION
This changeset makes the inclusion of the two GA360-specific mixins easier
by wrapping them into their own abstract mixin class.

This new `DataLayerMixin` is then added to the `BaseContentPage` for ex-Great-V1 content or
directly into any page that does not use `BaseContentPage`.

There is also a test that checks that all concrete subclasses of wagtail.Page
in domestic.models implement the `DataLayerMixin`. (Opinions welcome about cleaner ways to execute this test.)

eg: without the `DataLayerMixin` included in `BaseContentPage` we get:

```
E           AssertionError: These Domestic pages do not implement the DataLayerMixin, 
but should: [<class 'domestic.models.ArticleListingPage'>, <class 'domestic.models.ArticlePage'>, 
<class 'domestic.models.CampaignPage'>, <class 'domestic.models.CountryGuidePage'>, 
<class 'domestic.models.GreatDomesticHomePage'>, <class 'domestic.models.GuidancePage'>, 
<class 'domestic.models.MarketsTopicLandingPage'>, 
<class 'domestic.models.PerformanceDashboardPage'>, <class 'domestic.models.TopicLandingPage'>]
```


### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1619
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [ ] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
