### PR TITLE
GP2-1684: migrate SOO contact pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Pre-release changes - please put everything in the appropriate category below
 
+### Enhancements
+- GP2-1684: Port the contact pages which need users to be signed in (SOO ones) from V1 to V2
+### Fixed bugs
+
 ## [1.11.0](https://github.com/uktrade/great-cms/releases/tag/1.11.0)
 [Full Changelog](https://github.com/uktrade/great-cms/compare/1.10.0...1.11.0)
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -104,6 +104,7 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
             CORE_APP_DIR.path('templates'),
+            ROOT_DIR.path('templates'),  # For overriding templates in dependencies, such as great-components
         ],
         'APP_DIRS': True,
         'OPTIONS': {

--- a/config/settings.py
+++ b/config/settings.py
@@ -550,6 +550,10 @@ CONTACT_INTERNATIONAL_USER_NOTIFY_TEMPLATE_ID = env.str(
     'CONTACT_INTERNATIONAL_USER_NOTIFY_TEMPLATE_ID',
     'c07d1fb2-dc0c-40ba-a3e0-3113638e69a3',
 )
+CONTACT_SOO_ZENDESK_SUBJECT = env.str(
+    'CONTACT_DOMESTIC_ZENDESK_SUBJECT',
+    'great.gov.uk Selling Online Overseas contact form',
+)
 
 
 # UK Export Finance

--- a/contact/forms.py
+++ b/contact/forms.py
@@ -6,15 +6,15 @@ from directory_forms_api_client.forms import (
     ZendeskActionMixin,
 )
 from django.forms import (
-    IntegerField,
+    IntegerField as DjangoIntegerField,
     Select,
     Textarea,
     TextInput,
     TypedChoiceField,
     ValidationError,
+    widgets as django_widgets,
 )
 from great_components import forms
-from great_components.forms import Form as GreatComponentsForm, fields
 
 from contact import constants
 from contact.helpers import retrieve_regional_office
@@ -36,8 +36,33 @@ SOO_TURNOVER_OPTIONS = (
 )
 
 
-class CountryForm(GreatComponentsForm):
-    country = fields.ChoiceField(
+class GroupedRadioSelect(
+    forms.widgets.PrettyIDsMixin,
+    django_widgets.ChoiceWidget,
+):
+    # The customised version of RadioSelect in great-components (used in Great V2) is older
+    # than the version of RadioSelect in directory-components (used in Great V1), so this
+    # is a (temporary...?) way to get the appropriate behaviour from directory-component
+    # into great-cms until great-components can be brought up to date. Compare the source in
+    # https://github.com/uktrade/directory-components/blob/master/directory_components/forms/widgets.py
+    # with https://github.com/uktrade/great-components/blob/master/great_components/forms/widgets.py
+
+    template_name = 'great_components/form_widgets/multiple_input.html'
+    option_template_name = 'great_components/form_widgets/radio_option.html'
+    css_class_name = 'select-multiple'
+    input_type = 'radio'
+    is_grouped = True
+
+
+class IntegerField(
+    forms.DirectoryComponentsFieldMixin,
+    DjangoIntegerField,
+):
+    pass
+
+
+class CountryForm(forms.Form):
+    country = forms.fields.ChoiceField(
         label='Country',
         widget=Select(attrs={'id': 'great-header-country-select'}),
         choices=COUNTRIES,
@@ -64,7 +89,7 @@ class BaseShortForm(forms.Form):
     company_type = forms.ChoiceField(
         label='Company type',
         label_suffix='',
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
         choices=constants.COMPANY_TYPE_CHOICES,
     )
     company_type_other = forms.ChoiceField(
@@ -177,13 +202,13 @@ class ExportSupportForm(GovNotifyEmailActionMixin, forms.Form):
             ('£10M to £50M', '£10M to £50M'),
             ('£50M or higher', '£50M or higher'),
         ),
-        widget=forms.RadioSelect,
+        widget=GroupedRadioSelect,
         required=False,
     )
     employees_number = forms.ChoiceField(
         label='Number of employees',
         choices=EMPLOYEES_NUMBER_CHOICES,
-        widget=forms.RadioSelect,
+        widget=GroupedRadioSelect,
         error_messages={
             'required': 'Choose a number',
         },
@@ -191,7 +216,7 @@ class ExportSupportForm(GovNotifyEmailActionMixin, forms.Form):
     currently_export = forms.ChoiceField(
         label='Do you currently export?',
         choices=(('yes', 'Yes'), ('no', 'No')),
-        widget=forms.RadioSelect,
+        widget=GroupedRadioSelect,
         error_messages={'required': 'Please answer this question'},
     )
 
@@ -248,7 +273,7 @@ class LocationRoutingForm(forms.Form):
     )
     choice = forms.ChoiceField(
         label='',
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
         choices=CHOICES,
     )
 
@@ -267,7 +292,7 @@ class DomesticRoutingForm(forms.Form):
     )
     choice = forms.ChoiceField(
         label='',
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
         choices=CHOICES,  # possibly update by mixin
     )
 
@@ -295,7 +320,7 @@ class InternationalRoutingForm(forms.Form):
 
     choice = forms.ChoiceField(
         label='',
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
         choices=[],  # array overridden by constructor
     )
 
@@ -309,7 +334,7 @@ class GreatServicesRoutingForm(forms.Form):
     )
     choice = forms.ChoiceField(
         label='',
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
         choices=CHOICES,
     )
 
