### PR TITLE
GP2-1858: Switch sign out to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Implemented enhancements
 
+- GP2-1858 - Change logged out header sign out to dashboard
 - GP2-1770 - Business risk content changes.
 - GP2-1775 - Article page warning banner
 - GP2-1832 - Update page-parent permissons to allow homepage swap

--- a/core/templates/components/header_footer/sso_login.html
+++ b/core/templates/components/header_footer/sso_login.html
@@ -11,6 +11,6 @@
   </li>
 {% endcomment %}
   <li class="authenticated">
-    <a id="header-sign-out-link" href="{{ sso_logout_url }}" class="account-link signout">Sign out</a>
+    <a id="header-sign-out-link" href="{{ DASHBOARD_URL }}" class="account-link signout">Dashboard</a>
   </li>
 {% endif %}


### PR DESCRIPTION
Temporarily changes "sign out" to "dashboard" to prevent users being redirected to sso profile sign out

<img width="1284" alt="Screenshot 2021-03-12 at 10 55 44" src="https://user-images.githubusercontent.com/66948936/110930987-ac21fc80-8321-11eb-9fa9-0b314049423d.png">


### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1858
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
