### PR TITLE
GP2-2415: Amendments to video component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - GP2-2507 - Remove beta banner
+- GP2-2415 - Add preload attr and iOS poster/preview trick to video embed
 - GP2-1868 - Feature flag urls
 - GP2-2218 - WTE tab rearrangement
 - GP2-2370 - 3CE attribution on product search and removal of assumptions

--- a/core/templatetags/video_tags.py
+++ b/core/templatetags/video_tags.py
@@ -30,11 +30,20 @@ def render_video(block):
 
     video = block['video']
 
-    sources = format_html_join('\n', '<source{0}>', [[flatatt(source)] for source in video.sources])
+    timestamp_to_allow_poster_image_to_work_on_mobile_safari = '#t=0.1'
+
+    sources_data = []
+    for source in video.sources:
+        if 'src' in source:
+            source['src'] += timestamp_to_allow_poster_image_to_work_on_mobile_safari
+        sources_data.append([flatatt(source)])
+
+    sources = format_html_join('\n', '<source{0}>', sources_data)
 
     return format_html(
         f"""
-            <video controls {_get_poster_attribute(video)}{VIDEO_DURATION_DATA_ATTR_NAME}="{video_duration}">
+            <video preload="metadata" controls
+            {_get_poster_attribute(video)}{VIDEO_DURATION_DATA_ATTR_NAME}="{video_duration}">
                 {sources}
                 Your browser does not support the video tag.
             </video>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ anyascii==0.2.0
     # via wagtail
 arabic-reshaper==2.1.3
     # via xhtml2pdf
-attrs==21.1.0
+attrs==21.2.0
     # via jsonschema
 babel==2.9.1
     # via sphinx
@@ -331,7 +331,7 @@ xhtml2pdf==0.2.5
     # via -r requirements.in
 xlrd==2.0.1
     # via tablib
-xlsxwriter==1.4.0
+xlsxwriter==1.4.2
     # via wagtail
 xlwt==1.3.0
     # via tablib

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -26,7 +26,7 @@ arabic-reshaper==2.1.3
     # via xhtml2pdf
 astroid==2.5.6
     # via pylint
-attrs==21.1.0
+attrs==21.2.0
     # via
     #   allure-python-commons
     #   jsonschema
@@ -572,7 +572,7 @@ xhtml2pdf==0.2.5
     # via -r requirements.in
 xlrd==2.0.1
     # via tablib
-xlsxwriter==1.4.0
+xlsxwriter==1.4.2
     # via wagtail
 xlwt==1.3.0
     # via tablib

--- a/tests/unit/core/test_templatetags.py
+++ b/tests/unit/core/test_templatetags.py
@@ -35,8 +35,12 @@ def test_render_video_tag__with_thumbnail():
     block = dict(video=video_mock)
     html = render_video(block)
 
-    assert '<video controls poster="https://example.com/thumb.png" data-v-duration="120">' in html
-    assert '<source src="/media/foo.mp4" type="video/mp4">' in html
+    assert (
+        # Whitespace in this string is important for matching output
+        '<video preload="metadata" controls\n'
+        '            poster="https://example.com/thumb.png" data-v-duration="120">'
+    ) in html
+    assert '<source src="/media/foo.mp4#t=0.1" type="video/mp4">' in html
     assert 'Your browser does not support the video tag.' in html
 
 
@@ -48,9 +52,9 @@ def test_render_video_tag__without_thumbnail():
     )
     block = dict(video=video_mock)
     html = render_video(block)
-
-    assert '<video controls data-v-duration="120">' in html
-    assert '<source src="/media/foo.mp4" type="video/mp4">' in html
+    # Whitespace in this string is important for matching output
+    assert '<video preload="metadata" controls\n            data-v-duration="120">' in html
+    assert '<source src="/media/foo.mp4#t=0.1" type="video/mp4">' in html
     assert 'Your browser does not support the video tag.' in html
 
 


### PR DESCRIPTION
* Add preload="metadata" attribute to the video node
* Add #t=0.1 to end of video source URL to allow mobile safari to show a poster-like image

```
<video preload="metadata" controls="" poster="https://media.example.com/media_thumbnails/one-minute-video_gs7fCNL.png" data-v-duration="60">
      <source src="https://media.example.com/media/one-minute-timer_GbCdImp.mp4#t=0.1" transcript="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Utrum igitur tibi litteram videor an totas paginas commovere? Sed id ne cogitari quidem potest quale sit, ut non repugnet ipsum sibi. Duo Reges: constructio interrete." type="video/mp4">
      Your browser does not support the video tag.
</video>
```

_Tick or delete as appropriate:_

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2415
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
