### PR TITLE
NOTICKET: Add migraition for missing richtext-features change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Pre-release
 ### Fixed bugs
 - NO TICKET - add document-link back in as rich-text option
-
+- NO TICKET - further document-link backfills in as rich-text option, in fields missing from above
 ### Implemented enhancements
 - GP2-1440 - Ranking calculation for case study
 - GP2-1128 - Product Classifier - Mobile carousel

--- a/domestic/migrations/0017_add_guidance_page.py
+++ b/domestic/migrations/0017_add_guidance_page.py
@@ -35,7 +35,19 @@ class Migration(migrations.Migration):
                             (
                                 'text',
                                 wagtail.core.blocks.RichTextBlock(
-                                    features=['h1', 'h2', 'h3', 'h4', 'bold', 'italic', 'ol', 'ul', 'hr', 'link']
+                                    features=[
+                                        'h1',
+                                        'h2',
+                                        'h3',
+                                        'h4',
+                                        'bold',
+                                        'italic',
+                                        'ol',
+                                        'ul',
+                                        'hr',
+                                        'link',
+                                        'document-link',
+                                    ]
                                 ),
                             ),
                             (
@@ -72,7 +84,7 @@ class Migration(migrations.Migration):
                     (
                         'text',
                         wagtail.core.blocks.RichTextBlock(
-                            features=['h2', 'h3', 'h4', 'bold', 'italic', 'ol', 'ul', 'hr', 'link']
+                            features=['h2', 'h3', 'h4', 'bold', 'italic', 'ol', 'ul', 'hr', 'link', 'document-link']
                         ),
                     ),
                     (

--- a/domestic/migrations/0018_performancedashboardpage.py
+++ b/domestic/migrations/0018_performancedashboardpage.py
@@ -46,7 +46,18 @@ class Migration(migrations.Migration):
                                         (
                                             'data_description',
                                             wagtail.core.blocks.RichTextBlock(
-                                                features=['h2', 'h3', 'h4', 'bold', 'italic', 'ol', 'ul', 'hr', 'link']
+                                                features=[
+                                                    'h2',
+                                                    'h3',
+                                                    'h4',
+                                                    'bold',
+                                                    'italic',
+                                                    'ol',
+                                                    'ul',
+                                                    'hr',
+                                                    'link',
+                                                    'document-link',
+                                                ]
                                             ),
                                         ),
                                     ]


### PR DESCRIPTION
The hotfix to add in the `document-link` option for rich-text blocks worked on master when added to domestic.0016 but migrations on release and develop had moved on (and so the frozen schema no longer reflected the change made to 0016).

This change will remeduy this, but it shows the limitations of editing historical migrations :/

(Editing StreamField schemas is a no-op change at the DB level, so this changeset is 'ok', but it doesn't protect against other edits to the StreamField going on on parallel branches)

Master does not need this fixup, because it doesn't have the extra migrations that staging and develop do, which didn't get the hotfix (because the hotfix targeted master)

### Workflow

- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
