### PR TITLE
GP2-1559: Fixup allowed page types for StructuralPage

### DIFF
--- a/domestic/models.py
+++ b/domestic/models.py
@@ -195,6 +195,10 @@ class StructuralPage(BaseContentPage):
         FieldPanel('slug'),
     ]
 
+    subpage_types = [
+        'domestic.ArticlePage',
+    ]
+
     def serve_preview(self, request, mode_name='dummy'):
         # It doesn't matter what is passed as mode_name - we always HTTP404
         raise Http404()
@@ -824,6 +828,7 @@ class ArticlePage(
 
     parent_page_types = [
         'domestic.CountryGuidePage',
+        'domestic.StructuralPage',
         'domestic.ArticleListingPage',
         'domestic.TopicLandingPage',
     ]

--- a/tests/unit/domestic/test_models.py
+++ b/tests/unit/domestic/test_models.py
@@ -26,6 +26,7 @@ from domestic.models import (
     GuidancePage,
     MarketsTopicLandingPage,
     PerformanceDashboardPage,
+    StructuralPage,
     TopicLandingPage,
     industry_accordions_validation,
     main_statistics_validation,
@@ -1140,6 +1141,7 @@ class ArticlePageTests(WagtailPageTests):
             ArticlePage,
             {
                 CountryGuidePage,
+                StructuralPage,
                 ArticleListingPage,
                 TopicLandingPage,
             },
@@ -1659,4 +1661,14 @@ class GreatDomesticHomePageTests(WagtailPageTests):
         self.assertEqual(
             context['sector_form'].fields['sector'].choices,
             expected_sector_form.fields['sector'].choices,
+        )
+
+
+class StructuralPageTests(WagtailPageTests):
+    def test_allowed_children(self):
+        self.assertAllowedSubpageTypes(
+            StructuralPage,
+            {
+                ArticlePage,
+            },
         )


### PR DESCRIPTION
Prior to this change, StructuralPage wouldn't allow an ArticlePage to be its child, but would allow various other ones (ie, by default)

This change locks things down so that a) only ArticlePages can be child pages of StructuralPage and b) StructuralPages are allowed to be parents of ArticlePages.

In the future we may want to broaden this out, but for now it meets the criteria for the story

Includes tests

I'll get this into `release` soon too


### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1559
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added as part of original work





### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
