### PR TITLE
Fix for case study listing view if empty related page selected in any…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Pre-release changes - please put everything in the appropriate category below
 
 ### Enhancements
-- GA2-3054 - Updated GA360 mixin for special exception for authenticated staff users
+- no-ticket: Fix for case study listing view if empty related page selected in any case study
+- GA2-3054: Updated GA360 mixin for special exception for authenticated staff users
 - GP2-2841: Pinned CF buildpack and upgraded python to 3.9.5
 - GP2-2982: Rebuild sitemap.xml in great-cms
 - GP2-2981: Port Search Feedback page from V1 into V2

--- a/cms_extras/modeladmin.py
+++ b/cms_extras/modeladmin.py
@@ -187,7 +187,7 @@ class CaseStudyAdmin(ModelAdmin):
         return format_html_join(
             '',
             '<strong>{}: </strong> {}<br>',  # noqa
-            ((page_mapping.get(x.page.specific._meta.model_name), x.page) for x in obj.related_pages.all()),
+            ((page_mapping.get(x.page.specific._meta.model_name), x.page) for x in obj.related_pages.all() if x.page),
         )
 
     get_related_pages.short_description = 'Associated pages'


### PR DESCRIPTION
… case study

### Workflow

- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

One can test this via adding a case study creating a related page component but not selecting any page and save case study - that saves the empty page to a case study which breaks the listing view of the case study. This fix will avoid breaking admin UI


- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
