### PR TITLE
GP2-2491 Add spacing at end of forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - GP2-2472 - Increase padding on example component
 - GP2-2473 - Increase padding on lesson component
 - GP2-2471 - Update Tooltip component
+- GP2-2491 - Increase spacing at bottom of forms
 
 ### Fixed bugs
 - GP2-3099 - WTE Selector missing

--- a/exportplan/templates/exportplan/section.html
+++ b/exportplan/templates/exportplan/section.html
@@ -45,7 +45,7 @@
   {% block additional_content %}{% endblock %}
 
   {% block next_section %}
-  <section class="p-v-m bg-blue-deep-80">
+  <section class="p-v-m bg-blue-deep-80 m-t-xl">
     <div class="container">
       <div class="grid">
         <div class="c-1-4-l">&nbsp;</div>


### PR DESCRIPTION
Adding XL margin to top of the purple container that comes after forms. Ticket mentions 100px; using this spacing token means 90px but consistency with design system.

<img width="579" alt="Screenshot 2021-07-14 at 10 41 32" src="https://user-images.githubusercontent.com/496382/125600658-0e6e2355-a22a-4b60-a641-f9e3ba0defd9.png">

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2491
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
