### PR TITLE
GP2-2986 Merge companies-house api views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,17 @@
 ## Pre-release changes - please put everything in the appropriate category below
 
 ### Enhancements
-- no-ticket: Fix for case study listing view if empty related page selected in any case study
-- GA2-3054: Updated GA360 mixin for special exception for authenticated staff users
-- GP2-2841: Pinned CF buildpack and upgraded python to 3.9.5
-- GP2-2982: Rebuild sitemap.xml in great-cms
-- GP2-2981: Port Search Feedback page from V1 into V2
-- GP2-2980: Port Market Access / 'Report a Trade Barrier' pages from V1 into V2
-- GP2-2977: Port E-Commerce Export Support pages from V1 into V2
-- GP2-1618: Port legacy EU Exit / transition period forms from V1 into V2
-- GP2-1617: Port get-finance/UKEF contact form from great-domestic-ui
-- GP2-2856  remove unused api calls
+- GP2-2986 - Merge companies-house api views
+- no-ticket - Fix for case study listing view if empty related page selected in any case study
+- GA2-3054 - Updated GA360 mixin for special exception for authenticated staff users
+- GP2-2841 - Pinned CF buildpack and upgraded python to 3.9.5
+- GP2-2982 - Rebuild sitemap.xml in great-cms
+- GP2-2981 - Port Search Feedback page from V1 into V2
+- GP2-2980 - Port Market Access / 'Report a Trade Barrier' pages from V1 into V2
+- GP2-2977 - Port E-Commerce Export Support pages from V1 into V2
+- GP2-1618 - Port legacy EU Exit / transition period forms from V1 into V2
+- GP2-1617 - Port get-finance/UKEF contact form from great-domestic-ui
+- GP2-2856 - remove unused api calls
 - no-ticket - package upgrade
 - GP2-2856 - remove target market
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -132,12 +132,6 @@ urlpatterns = [
         name='api-companies-house',
     ),
     path(
-        # THIS IS USED BY EX-GREAT-DOMESTIC-UI PAGES
-        'api/internal/companies-house-search/',
-        skip_ga360(views.CompaniesHouseSearchApiView.as_view()),
-        name='api-internal-companies-house-search',
-    ),
-    path(
         'subtitles/<int:great_media_id>/<str:language>/content.vtt',
         login_required(
             # NB remove/update login_required() if we start serving subtitles for videos in

--- a/core/views.py
+++ b/core/views.py
@@ -2,15 +2,14 @@ import abc
 import json
 import logging
 
-from directory_ch_client import ch_search_api_client
 from directory_forms_api_client.helpers import Sender
 from django.conf import settings
 from django.contrib.sitemaps import Sitemap as DjangoSitemap
-from django.http import Http404, HttpResponse, JsonResponse
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.urls import reverse, reverse_lazy
-from django.views.generic import FormView, TemplateView, View
+from django.views.generic import FormView, TemplateView
 from django.views.generic.base import RedirectView
 from formtools.wizard.views import NamedUrlSessionWizardView
 from great_components.mixins import GA360Mixin
@@ -386,19 +385,6 @@ def serve_subtitles(request, great_media_id, language):
 
     response = HttpResponse(subtitles, content_type='text/vtt')
     return response
-
-
-class CompaniesHouseSearchApiView(View):
-    form_class = forms.CompaniesHouseSearchForm
-
-    def get(self, request, *args, **kwargs):
-        form = self.form_class(data=request.GET)
-        if not form.is_valid():
-            return JsonResponse(form.errors, status=400)
-
-        api_response = ch_search_api_client.company.search_companies(query=form.cleaned_data['term'])
-        api_response.raise_for_status()
-        return JsonResponse(api_response.json()['items'], safe=False)
 
 
 class CMSPagesSitemap(WagtailSitemap):

--- a/core/views_api.py
+++ b/core/views_api.py
@@ -140,7 +140,7 @@ class CompaniesHouseAPIView(generics.GenericAPIView):
     permission_classes = []
 
     def get(self, request, *args, **kwargs):
-        service = request.GET.get('service')
+        service = request.GET.get('service', 'search')
         if service == 'search':
             response = ch_search_api_client.company.search_companies(query=request.GET.get('term'))
         elif service == 'profile':

--- a/domestic/static/javascript/company-lookup.js
+++ b/domestic/static/javascript/company-lookup.js
@@ -24,7 +24,7 @@ GOVUK.data = (new function() {
       url: url,
       method: "GET",
       success: function(response) {
-        service.response = response;
+        service.response = response && response.items;
       }
     }, configuration || {});
 
@@ -58,7 +58,7 @@ GOVUK.data = (new function() {
 
 
   // Create service to fetch Company from name lookup on Companies House API
-  this.getCompanyByName = new Service("/api/internal/companies-house-search/");
+  this.getCompanyByName = new Service("/api/companies-house/");
 });
 
 GOVUK.components = (new function() {

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -1033,38 +1033,3 @@ def test_serve_subtitles__login_required(client):
 
     assert resp.status_code == 302
     assert resp._headers['location'] == ('Location', reverse('core:login') + f'?next={dest}')
-
-
-@pytest.mark.django_db
-@patch('directory_ch_client.ch_search_api_client.company.search_companies')
-def test_companies_house_search_internal(mock_search_companies, client):
-    mock_search_companies.return_value = create_response(
-        {
-            'items': [
-                {'name': 'Smashing corp'},
-            ],
-        },
-    )
-    url = reverse('core:api-internal-companies-house-search')
-
-    response = client.get(url, data={'term': 'thing'})
-
-    assert response.status_code == 200
-    assert response.content == b'[{"name": "Smashing corp"}]'
-
-
-@pytest.mark.django_db
-@patch('directory_ch_client.ch_search_api_client.company.search_companies')
-def test_companies_house_search_internal__invalid_form(mock_search_companies, client):
-    mock_search_companies.return_value = create_response(
-        {
-            'items': [
-                {'name': 'Smashing corp'},
-            ],
-        },
-    )
-    url = reverse('core:api-internal-companies-house-search')
-
-    response = client.get(url, data={})
-
-    assert response.status_code == 400


### PR DESCRIPTION
There were two api views in the system.  One called by JavaScript in a migrated BAU form. The other used                                                    within Magna for VFM.
This PR, switches the BAU javascript to use the same api view as Maga react code, and removed the surplus api view along with tests. 

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2986
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
