### PR TITLE
GP2-2981: Update directory-forms-api-client requirement to stop blow-up

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,7 @@ great-components==1.1.*
 directory-api-client==22.20.*
 directory-constants==20.23.*
 directory-healthcheck==2.0.0
-directory-forms-api-client==5.3.*
+directory-forms-api-client==6.1.*
 directory-sso-api-client>=6.5.*
 django-staff-sso-client==1.0.*
 directory-ch-client==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,11 +23,11 @@ beautifulsoup4==4.8.2
     #   great-components
     #   readtime
     #   wagtail
-boto3==1.17.90
+boto3==1.17.92
     # via
     #   -r requirements.in
     #   django-storages
-botocore==1.20.90
+botocore==1.20.92
     # via
     #   boto3
     #   s3transfer
@@ -60,7 +60,7 @@ directory-constants==20.23.0
     # via
     #   -r requirements.in
     #   great-components
-directory-forms-api-client==5.3.0
+directory-forms-api-client==6.1.0
     # via -r requirements.in
 directory-healthcheck==2.0.0
     # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -20,6 +20,8 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
+appnope==0.1.2
+    # via ipython
 arabic-reshaper==2.1.3
     # via xhtml2pdf
 astroid==2.5.6
@@ -39,17 +41,17 @@ beautifulsoup4==4.8.2
     #   great-components
     #   readtime
     #   wagtail
-black==21.5b2
+black==21.6b0
     # via
     #   -r requirements_test.in
     #   blacken-docs
 blacken-docs==1.6.0
     # via -r requirements_test.in
-boto3==1.17.90
+boto3==1.17.92
     # via
     #   -r requirements.in
     #   django-storages
-botocore==1.20.90
+botocore==1.20.92
     # via
     #   boto3
     #   s3transfer
@@ -104,7 +106,7 @@ directory-constants==20.23.0
     # via
     #   -r requirements.in
     #   great-components
-directory-forms-api-client==5.3.0
+directory-forms-api-client==6.1.0
     # via -r requirements.in
 directory-healthcheck==2.0.0
     # via -r requirements.in
@@ -456,7 +458,7 @@ requests==2.25.1
     #   wagtail
 ruamel.yaml.clib==0.2.2
     # via ruamel.yaml
-ruamel.yaml==0.17.7
+ruamel.yaml==0.17.9
     # via pre-commit-hooks
 s3transfer==0.4.2
     # via boto3


### PR DESCRIPTION
Follow on from #1393 