### PR TITLE
Add learning banner on advice listing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - GP2-1778 - Support post-login and post-signup redirection to original requested destination
 - GP2-1738 - Market guide links feature flag
 - GP2-1783 - Export plan landing page - Number of completed questions
+- GP2-1732 - Learning banner on advice listing pages
 - GP2-1763 - Logged out footer
 - GP2-1569 - Compare markets page - add age group tab
 - GP2-1729 - Add learning banner

--- a/domestic/templates/domestic/article_listing_page.html
+++ b/domestic/templates/domestic/article_listing_page.html
@@ -2,8 +2,6 @@
 
 {% load wagtailcore_tags %}
 {% load static %}
-{% load routablepageurl from wagtailroutablepage_tags %}
-{% load url_map %}
 
 {% block css_layout_class %}article-list-page{% endblock css_layout_class %}
 

--- a/domestic/templates/domestic/article_listing_page.html
+++ b/domestic/templates/domestic/article_listing_page.html
@@ -21,8 +21,9 @@
   </div>
 
   {% if 'advice' in page.get_parent|lower %}
+  {% url "core:signup" as link_url %}
     <div class="container">
-      {% include 'components/learning_banner.html' with tag_text="New" heading="Turn advice into action" sub_heading="Get exporting lessons from trade experts" cta_text="Upskill now" cta_url="#" cta_alt_text="Upskill now" %}
+      {% include 'components/learning_banner.html' with tag_text="New" heading="Turn advice into action" sub_heading="Get exporting lessons from trade experts" cta_text="Upskill now" cta_url=link_url cta_alt_text="Upskill now" %}
     </div>
   {% endif %}
 

--- a/domestic/templates/domestic/article_listing_page.html
+++ b/domestic/templates/domestic/article_listing_page.html
@@ -2,6 +2,8 @@
 
 {% load wagtailcore_tags %}
 {% load static %}
+{% load routablepageurl from wagtailroutablepage_tags %}
+{% load url_map %}
 
 {% block css_layout_class %}article-list-page{% endblock css_layout_class %}
 
@@ -17,6 +19,13 @@
       {% include 'components/breadcrumbs_cms.html' %}
     {% endblock %}
   </div>
+
+  {% if 'advice' in page.get_parent|lower %}
+    <div class="container">
+      {% include 'components/learning_banner.html' with tag_text="New" heading="Turn advice into action" sub_heading="Get exporting lessons from trade experts" cta_text="Upskill now" cta_url="#" cta_alt_text="Upskill now" %}
+    </div>
+  {% endif %}
+
 
   <div class="container">
     {% if page.list_teaser %}

--- a/domestic/templates/domestic/topic_landing_pages/generic.html
+++ b/domestic/templates/domestic/topic_landing_pages/generic.html
@@ -15,8 +15,9 @@
 {% endblock %}
 
 {% if page.slug|lower == "article" %}
+{% url "core:signup" as link_url %}
   <div class="container">
-    {% include 'components/learning_banner.html' with tag_text="New" heading="Turn advice into action" sub_heading="Get exporting lessons from trade experts" cta_text="Upskill now" cta_url="#" cta_alt_text="Upskill now" %}
+    {% include 'components/learning_banner.html' with tag_text="New" heading="Turn advice into action" sub_heading="Get exporting lessons from trade experts" cta_text="Upskill now" cta_url=link_url cta_alt_text="Upskill now" %}
   </div>
 {% endif %}
 

--- a/domestic/templates/domestic/topic_landing_pages/generic.html
+++ b/domestic/templates/domestic/topic_landing_pages/generic.html
@@ -14,7 +14,7 @@
 </div>
 {% endblock %}
 
-{% if page.slug|lower == "article" %}
+{% if page.slug|lower == "advice" %}
 {% url "core:signup" as link_url %}
   <div class="container">
     {% include 'components/learning_banner.html' with tag_text="New" heading="Turn advice into action" sub_heading="Get exporting lessons from trade experts" cta_text="Upskill now" cta_url=link_url cta_alt_text="Upskill now" %}


### PR DESCRIPTION
Add learning banner on advice listing pages

![image](https://user-images.githubusercontent.com/9799548/110353902-81892880-802f-11eb-93cc-f932afcfca19.png)
![image](https://user-images.githubusercontent.com/9799548/110353903-81892880-802f-11eb-8532-0740456f26ee.png)


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1732
- [x]. ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.
- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
