### PR TITLE
GP2-2982: remove URLs from sitemap for pages disabled by feature flag…

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -440,13 +440,17 @@ class StaticViewSitemap(DjangoSitemap):
             '/contact/international/',
             '/contact/selling-online-overseas/',
             '/contact/selling-online-overseas/organisation/',
-            '/contact/department-for-business-energy-and-industrial-strategy/',
-            '/contact/department-for-environment-food-and-rural-affairs/',
-            '/contact/exporting-to-the-uk/',
-            '/contact/exporting-to-the-uk/import-controls/',
-            '/contact/exporting-to-the-uk/other/',
-            '/contact/exporting-to-the-uk/trade-with-uk-app/',
             '/contact/office-finder/',
+            # These were removed from the V1 sitemap because the pages were 404ing anyway because
+            # FEATURE_EXPORTING_TO_UK_ON_ENABLED was not set on production any more, so the views
+            # ExportingToUKDERAFormView, ExportingToUKBEISFormView and ExportingToUKFormView have
+            # NOT YET been ported to Great V2
+            # '/contact/department-for-business-energy-and-industrial-strategy/',
+            # '/contact/department-for-environment-food-and-rural-affairs/',
+            # '/contact/exporting-to-the-uk/',
+            # '/contact/exporting-to-the-uk/import-controls/',
+            # '/contact/exporting-to-the-uk/other/',
+            # '/contact/exporting-to-the-uk/trade-with-uk-app/',
             # The following are all auto-generated from the urlconf
             'core:cookie-preferences',
             'core:login',

--- a/tests/unit/core/test_sitemap.py
+++ b/tests/unit/core/test_sitemap.py
@@ -48,12 +48,6 @@ def test_sitemap_includes_expected_django_pages(
         '/contact/international/',
         '/contact/selling-online-overseas/',
         '/contact/selling-online-overseas/organisation/',
-        '/contact/department-for-business-energy-and-industrial-strategy/',
-        '/contact/department-for-environment-food-and-rural-affairs/',
-        '/contact/exporting-to-the-uk/',
-        '/contact/exporting-to-the-uk/import-controls/',
-        '/contact/exporting-to-the-uk/other/',
-        '/contact/exporting-to-the-uk/trade-with-uk-app/',
         '/contact/office-finder/',
         '/robots.txt',
     ]
@@ -75,6 +69,16 @@ def test_sitemap_includes_expected_django_pages(
         '/healthcheck/',
         '/sitemap.xml',
         '/capability/',
+        # These were removed from the V1 sitemap because the pages were 404ing anyway because
+        # FEATURE_EXPORTING_TO_UK_ON_ENABLED was not set on production any more, so the views
+        # ExportingToUKDERAFormView, ExportingToUKBEISFormView and ExportingToUKFormView have
+        # NOT YET been ported to Great V2
+        '/contact/exporting-to-the-uk/',
+        '/contact/exporting-to-the-uk/import-controls/',
+        '/contact/exporting-to-the-uk/other/',
+        '/contact/exporting-to-the-uk/trade-with-uk-app/',
+        '/contact/department-for-business-energy-and-industrial-strategy/',
+        '/contact/department-for-environment-food-and-rural-affairs/',
     ]
 
     url = reverse('core:sitemap')


### PR DESCRIPTION
This changeset updates changes made for GP2-2982 to remove a small number of static-page URLs which are currently 404ing because they have been disabled via a feature flag. 

When I come to port the views from V1 into V2, I will make sure the sitemap only shows them if they are enabled via the flag.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2982
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry already exists.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
