### PR TITLE
GP2-2358: Change footer link for contact pages to match custom routing to full contact pages in BAU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 - GP2-2372 - Disclaimer for the Beta release
+
+- GP2-2358 - Change footer to use /contact/ as contact URL
 - GP2-2353 - VFM final page back button
 - GP2-2176 - VFM Multiselect
 - GP2-2095 - Error page styling and slug tidyup

--- a/core/templates/components/header_footer/footer_base.html
+++ b/core/templates/components/header_footer/footer_base.html
@@ -13,7 +13,7 @@
   <nav class="great-footer-links container">
     <ul class="great-footer-site-links">
         <li>
-            <a href="{% url 'core:contact-us-help' %}" title="Contact us">Contact us</a>
+            <a href="{% url_map 'contact_url' %}" title="Contact us">Contact us</a>
         </li>
         <li>
             <a href="{% slugurl 'privacy-and-cookies' %}" title="Privacy and cookies">Privacy and cookies</a>

--- a/core/templates/core/footer.html
+++ b/core/templates/core/footer.html
@@ -5,7 +5,7 @@
   <nav class="magna-footer__nav bg-blue-deep-90 text-white">
     <ul class="magna-footer__links footer-links">
       <li>
-        <a href="{% url 'core:contact-us-help' %}" title="Contact us">Contact us</a>
+        <a href="{% url_map 'contact_url' %}" title="Contact us">Contact us</a>
       </li>
       <li>
         <a href="{% slugurl 'privacy-and-cookies' %}" title="Privacy and cookies">Privacy and cookies</a>


### PR DESCRIPTION
`/contact-us/help/` is no longer the path we want to send people to - instead they must go to `/contact/` to enter the full BAU contact triage flow 

(`/contact/` will 404 locally, but is the URL path that is custom-routed to the V1 contact pages until they are ported to V2)

There will be related PRs for BAU repos, as this also needs changing in directory-components.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [X] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
