### PR TITLE
GP2-2988: Fix SOO contact form - make empty name fields editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 - GP2-1684: Port the contact pages which need users to be signed in (SOO ones) from V1 to V2
 ### Fixed bugs
-
+- GP2-2988: Make SOO contact form name fields editable if not already populated.
 ## [1.11.0](https://github.com/uktrade/great-cms/releases/tag/1.11.0)
 [Full Changelog](https://github.com/uktrade/great-cms/compare/1.10.0...1.11.0)
 

--- a/contact/forms.py
+++ b/contact/forms.py
@@ -530,15 +530,9 @@ class InternationalContactForm(
 class SellingOnlineOverseasContactDetails(forms.Form):
     contact_first_name = forms.CharField(
         label='First name',
-        disabled=True,
-        required=False,
-        container_css_classes='border-active-blue read-only-input-container',
     )
     contact_last_name = forms.CharField(
         label='Last name',
-        disabled=True,
-        required=False,
-        container_css_classes='border-active-blue read-only-input-container',
     )
     contact_email = forms.EmailField(
         label='Your email',
@@ -553,6 +547,25 @@ class SellingOnlineOverseasContactDetails(forms.Form):
         label='I prefer to be contacted by email',
         required=False,
     )
+
+    def _set_name_field_editability(self):
+        # If cetain fields lack content, allow each one to be editable.
+        for fieldname in [
+            'contact_first_name',
+            'contact_last_name',
+        ]:
+            if self.initial.get(fieldname):
+                self.fields[fieldname].required = False
+                self.fields[fieldname].disabled = True
+                # note that we can't set .container_css_classes, but we can do this:
+                self.fields[fieldname]._container_css_classes = 'border-active-blue read-only-input-container'
+            else:
+                self.fields[fieldname].required = True
+                self.fields[fieldname].disabled = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._set_name_field_editability()
 
 
 class SellingOnlineOverseasApplicant(forms.Form):

--- a/tests/unit/contact/test_forms.py
+++ b/tests/unit/contact/test_forms.py
@@ -424,3 +424,125 @@ def test_selling_online_overseas_applicant_valid_form_individual():
         }
     )
     assert form.is_valid()
