### PR TITLE
Gp2 2940 dac focus visible 01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,18 @@
 ## Pre-release changes - please put everything in the appropriate category below
 
 ### Enhancements
+
 - GP2-2981: Port Search Feedback page from V1 into V2
 - GP2-2980: Port Market Access / 'Report a Trade Barrier' pages from V1 into V2
 - GP2-2977: Port E-Commerce Export Support pages from V1 into V2
 - GP2-1618: Port legacy EU Exit / transition period forms from V1 into V2
 - GP2-1617: Port get-finance/UKEF contact form from great-domestic-ui
-- GP2-2856  remove unused api calls
+- GP2-2856 remove unused api calls
 - no-ticket - package upgrade
 - GP2-2856 - remove target market
 
 ### Fixed bugs
+
 - GP2-2915 - DAC_Information_and_Relationships_06 Roles on WTE tables
 - GP2-2914 - DAC_Information_and_Relationships_05 Dynamic caption on WTE
 - GP2-2863 - Skip GA360 on search path
@@ -40,11 +42,16 @@
 - GP2-2919 - DAC_CSS_Content_04
 - GP2-2897 - DAC_Name_Role_Value_01
 - GP2-2899 - DAC_Name_Role_Value_03
+- GP2-2940 - DAC_Focus_Visible_01 (AA)
 
 ## [1.10.1](https://github.com/uktrade/great-cms/releases/tag/1.10.1)
+
 ### Enhancements
+
 - NOTICKET - update changelog, post-release
+
 ### Fixed bugs
+
 - GP2-2890 - DAC NonText Content 01
 - GP2-2835 - Redirect fix for initial request for domestic going to international/ Disable caching on homepage
 - GP2-2889 - DAC Decorative_Images_01 - clear alt tags on decorative images
@@ -55,7 +62,6 @@
 - GP2-2868 - Tech Debt fix sentry errors
 - GP2-2870 - rename /sso/ path to /great-cms-sso/
 
-
 ## [1.10.0](https://github.com/uktrade/great-cms/releases/tag/1.10.0)
 
 MAGNA RELEASE