@@ -321,7 +346,7 @@ class GreatAccountRoutingForm(forms.Form):
 
     choice = forms.ChoiceField(
         label='',
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
         choices=[],  # array overridden by constructor
     )
 
@@ -338,7 +363,7 @@ class ExportOpportunitiesRoutingForm(forms.Form):
     )
     choice = forms.ChoiceField(
         label='',
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
         choices=CHOICES,
     )
 
@@ -433,7 +458,7 @@ class BusinessDetailsForm(ConsentFieldMixin, forms.Form):
 
     company_type = forms.ChoiceField(
         label_suffix='',
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
         choices=constants.COMPANY_TYPE_CHOICES,
     )
     companies_house_number = forms.CharField(
@@ -486,7 +511,7 @@ class InternationalContactForm(
     family_name = forms.CharField()
     email = forms.EmailField(label='Email address')
     organisation_type = forms.ChoiceField(
-        label_suffix='', widget=forms.RadioSelect(), choices=ORGANISATION_TYPE_CHOICES
+        label_suffix='', widget=GroupedRadioSelect(), choices=ORGANISATION_TYPE_CHOICES
     )
     organisation_name = forms.CharField(label='Your organisation name')
     country_name = forms.ChoiceField(
@@ -559,7 +584,7 @@ class SellingOnlineOverseasApplicant(forms.Form):
         label='Your business turnover last year',
         help_text="You may use 12 months rolling or last year's annual turnover.",
         choices=SOO_TURNOVER_OPTIONS,
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
     )
 
 
@@ -586,7 +611,7 @@ class SellingOnlineOverseasApplicantNonCH(forms.Form):
         label='Your business turnover last year',
         help_text="You may use 12 months rolling or last year's annual turnover.",
         choices=SOO_TURNOVER_OPTIONS,
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
     )
 
 
@@ -613,7 +638,7 @@ class SellingOnlineOverseasApplicantIndividual(forms.Form):
         label='Your business turnover last year',
         help_text="You may use 12 months rolling or last year's annual turnover.",
         choices=SOO_TURNOVER_OPTIONS,
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
     )
 
 
@@ -633,7 +658,7 @@ class SellingOnlineOverseasApplicantDetails(forms.Form):
     sku_count = IntegerField(
         label='How many stock keeping units (SKUs) do you have?',
         help_text=(
-            'A stock keeping unit is an individual item, such as a product ' 'or a service that is offered for sale.'
+            'A stock keeping unit is an individual item, such as a product or a service that is offered for sale.'
         ),
         widget=TextInput(attrs={'class': 'short-field'}),
     )
@@ -643,7 +668,7 @@ class SellingOnlineOverseasApplicantDetails(forms.Form):
         label_suffix='',
         coerce=lambda x: x == 'True',
         choices=[(True, 'Yes'), (False, 'No')],
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
         required=False,
     )
 
