### PR TITLE
[GP-3282] Backport to develop: skip GA on signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 - GP2-2856 - remove target market
 
 ### Fixed bugs
+- GP2-3282 - Skip GA on signup to avoid capturing PII
 - GP2-2933 - DAC_Custom_Controls_01 Select widget
 - GP2-2924 - DAC_CSS_Images_as_Labels_03 Select widget expander
 - GP2-2908 - DAC_Headings_07 Learning step headings

--- a/core/urls.py
+++ b/core/urls.py
@@ -81,7 +81,13 @@ urlpatterns = [
     ),
     path('login/', anonymous_user_required(views.LoginView.as_view()), name='login'),
     path('logout/', login_required(skip_ga360(views.LogoutView.as_view())), name='logout'),
-    path('signup/', anonymous_user_required(views.SignupView.as_view()), name='signup'),
+    path(
+        'signup/',
+        anonymous_user_required(
+            skip_ga360(views.SignupView.as_view()),
+        ),
+        name='signup',
+    ),
     path(
         'signup/company-name/',
         login_required(skip_ga360(views.CompanyNameFormView.as_view())),


### PR DESCRIPTION
CONTEXT: This changeset emoves GA tracking on `/signup`

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP-3282
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
