### PR TITLE
Bugfix: Account link was appearing for signed out user

### DIFF
--- a/core/templates/components/header_footer/domestic_header_nav.html
+++ b/core/templates/components/header_footer/domestic_header_nav.html
@@ -24,12 +24,11 @@
       <li class="menu-item" data-js-menu-item-container>
         <a href="{% slugurl 'dashboard' %}" class="link-heading new" id="header-make-{{ device_type }}" {% if js_tag %}data-js-menu-index=2{% endif %}>Make an export plan</a>
       </li>
+      <li class="menu-item" data-js-menu-item-container>
+        <a href="/profile/" class="link-heading {% if device_type != 'mobile' %}mobile-only{% endif %}" id="header-advice-{{ device_type }}" {% if js_tag %}data-js-menu-index=3{% endif %}>Account</a>
       {% endif %}
 
       {% if not request.user.is_authenticated or device_type == 'mobile' %}
-      <li class="menu-item" data-js-menu-item-container>
-        <a href="/profile" class="link-heading" id="header-advice-{{ device_type }}" {% if js_tag %}data-js-menu-index=3{% endif %}>Account</a>
-      </li>
       <li class="menu-item" data-js-menu-item-container>
         <a href="{% slugurl 'advice' %}" class="link-heading" id="header-advice-{{ device_type }}" {% if js_tag %}data-js-menu-index=3{% endif %}>Advice</a>
       </li>

--- a/tests/unit/domestic/test_models.py
+++ b/tests/unit/domestic/test_models.py
@@ -1058,17 +1058,17 @@ def test_markets_page__no_results__page_content(
     ) in body_text
 
     # Brittle tests warning
-    assert str(links[23]) == (
+    assert str(links[21]) == (
         '<a class="link" href="https://www.great.gov.uk/export-opportunities/">'
         'Browse our export opportunities service to find opportunities to sell your product in overseas markets</a>'
     )
 
-    assert str(links[24]) == (
+    assert str(links[22]) == (
         '<a class="link" href="https://www.great.gov.uk/contact/office-finder">'
         'Get in touch with a trade adviser to discuss your export business plan</a>'
     )
 
-    assert str(links[25]) == ('<a class="view-markets link bold margin-top-15" href="/markets/">Clear all filters</a>')
+    assert str(links[23]) == ('<a class="view-markets link bold margin-top-15" href="/markets/">Clear all filters</a>')
 
 
 class ArticleListingPageTests(SetUpLocaleMixin, WagtailPageTests):


### PR DESCRIPTION
This changeset fix the account link for the signed-out user

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.
- [x] Includes screenshot(s) - ideally before and after, but at least after
- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)


![image](https://user-images.githubusercontent.com/717254/115689102-ac1b1080-a353-11eb-89c7-06228ef07951.png)