+
+
+def test_selling_online_overseas_contact_details_form__editable_fields():
+
+    form_1 = forms.SellingOnlineOverseasContactDetails(
+        initial={
+            'contact_first_name': 'Alice',
+            'contact_last_name': 'McTest',
+            'contact_email': 'alice@example.com',
+            'phone': '998877665544',
+        }
+    )
+    assert form_1.fields['contact_first_name'].disabled is True
+    assert form_1.fields['contact_first_name'].required is False
+    assert form_1.fields['contact_first_name'].container_css_classes == 'border-active-blue read-only-input-container '
+
+    assert form_1.fields['contact_last_name'].disabled is True
+    assert form_1.fields['contact_last_name'].required is False
+    assert form_1.fields['contact_last_name'].container_css_classes == 'border-active-blue read-only-input-container '
+
+    assert form_1.fields['contact_email'].disabled is True
+    assert form_1.fields['contact_email'].required is False
+    assert form_1.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_1.fields['phone'].disabled is False
+    assert form_1.fields['phone'].required is True
+    assert form_1.fields['phone'].container_css_classes == 'form-group '
+
+    form_2 = forms.SellingOnlineOverseasContactDetails(
+        initial={
+            'contact_first_name': 'Alice',
+            'contact_email': 'alice@example.com',
+            'phone': '998877665544',
+        }
+    )
+    assert form_2.fields['contact_first_name'].disabled is True
+    assert form_2.fields['contact_first_name'].required is False
+    assert form_2.fields['contact_first_name'].container_css_classes == 'border-active-blue read-only-input-container '
+
+    assert form_2.fields['contact_last_name'].disabled is False
+    assert form_2.fields['contact_last_name'].required is True
+    assert form_2.fields['contact_last_name'].container_css_classes == 'form-group '
+
+    assert form_2.fields['contact_email'].disabled is True
+    assert form_2.fields['contact_email'].required is False
+    assert form_2.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_2.fields['phone'].disabled is False
+    assert form_2.fields['phone'].required is True
+    assert form_2.fields['phone'].container_css_classes == 'form-group '
+
+    form_3 = forms.SellingOnlineOverseasContactDetails(
+        initial={
+            'contact_last_name': 'McTest',
+            'contact_email': 'alice@example.com',
+            'phone': '998877665544',
+        }
+    )
+    assert form_3.fields['contact_first_name'].disabled is False
+    assert form_3.fields['contact_first_name'].required is True
+    assert form_3.fields['contact_first_name'].container_css_classes == 'form-group '
+
+    assert form_3.fields['contact_last_name'].disabled is True
+    assert form_3.fields['contact_last_name'].required is False
+    assert form_3.fields['contact_last_name'].container_css_classes == 'border-active-blue read-only-input-container '
+
+    assert form_3.fields['contact_email'].disabled is True
+    assert form_3.fields['contact_email'].required is False
+    assert form_3.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_3.fields['phone'].disabled is False
+    assert form_3.fields['phone'].required is True
+    assert form_3.fields['phone'].container_css_classes == 'form-group '
+
+    form_4 = forms.SellingOnlineOverseasContactDetails(
+        initial={
+            'contact_email': 'alice@example.com',
+            'phone': '998877665544',
+        }
+    )
+    assert form_4.fields['contact_first_name'].disabled is False
+    assert form_4.fields['contact_first_name'].required is True
+    assert form_4.fields['contact_first_name'].container_css_classes == 'form-group '
+
+    assert form_4.fields['contact_last_name'].disabled is False
+    assert form_4.fields['contact_last_name'].required is True
+    assert form_4.fields['contact_last_name'].container_css_classes == 'form-group '
+
+    assert form_4.fields['contact_email'].disabled is True
+    assert form_4.fields['contact_email'].required is False
+    assert form_4.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_4.fields['phone'].disabled is False
+    assert form_4.fields['phone'].required is True
+    assert form_4.fields['phone'].container_css_classes == 'form-group '
+
+    form_5 = forms.SellingOnlineOverseasContactDetails(initial={})
+    assert form_5.fields['contact_first_name'].disabled is False
+    assert form_5.fields['contact_first_name'].required is True
+    assert form_5.fields['contact_first_name'].container_css_classes == 'form-group '
+
+    assert form_5.fields['contact_last_name'].disabled is False
+    assert form_5.fields['contact_last_name'].required is True
+    assert form_5.fields['contact_last_name'].container_css_classes == 'form-group '
+
+    assert form_5.fields['contact_email'].disabled is True
+    assert form_5.fields['contact_email'].required is False
+    assert form_5.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_5.fields['phone'].disabled is False
+    assert form_5.fields['phone'].required is True
+    assert form_5.fields['phone'].container_css_classes == 'form-group '


### PR DESCRIPTION
BUGFIX: Make the name fields in the SOO contact wizard to still be editable if the first and/or last name is not yet known

This is needed because Great V2 allows users to sign up without providing a first or last name, which would then cause the overall wizard to 500.

**NOTE THAT this fix is being applied to the pages after they have been migrated from V1 into V2, but if we decide we want to hotfix this to production on GDUI, it is a copy-paste change to port over.**

Tests work at the Python level, but tested manually, too, of course.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2988
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [X] Includes screenshot(s)

**BEFORE** - see https://uktrade.atlassian.net/wiki/spaces/Great/pages/2681405487/SOO+applications+-+make+first+and+last+name+fields+editable

**AFTER**

<img width="437" alt="Screenshot 2021-07-01 at 18 04 26" src="https://user-images.githubusercontent.com/101457/124307800-3d7ede00-db60-11eb-877b-08fe7d5a7a2d.png">
<img width="443" alt="Screenshot 2021-07-01 at 18 04 15" src="https://user-images.githubusercontent.com/101457/124307801-3e177480-db60-11eb-8d34-25c9aafb6773.png">


### Merging

- Leave to Steve to merge into a different target branch, after GP2-1648 has been merged to the contact-pages feature branch