@@ -658,7 +683,7 @@ class SellingOnlineOverseasExperience(forms.Form):
     experience = forms.ChoiceField(
         label='Have you sold products online to customers outside the UK?',
         choices=EXPERIENCE_OPTIONS,
-        widget=forms.RadioSelect(),
+        widget=GroupedRadioSelect(),
     )
 
     description = forms.CharField(

--- a/contact/templates/domestic/contact/soo/base.html
+++ b/contact/templates/domestic/contact/soo/base.html
@@ -1,0 +1,42 @@
+{% extends 'domestic/contact/wizard-domestic.html' %}
+
+{% load static from static %}
+{% load breadcrumbs success_box from component_tags %}
+
+{% block head_title %}{{ market_name|default:'' }} application - Selling Online Overseas -  great.gov.uk{% endblock %}
+
+{% block head_css %}
+    {{ block.super }}
+    <link href="{% static 'styles/contact-selling-online-overseas.css' %}" rel="stylesheet" type="text/css" />
+{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="container">
+        {% breadcrumbs market_name %}
+            <a href="/">great.gov.uk</a>
+            {% comment %} services_urls comes from great_components.context_processors.urls_processor {% endcomment %}
+            <a href="{{ services_urls.soo }}">Selling Online Overseas</a>
+        {% endbreadcrumbs %}
+    </div>
+{% endblock %}
+
+{% block step_title_container %}
+{% if registration_complete %}
+    <div class="margin-bottom-60">
+        {% success_box heading="Account created" description="You can now continue with your application" %}
+    </div>
+{% endif %}
+    <h1 class="heading-xlarge width-full width-two-thirds-l">{{ market_name|default:'' }} - Application via Department for International Trade</h1>
+
+{% endblock %}
+{% block extra_contents %}
+{% if wizard.steps.prev %}
+    <button name="wizard_goto_step" class="previous-step padding-0 margin-bottom-30 margin-bottom-45-l" type="submit" value="{{ wizard.steps.prev }}">Back</button>
+{% endif %}
+<div class="step-counter mid-grey-text">Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</div>
+<h1 class="heading-large margin-top-0">{% block step_title %}{% endblock %}</h1>
+{% endblock %}
+{% block form_class %}soo-application-form step-{{ wizard.steps.step1 }} margin-bottom-90{% endblock %}
+{% block form_contents_class %}full-width width-two-thirds{% endblock %}
+{% block button_continue_label %}Save and continue{% endblock %}
+{% block back_button %}{% endblock %}

--- a/contact/templates/domestic/contact/soo/step-applicant-details.html
+++ b/contact/templates/domestic/contact/soo/step-applicant-details.html
@@ -1,0 +1,6 @@
+{% extends 'domestic/contact/soo/base.html' %}
+
+{% load static from static %}
+{% block breadcrumbs %}{% endblock %}
+{% block step_title_container %}{% endblock %}
+{% block step_title %}About your products{% endblock %}

--- a/contact/templates/domestic/contact/soo/step-applicant.html
+++ b/contact/templates/domestic/contact/soo/step-applicant.html
@@ -1,0 +1,70 @@
+{% extends 'domestic/contact/soo/base.html' %}
+
+{% load static from static %}
+{% block breadcrumbs %}{% endblock %}
+{% block step_title_container %}{% endblock %}
+{% block step_title %}About your business{% endblock %}
+
+{% block body_js %}
+    {{ block.super }}
+    <script src="{% static 'javascript/company-lookup.js' %}"></script>
+    <script type="text/javascript">
+      var $companyNumberContainer = $("#id_applicant-company_number-container");
+      var $companyNumberField = $("#id_applicant-company_number");
+      var $noCompanyNumber = $("#id_applicant-soletrader");
+      function hideCompanyNumberFieldContainer() {
+        $companyNumberField.val("");
+        $companyNumberContainer.hide();
+      }
+      // hide company number field container if checkbox is checked before page is loaded fully
+      if($noCompanyNumber.is(":checked")) {
+        hideCompanyNumberFieldContainer();
+      }
+
+      $(document).ready(function() {
+        var lookup = new GOVUK.components.CompaniesHouseNameLookup($("#id_applicant-company_name"), $companyNumberField);
+
+        // Hide and clear company number field if declare they have no number.
+        $noCompanyNumber.on("change", function() {
+          if(this.checked) {
+            hideCompanyNumberFieldContainer();
+          }
+          else {
+            $companyNumberContainer.show();
+          }
+        });
+
+        // Adjustments for the Companies House lookup on company name field and
+        // automatic population of the company number and postcode on selection.
+        lookup.bindContentEvents = function() {
+
+          // First allow the normal functionality to run.
+          GOVUK.components.CompaniesHouseNameLookup.prototype.bindContentEvents.call(lookup);
+
+          // Now add customisations for this SOO form (includes postcode population).
+          lookup._private.$list.on("click.CompaniesHouseNameLookup", function(event) {
+            var companies = GOVUK.data.getCompanyByName.response;
+            var selectedCompanyNumber = lookup._private.$field.val();
+            for(var i=0; i<companies.length; ++i) {
+              if(companies[i].company_number == selectedCompanyNumber) {
+                $("#id_applicant-company_postcode").val(companies[i].address.postal_code);
+              }
+            }
+
+            // Where has the auto-close gone??
+            lookup.close();
+          });
+        }
+
+        // In case user selects 'no companies house number' before filling in
+        // company name (unlikely), let's prevent the number lookup functionality.
+        lookup.search = function() {
+          if(! $noCompanyNumber.get(0).checked) {
+            GOVUK.components.SelectiveLookup.prototype.search.call(lookup);
+          }
+        }
+      });
+    </script>
+
+
+{% endblock %}

--- a/contact/templates/domestic/contact/soo/step-contact-details.html
+++ b/contact/templates/domestic/contact/soo/step-contact-details.html
@@ -1,0 +1,23 @@
+{% extends 'domestic/contact/soo/base.html' %}
+
+{% load static from static %}
+{% block intro_text %}{% endblock %}
+
+{% block step_title_container %}
+    {{ block.super }}
+    <div class="width-full width-two-thirds-xl">
+        <p>Your answers to the questions below help us to decide the best way to support your business.  We've automatically used some details you gave us earlier.  You can update your details later on your account page.<br/>All fields are required unless marked as optional.</p>
+    </div>
+    <h2 class="heading-large background-stone-30 padding-15">Benefits of applying here</h3>
+    <div class="width-full width-two-thirds-xl">
+        <p>The Department for International Trade facilitates the introduction between you and the marketplace directly.</p>
+        <h4 class="heading-small">Save time</h4>
+        <p class="margin-bottom-0 margin-top-0">Your application will be 'fast tracked' through this channel, providing a direct route to the marketplace.</p>
+        <p class="margin-bottom-0 margin-top-0">Your application for this marketplace will be reviewed for suitability and we will respond to you within 5 working days.</p>
+        <h4 class="heading-small">Save money</h4>
+        <p class="margin-bottom-0 margin-top-0">If successfully matched, you may be able to get access to marketplace offers.</p>
+    </div>
+    <hr class="background-stone-30 margin-top-45 margin-bottom-45">
+{% endblock %}
+
+{% block step_title %}Your details{% endblock %}

--- a/contact/templates/domestic/contact/soo/step-experience.html
+++ b/contact/templates/domestic/contact/soo/step-experience.html
@@ -1,0 +1,6 @@
+{% extends 'domestic/contact/soo/base.html' %}
+
+{% load static from static %}
+{% block breadcrumbs %}{% endblock %}
+{% block step_title_container %}{% endblock %}
+{% block step_title %}About your exporting experience{% endblock %}

--- a/contact/urls.py
+++ b/contact/urls.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required
 from django.urls import path, reverse_lazy
 from great_components.decorators import skip_ga360
 
@@ -18,6 +19,8 @@ from contact.views import (
     OfficeFinderFormView,
     OfficeSuccessView,
     RoutingFormView,
+    SellingOnlineOverseasFormView,
+    SellingOnlineOverseasSuccessView,
 )
 from core import snippet_slugs
 from core.views import QuerystringRedirectView
@@ -195,5 +198,46 @@ urlpatterns = [
             'snippet_import_path': 'contact.models.ContactSuccessSnippet',  # see core.mixins.GetSnippetContentMixin
         },
         name='contact-us-international-success',
+    ),
+    path(
+        'contact/selling-online-overseas/',
+        QuerystringRedirectView.as_view(
+            url=reverse_lazy(
+                'contact:contact-us-soo',
+                kwargs={'step': 'contact-details'},
+            )
+        ),
+        name='contact-us-soo-redirect',
+    ),
+    path(
+        'contact/selling-online-overseas/organisation/',
+        QuerystringRedirectView.as_view(
+            url=reverse_lazy(
+                'contact:contact-us-soo',
+                kwargs={'step': 'contact-details'},
+            )
+        ),
+        name='contact-us-soo-organisation-redirect',
+    ),
+    path(
+        'contact/selling-online-overseas/success/',
+        skip_ga360(SellingOnlineOverseasSuccessView.as_view()),
+        {
+            'slug': snippet_slugs.HELP_FORM_SUCCESS_SOO,
+            'snippet_import_path': 'contact.models.ContactSuccessSnippet',  # see core.mixins.GetSnippetContentMixin
+        },
+        name='contact-us-selling-online-overseas-success',
+    ),
+    path(
+        'contact/selling-online-overseas/<slug:step>/',
+        login_required(
+            skip_ga360(
+                SellingOnlineOverseasFormView.as_view(
+                    url_name='contact:contact-us-soo',
+                    done_step_name='finished',
+                )
+            )
+        ),
+        name='contact-us-soo',
     ),
 ]

