### PR TITLE
GP2-2156: Add robots.txt to great-cms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release changes - please put everything in the appropriate category below
 
 ### Enhancements
+- GP2-2156 - Add robots.txt
 - GP2-2069 - Replicate the Cookie management behaviour from V1.
 - No ticket - wagtail upgrade to 2.11.7 and other packages including reportlab lib
 - GP2-2283 - Remove "Some features are not available" from the export plan landing page

--- a/core/templates/robots.txt
+++ b/core/templates/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+
+Disallow: /admin/
+Disallow: /django-admin/
+Disallow: /api/
+Disallow: /activity-stream/
+Disallow: /sso/
+
+Sitemap: {{base_url}}/sitemap.xml

--- a/core/urls.py
+++ b/core/urls.py
@@ -28,6 +28,11 @@ def anonymous_user_required(function):
 
 urlpatterns = [
     path(
+        'robots.txt',
+        skip_ga360(views.RobotsView.as_view()),
+        name='robots',
+    ),
+    path(
         'cookies/',
         skip_ga360(
             views.CookiePreferencesPageView.as_view(),

--- a/core/views.py
+++ b/core/views.py
@@ -355,3 +355,18 @@ class InvestmentSupportDirectoryRedirectView(QuerystringRedirectView):
 class CookiePreferencesPageView(TemplateView):
     # NB: template currently bears the ex-V1 styling, so comes from great-cms/domestic/templates/domestic/
     template_name = 'domestic/cookie-preferences.html'
+
+
+class RobotsView(TemplateView):
+    template_name = 'robots.txt'
+    content_type = 'text/plain'
+
+    def get_context_data(self, **kwargs):
+        base_url = settings.BASE_URL
+        if base_url[-1] == '/':
+            base_url = base_url[:-1]
+
+        return super().get_context_data(
+            **kwargs,
+            base_url=base_url,
+        )

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 import pytest
 from django.conf import settings
 from django.http.cookie import SimpleCookie
+from django.test import override_settings
 from django.urls import reverse
 from formtools.wizard.views import normalize_name
 from pytest_django.asserts import assertTemplateUsed
@@ -931,3 +932,39 @@ def test_service_removed_view(
         assert article_page_1.url in _content
         assert article_page_2.url in _content
         assert article_page_3.url not in _content  # because a child of the listing page
+
+
+@pytest.mark.parametrize(
+    'base_url, expected_sitemap_url',
+    (
+        (
+            'https://great.gov.uk',
+            'https://great.gov.uk/sitemap.xml',
+        ),
+        (
+            'https://great.gov.uk/',
+            'https://great.gov.uk/sitemap.xml',
+        ),
+    ),
+)
+@pytest.mark.django_db
+def test_robots_txt(client, base_url, expected_sitemap_url):
+
+    with override_settings(BASE_URL=base_url):
+
+        resp = client.get(reverse('core:robots'))
+        assert resp.status_code == 200
+
+        assert resp.content == b''.join(
+            [
+                b'User-agent: *\n',
+                b'\n',
+                b'Disallow: /admin/\n',
+                b'Disallow: /django-admin/\n',
+                b'Disallow: /api/\n',
+                b'Disallow: /activity-stream/\n',
+                b'Disallow: /sso/\n',
+                b'\n',
+                f'Sitemap: {expected_sitemap_url}\n'.encode(),
+            ]
+        )


### PR DESCRIPTION
This changeset adds a simple robots.txt file, based on what we used in V1 but extended in line with aspects of great-cms that are pointless for search engines to crawl


### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2156
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data

  * Go to /robots.txt in your local build

- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
