### PR TITLE
Skip GA360 on search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 - GP2-1617: Port get-finance/UKEF contact form from great-domestic-ui
 ### Fixed bugs
+- GP2-2863 - Skip GA360 on search path
 - GP2-2910 - DAC_Information_and_Relationships_01 Learnin categories links
 - GP2-2887 - DAC_Focus_Order_04 - EP data snapshot fix
 - GP2-2886 - DAC_Focus_Order_03 - EP Objectives list focus management

--- a/search/urls.py
+++ b/search/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from great_components.decorators import skip_ga360
 
 import search.views
 
@@ -7,7 +8,7 @@ app_name = 'search'
 urlpatterns = [
     path(
         '',
-        search.views.SearchView.as_view(),
+        skip_ga360(search.views.SearchView.as_view()),
         name='search',
     ),
 ]


### PR DESCRIPTION
CONTEXT: This changeset updates the search URL so that the search view skips the GA360 mixin

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2863
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers.