--- a/contact/views.py
+++ b/contact/views.py
@@ -611,9 +611,13 @@ class SellingOnlineOverseasFormView(
         return f'selling_online_overseas_form_view_{self.request.user.id}'
 
     def get_form_data_cache(self):
+        # Note: this _looks_ like dead code – can't see a reference in an superclasses
+        # See 550de82 and then e74d335 in great-domestic-ui.
         return cache.get(self.get_cache_prefix(), None)
 
     def set_form_data_cache(self, form_data):
+        # This code is called, but because self.get_form_data_cache() doesn't appear to
+        # be used, it's effectively redundant.
         cache.set(
             self.get_cache_prefix(),
             form_data,

--- a/sso/models.py
+++ b/sso/models.py
@@ -68,3 +68,13 @@ class BusinessSSOUser(AbstractUser):
 
     def set_user_data(self, data, name):
         return helpers.set_user_data(self.session_id, data, name)
+
+    def get_mobile_number(self):
+        mobile_number = self.mobile_phone_number
+        if mobile_number in ['', None] and self.company:
+            mobile_number = getattr(self.company, 'mobile_number', None)
+        return mobile_number
+
+    @property
+    def company_type(self):
+        return getattr(self.company, 'company_type', None) if self.company else None

--- a/sso/models.py
+++ b/sso/models.py
@@ -70,10 +70,11 @@ class BusinessSSOUser(AbstractUser):
         return helpers.set_user_data(self.session_id, data, name)
 
     def get_mobile_number(self):
+        empty_vals = ['', None]
         mobile_number = self.mobile_phone_number
-        if mobile_number in ['', None] and self.company:
+        if mobile_number in empty_vals and self.company:
             mobile_number = getattr(self.company, 'mobile_number', None)
-        return mobile_number
+        return mobile_number if mobile_number not in empty_vals else None
 
     @property
     def company_type(self):

--- a/templates/great_components/form_widgets/README.txt
+++ b/templates/great_components/form_widgets/README.txt
@@ -1,0 +1,1 @@
+These templates were copied over from directory_components (yes, not great_components) as overrides for the ones in great_components, because the ones in directory_components are _currently_ more up to date than the ones in great_components.

--- a/templates/great_components/form_widgets/form.html
+++ b/templates/great_components/form_widgets/form.html
@@ -1,0 +1,13 @@
+{% if form.non_field_errors %}
+  <div class="error-message margin-bottom-30">
+    <div class="{{ form.error_css_class }}">
+      {{ form.non_field_errors }}
+    </div>
+  </div>
+{% endif %}
+{% for field in form.visible_fields %}
+  {% include 'great_components/form_widgets/form_field.html' with field=field %}
+{% endfor %}
+{% for field in form.hidden_fields %}
+    {{ field }}
+{% endfor %}

--- a/templates/great_components/form_widgets/form_field.html
+++ b/templates/great_components/form_widgets/form_field.html
@@ -1,0 +1,26 @@
+<div class="{{ field.css_classes }}" id="{{ field.id_for_label }}-container">
+    {% if field.field.widget.is_grouped %}
+    <fieldset>
+      {% if field.label %}
+        <legend>
+          {{ field.label_tag }}
+        </legend>
+      {% endif %}
+  {% else %}
+    {% if field.label %}
+      {{ field.label_tag }}
+    {% elif field.field.widget.hidden_label %}
+      <label class="visually-hidden" for="{{field.id_for_label}}">{{ field.field.widget.hidden_label }}</label>
+    {% endif %}
+  {% endif %}
+  {% if field.errors %}
+    <div class="error-message" role="alert" aria-atomic="true">{{ field.errors }}</div>
+  {% endif %}
+  {% if field.help_text %}
+    <span class="form-hint">{{ field.help_text }}</span>
+  {% endif %}
+  {{ field }}
+  {% if field.field.widget.is_grouped %}
+    </fieldset>
+  {% endif %}
+</div>

--- a/templates/great_components/form_widgets/multiple_input.html
+++ b/templates/great_components/form_widgets/multiple_input.html
@@ -1,0 +1,19 @@
+<div class="form-group">
+{% with id=widget.attrs.id %}
+<ul{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>
+  {% for group, options, index in widget.optgroups %}
+    {% if group %}
+      <li>
+        <ul class="form-group"{% if id %} id="{{ id }}_{{ index }}"{% endif %}>
+          <label{% if id %} id="{{ id }}-{% filter force_escape|lower %}{{ group }}{% endfilter %}-label"{% endif %} class="form-label">{{ group }}</label>
+    {% endif %}
+    {% for option in options %}
+      <li class="multiple-choice">{% include option.template_name with widget=option %}</li>
+    {% endfor %}
+    {% if group %}
+      </ul></li>
+    {% endif %}
+  {% endfor %}
+</ul>
+{% endwith %}
+</div>

--- a/templates/great_components/form_widgets/nested-radio.html
+++ b/templates/great_components/form_widgets/nested-radio.html
@@ -1,0 +1,6 @@
+{% include "great_components/form_widgets/radio_option.html" %}
+{% if widget.value == widget.nested_form_choice %}
+	<div class="radio-nested govuk-inset-text">
+		{{ widget.nested_form }}
+	</div>
+{% endif %}

--- a/templates/great_components/form_widgets/radio_option.html
+++ b/templates/great_components/form_widgets/radio_option.html
@@ -1,0 +1,4 @@
+{% include "django/forms/widgets/input.html" %}
+<label{% if widget.attrs.id %} id="{{ widget.attrs.id }}-label" for="{{ widget.attrs.id }}"{% endif %} class="form-label">
+	{{ widget.label }}
+</label>

--- a/tests/unit/contact/test_forms.py
+++ b/tests/unit/contact/test_forms.py
@@ -385,3 +385,42 @@ def test_feedback_form_full_name(captcha_stub):
     )
 
     assert form_instance.full_name == 'Alice McTest'
+
+
+def test_selling_online_overseas_applicant_valid_form_ch():
+    form = forms.SellingOnlineOverseasApplicant(
+        data={
+            'company_name': 'Acme',
+            'company_number': '123',
+            'company_address': 'Same Street',
+            'website_address': 'bar',
+            'turnover': 'Under 100k',
+        }
+    )
+    assert form.is_valid()
+
+
+def test_selling_online_overseas_applicant_valid_form_non_ch():
+    form = forms.SellingOnlineOverseasApplicantNonCH(
+        data={
+            'company_name': 'Acme',
+            'company_address': 'Same Street',
+            'website_address': 'bar',
+            'turnover': 'Under 100k',
+        }
+    )
+    assert form.is_valid()
+
+
+def test_selling_online_overseas_applicant_valid_form_individual():
+    form = forms.SellingOnlineOverseasApplicantIndividual(
+        data={
+            'company_name': 'Acme',
+            'company_number': '123',
+            'company_address': 'Same Street',
+            'company_postcode': 'SW1H 0TL',
+            'website_address': 'bar',
+            'turnover': 'Under 100k',
+        }
+    )
+    assert form.is_valid()

--- a/tests/unit/sso/test_models.py
+++ b/tests/unit/sso/test_models.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from directory_sso_api_client import sso_api_client
 from sso import models
 from tests.helpers import create_response
@@ -45,3 +47,88 @@ def test_has_visited_page(mock_get_user_page_views):
     mock_get_user_page_views.return_value = create_response(page_views_response)
     assert user.get_page_views() == page_views_response
     assert user.has_visited_page(page='mypage') == {'mypage': 1}
+
+
+@pytest.mark.parametrize(
+    'user_mobile_number,company_data,expected_number',
+    (
+        (
+            '07700 900000',
+            {'mobile_number': '07700 9999999'},
+            '07700 900000',
+        ),
+        (
+            '',
+            {'mobile_number': '07700 9999999'},
+            '07700 9999999',
+        ),
+        (
+            None,
+            {'mobile_number': '07700 9999999'},
+            '07700 9999999',
+        ),
+        (
+            '',
+            {'mobile_number': ''},
+            None,
+        ),
+        (
+            '',
+            {'something_that_is_not_mobile_number': 'abcdef'},
+            None,
+        ),
+        (
+            None,
+            {'something_that_is_not_mobile_number': 'abcdef'},
+            None,
+        ),
+    ),
+    ids=[
+        'user number takes priority over company number',
+        'company number used if user number is empty string',
+        'company number used if user number is null',
+        'None returned if both numbers are empty strings',
+        'None returned if user number is empty string and no company number available',
+        'None returned if user number is null and no company number available',
+    ],
+)
+@mock.patch('sso.helpers.get_company_profile')
+def test_get_mobile_number(mock_get_company_profile, user_mobile_number, company_data, expected_number):
+
+    mock_get_company_profile.return_value = company_data
+
+    user = models.BusinessSSOUser(
+        mobile_phone_number=user_mobile_number,
+    )
+
+    assert user.get_mobile_number() == expected_number
+
+
+@pytest.mark.parametrize(
+    'company_data,expected',
+    (
+        (
+            {'company_type': 'TEST'},
+            'TEST',
+        ),
+        (
+            {'company_type': ''},  #  unlikely to be a real-world value
+            '',
+        ),
+        (
+            {'something_not_company_type': 'abcdef'},
+            None,
+        ),
+        (
+            {},
+            None,
+        ),
+    ),
+)
+@mock.patch('sso.helpers.get_company_profile')
+def test_company_type(mock_get_company_profile, company_data, expected):
+    mock_get_company_profile.return_value = company_data
+
+    user = get_user()
+
+    assert user.company_type == expected


### PR DESCRIPTION
This changeset ports the pages at /contact/selling-online-overseas/* from V1 into V2.

These pages, which require a user to be signed in, are how someoene applies for support.

Note that the workflow expects a ?market=Name%20Of%20Company querystring, else will show None in the breadcrumbs and have only a partial headline if you just go directly to /contact/selling-online-overseas/ -- this is expected/current behaviour

Also note that if you have a user account created purely in Magna, it will lack a first and last name, which will stop you completing the wizard. That bug will be handled in a separate PR, as it's an existing issue.

**IMPORTANT**
This changeset also required extra work to port/fix broken styling in these SOO contact pages.

The root cause of this was basically:
* great-cms uses great-components
* great-components was forked from directory-components about two years ago
* directory-components continued to evolve
* those changes were not backported to great-components

Given the time constraint and cognitive overhead of (safely) updating and releasing a new version of great-components, I've instead gone with local-to-great-cms overrides for the relevant templates that were out of date, as well as porting/reimplementing a couple of Python widgets. Once great-components is up to date, these changes can be removed - hence keeping them in an isolated commit

**_Let me know if you disagree with this approach._**

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-1684
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [X] Explains how to test locally, including how to set up appropriate data

* spin up great-cms, directory-sso, directory-sso-proxy and directory-forms-api locally
* go to `/contact/selling-online-overseas/?market=SomeTestMarketNameHere` and you'll see the start page reflects the name of the org passed as `?market=`
  * try `<script>` injection, etc, in that querystring. No new mitigations have been added, just existing behaviour ported and that param is escaped in the HTML
  * work through the wizard
  * submit
  * check forms-api local admin for details of the record. It will also be in dev/staging zendesk

- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [X] NO new environment variables needed in Vault - defaults in settings are enough
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [X] Frontend assets FOR /domestic/static/sass/ ONLY  have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
