### PR TITLE
GP2-2240: Improve stability of search results ordering/boosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - GP2-1709 - trade barrier integration
 
 ### Fixed bugs
-
+- GP2-2240 - Search tuning
 - GP2-2215 - Fix privacy policy sign up link
 - GP2-2120 - Change to adapting your product. Fix tooltips. Add learning. Update data.
 - GP2-2050 - Update incorrect learning banner copy

--- a/tests/unit/search/test_helpers.py
+++ b/tests/unit/search/test_helpers.py
@@ -49,7 +49,7 @@ def test_search_with_activitystream(mock_session_send):
     issued_request = mock_session_send.call_args_list[0][0][0]
 
     for key, val in {
-        'Content-Length': '666',
+        'Content-Length': '760',
         'X-Forwarded-Proto': 'https',
         'X-Forwarded-For': 'debug',
         # 'Authorization': 'Hawk mac="8z+txQ3WIkigNHZbfCNLEFdFdOEa2y1fxELboX0Vgpg=", hash="1fsYlfW1YnvyKz7s1HJwjDVq3ys9o6ofYaWyAs6YHDI=", id="debug", ts="1579003201", nonce="o3TJ7i"',  # noqa


### PR DESCRIPTION
We've been seeing some unexpected/flip-flopping ordering of results on Dev and can't fully explain why the ranking scores for Articles vs Services

This changeset contains a recommendation from @michalc (the creator of DIT's ActivityStream) which moves the boost aspect of the query away from a 'should' clause with potential full-text search matching on the type (which may or may not be conflicting with the un-namespaced Article-type and Service-type records also being ingested from BAU into AS). Instead, we're trying out some clear function-based boosting.

This appears to be better:
1. The scores we're seeing for items returned correspond more predictably to the boosting involved (eg before Services were boosted by 20000, but the score was rarely higher than 13100 for a top-ranked result. Now, the boosted rank for a given Service document is literally the boost factor * rank of the Service document, so tuning is much easier to see.

2. We've maintained a similar 'watershed' between Services and Articles or Markets, but reduced the impact by an order of magnitiude. This is feeling like something of an art, but so far local tests seem promising

This is hard to test, but I am happy to demo over screenshare

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2240
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.


### Merging
- [ ] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