@@ -63,6 +69,7 @@ MAGNA RELEASE
 [Full Changelog](https://github.com/uktrade/great-cms/compare/1.9.0...1.10.0)
 
 ### Enhancements
+
 - GP2-2816 - Set Wagtaildocs serve method to 'direct' to avoid denial when proxying at PaaS level
 - noticket - remove social buttons
 - no-ticket - Disabled case study tagging search ability on Admin UI
@@ -85,6 +92,7 @@ MAGNA RELEASE
 - GP2-2777 - Remove DIT footer logos
 
 ### Fixed bugs
+
 - GP2-2805 - Export plan image problem on the dashboard
 - GP2-2803 - [UAT]-Export plan dashboard images issues
 - GP2-2790 - remove Getting paid page tooltip
@@ -122,14 +130,13 @@ MAGNA RELEASE
 - GP2-2763 - saving-blank-error
 - GP2-2724 - update-lesson be
 - GP2-2775 - sav business risk
-_ GP2-2775 - getting paid error
+  \_ GP2-2775 - getting paid error
 - gp2765 - content changes
 - NOTICKET - error saving ep atm
 - NOTICKET - update pdf logo
 - NOTICKET - remove lesson
 - NOTICKET - configure APM log server
 - NOTICKET - fix image references
-
 
 ## [1.9.0](https://github.com/uktrade/great-cms/releases/tag/1.9.0)
 
@@ -181,6 +188,7 @@ _ GP2-2775 - getting paid error
 - GP2-2401 - pdf save
 
 ### Fixed bugs
+
 - Gp2-2506 - Getting paid page - Content change for default text (Payment methods drop-down)
 - GP2-2399 - [Mobile]-Costs and pricing
 - GP2-2420 - Export plan - CHEG details look strange on mobile

--- a/react-components/src/components/Dashboard/DashboardSection.jsx
+++ b/react-components/src/components/Dashboard/DashboardSection.jsx
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from 'react'
+
+const activeDivStyle = {
+  border: '2px solid #ffbf47',
+}
+
+export const DashboardSection = ({
+  disabled,
+  image,
+  is_complete,
+  title,
+  url,
+  section_progress,
+  index,
+  sectionActive,
+  setActiveUrl,
+  openComingSoonModal,
+}) => {
+  const [active, setActive] = useState(false)
+
+  useEffect(() => {
+    if (sectionActive === index) {
+      setActive(true)
+      setActiveUrl(url)
+    } else {
+      setActive(false)
+    }
+  }, [sectionActive])
+
+  return (
+    <>
+      <div className="c-1-3-xl c-1-2-m">
+        <div
+          className={`bg-white m-b-s section-list__item ${
+            is_complete ? 'section-list__item--is-complete' : ''
+          }`}
+          style={active ? activeDivStyle : {}}
+        >
+          {disabled ? (
+            <div
+              className="width-full link section-list__disabled section-list__link"
+              onClick={openComingSoonModal}
+              aria-hidden="true"
+              role="button"
+            >
+              <div className="section-list__image-container">
+                <span
+                  className="section-list__coming bg-blue-deep-80 text-white body-m p-xxs"
+                  data-sectiontitle={title}
+                >
+                  Coming soon
+                </span>
+                <img
+                  className="width-full p-h-s p-t-m p-b-s"
+                  src="/static/images/coming-soon.svg"
+                  alt=""
+                  data-sectiontitle={title}
+                />
+              </div>
+              <div className="p-v-s p-h-xs">
+                <h3
+                  className="h-xs text-blue-deep-80 p-0"
+                  data-sectiontitle={title}
+                >
+                  {title}
+                </h3>
+              </div>
+            </div>
+          ) : (
+            <a
+              className="width-full link section-list__link"
+              href={url}
+              title={title}
+            >
+              <div
+                className="section-list__image-container"
+                data-complete={is_complete ? 'Complete' : ''}
+              >
+                {is_complete && (
+                  <span className="visually-hidden">Complete</span>
+                )}
+                <img
+                  className={`width-full p-h-s p-t-m p-b-s ${
+                    is_complete ? 'bg-green-30' : 'bg-blue-deep-20'
+                  }`}
+                  src={`/static/images/${image}`}
+                  alt=""
+                />
+              </div>
+              <div className="p-t-s p-b-xs p-h-xs">
+                <h3 className="h-xs text-blue-deep-80 p-0">{title}</h3>
+                <p className="m-b-0 m-t-xxs">
+                  {section_progress.find((x) => x.url === url).populated} out of{' '}
+                  {section_progress.find((x) => x.url === url).total} questions
+                  answered
+                </p>
+              </div>
+            </a>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default DashboardSection

--- a/react-components/src/components/Dashboard/index.jsx
+++ b/react-components/src/components/Dashboard/index.jsx
@@ -36,7 +36,6 @@ export const Dashboard = memo(
           }
           setSectionActive(sectionActive + 1)
         } else if (keyCode === 13) {
-          console.log(activeUrl)
           window.open(activeUrl, '_self')
         }
       },

--- a/react-components/src/components/Dashboard/index.jsx
+++ b/react-components/src/components/Dashboard/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, memo, useCallback, useEffect, useRef } from 'react'
+import React, { useState, memo, useCallback, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 import { ComingSoon } from '@src/components/Sidebar/ComingSoon'


### PR DESCRIPTION
- Input Left, Right and Enter detection to navigate through dashboard cards and Enter to go to url with keyboard.
- Inner Style for focused dashboard card with Great default focus yellow.
- Updated CHANGELOG.md with GP2-2940: DAC_Focus_Visible_01 (AA)

(Please add a sentence or two explaining the context of this PR. Reviewers can go to the ticket for detail.)
CONTEXT: This changeset adds/removes/updates [summary of feature/area/code] so that [summary of benefit].

"Solution:
Ensure there is a mechanism in place to allow users to identify when components are focused." - May 2021 Audit Page 135.

It seems like Tab with keyboard was working and showing focus. 

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2940
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
