### PR TITLE
GP2-2868-Tidy-sentry-alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - GP2-2831 - fix typo on 404 page
 - GP2-2881 - Accessibility fix - alert screen readers for text updates
 - GP2-2883 - Accessibility fix - fix sign out menu button keyboard issues
+- GP2-2868 - Tech Debt fix sentry errors
 
 ## [1.10.0](https://github.com/uktrade/great-cms/releases/tag/1.10.0)
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -91,7 +91,6 @@ MIDDLEWARE = [
     'wagtail.contrib.legacy.sitemiddleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'core.middleware.UserSpecificRedirectMiddleware',
-    'core.middleware.UserLocationStoreMiddleware',
     'core.middleware.StoreUserExpertiseMiddleware',
     'wagtailcache.cache.FetchFromCacheMiddleware',
     'core.middleware.CheckGATags',

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -184,7 +184,6 @@ class DomesticDashboard(
             initial={'step_a': True, 'step_b': True, 'step_c': True}
         )
         context['industry_options'] = [{'value': key, 'label': label} for key, label in choices.SECTORS]
-        context['events'] = helpers.get_dashboard_events(user.session_id)
         context['export_opportunities'] = helpers.get_dashboard_export_opportunities(user.session_id, user.company)
         context.update(get_lesson_completion_status(user, context))
         context['export_plan_in_progress'] = user.has_visited_page(cms_slugs.EXPORT_PLAN_DASHBOARD_URL)

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -336,7 +336,6 @@ def test_dashboard_apis_ok(
     client,
     user,
     get_request,
-    patch_get_dashboard_events,
     patch_get_dashboard_export_opportunities,
     patch_set_user_page_view,
     patch_get_user_page_views,
@@ -344,7 +343,6 @@ def test_dashboard_apis_ok(
     domestic_homepage,
     mock_get_user_profile,
 ):
-    patch_get_dashboard_events.stop()
     patch_get_dashboard_export_opportunities.stop()
 
     with patch('directory_api_client.api_client.personalisation.events_by_location_list') as events_api_results:
@@ -404,22 +402,6 @@ def test_dashboard_apis_ok(
             dashboard = DomesticDashboardFactory(parent=domestic_homepage, slug='dashboard')
             context_data = dashboard.get_context(get_request)
 
-            assert context_data['events'] == [
-                {
-                    'title': 'Global Aid and Development Directory',
-                    'description': 'DIT is producing a directory of compani…',
-                    'url': 'www.example.com',
-                    'location': 'London',
-                    'date': '06 Jun 2020',
-                },
-                {
-                    'title': 'Less Info',
-                    'description': 'Content',
-                    'url': 'www.example.com',
-                    'location': 'n/a',
-                    'date': 'n/a',
-                },
-            ]
             assert context_data['export_opportunities'] == [
                 {
                     'title': 'French sardines required',
@@ -437,7 +419,6 @@ def test_dashboard_apis_fail(
     client,
     user,
     get_request,
-    patch_get_dashboard_events,
     patch_get_dashboard_export_opportunities,
     patch_set_user_page_view,
     patch_get_user_page_views,
@@ -445,7 +426,6 @@ def test_dashboard_apis_fail(
     domestic_homepage,
     mock_get_user_profile,
 ):
-    patch_get_dashboard_events.stop()
     patch_get_dashboard_export_opportunities.stop()
     patch_get_user_lesson_completed.stop()
     with patch('directory_api_client.api_client.personalisation.events_by_location_list') as events_api_results:
@@ -460,7 +440,6 @@ def test_dashboard_apis_fail(
             dashboard = DomesticDashboardFactory(parent=domestic_homepage, slug='dashboard')
             context_data = dashboard.get_context(get_request)
 
-            assert context_data['events'] == []
             assert context_data['export_opportunities'] == []
 
 


### PR DESCRIPTION
This tidies some of the alerts in PROD. Events are currently used on the platform including user location. After confirming with Suraj it was advised to remove these features all together. 

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [ ] Jira ticket has the correct status.
- [ ] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
