### PR TITLE
GP2-2507: Remove beta banner from learning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- GP2-2507 - Remove beta banner
 - GP2-1868 - Feature flag urls
 - GP2-2218 - WTE tab rearrangement
 - GP2-2370 - 3CE attribution on product search and removal of assumptions

--- a/learn/templates/learn/automated_list_page.html
+++ b/learn/templates/learn/automated_list_page.html
@@ -8,24 +8,7 @@
 
 {% block content %}
     <section id="learn-root" class="learn__page learn__categories-page container">
-        <section class="learn__categories-content container m-t-s">
-            <div class="grid">
-                <div class="c-1-4 hide-on-mobile">
-                    <span>&nbsp;</span>
-                </div>
-                <div class="c-1-2">
-                    <div class="learn__beta-banner media-block media-block--round-image m-b-m m-t-xs m-f-n-s">
-                        <i class="fas fa-info-circle"></i>
-                        <div class="g-panel">
-                            <h3 class="h-xs text-blue-deep-80 p-t-xs">Some lessons aren’t available yet</h3>
-                            <p class="text-blue-deep-80 m-t-xxs">This Beta version is limited</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="c-1-4 hide-on-mobile">
-                    <span>&nbsp;</span>
-                </div>
-            </div>
+        <section class="learn__categories-content container m-t-l">
         {% for learning_module in page.get_children.specific.live %}
         {% with high_level_completion_progress|get_item:learning_module.id as module_completion_data %}
         <a href="{% pageurl learning_module %}" title="{{ page.button_label }}" class="learn__category-link">


### PR DESCRIPTION
Removes this:

![image](https://user-images.githubusercontent.com/66948936/117434611-ca246b80-af24-11eb-8221-d0b451fca87f.png)

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
