### PR TITLE
Gp2 3345 gd UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - NOTICKET - Remove and cleanup broken Storybook setup
 - GP2-3352 - remove feature FEATURE_FLAG_HARD_CODE_USER_INDUSTRIES_EXPERTISE
 - GP2-3352 - Obfuscate the export plan id in urls
+- GP2-3345 - GDUI dicrectory_components statics
 
 ### Fixed bugs
 - GP2-3363 - Fix costs_and_pricing page

--- a/config/settings.py
+++ b/config/settings.py
@@ -79,6 +79,7 @@ INSTALLED_APPS = [
     'healthcheck.apps.HealthcheckAppConfig',
     'health_check.cache',
     'sso_profile',
+    'directory_components',
 ]
 
 MIDDLEWARE = [

--- a/config/url_redirects.py
+++ b/config/url_redirects.py
@@ -9,6 +9,7 @@ from core.cms_slugs import PRIVACY_POLICY_URL, TERMS_URL
 from core.views import (
     OpportunitiesRedirectView,
     QuerystringRedirectView,
+    SSORedirectView,
     TranslationRedirectView,
 )
 
@@ -852,5 +853,14 @@ articles_redirects = [
     ),
 ]
 
+gdui_redirects = [url('^sso/static/', SSORedirectView.as_view())]
 
-redirects += tos_redirects + contact_redirects + privacy_redirects + international_redirects + articles_redirects
+
+redirects += (
+    tos_redirects
+    + contact_redirects  # noqa W503
+    + privacy_redirects  # noqa W503
+    + international_redirects  # noqa W503
+    + articles_redirects  # noqa W503
+    + gdui_redirects  # noqa W503
+)

--- a/core/views.py
+++ b/core/views.py
@@ -469,3 +469,16 @@ class StaticViewSitemap(DjangoSitemap):
         elif item == 'domestic:report-ma-barrier':
             return reverse(item, kwargs={'step': 'about'})
         return reverse(item)
+
+
+class SSORedirectView(RedirectView):
+    permanent = False
+    query_string = True
+
+    def get_redirect_url(self, *args, **kwargs):
+        path_url = self.request.path
+        path_list = path_url.split("/")[2:]
+        path_joined = "/".join(path_list)
+        redirect_url = f"/{path_joined}"
+
+        return redirect_url


### PR DESCRIPTION
Simple redirect to go from sso/static/directory_components/* to static/directory_components/*

Going through there are clones of redirects in both repos gdui only two routes of statics are called from logs for the past week:

international/static/directory_components/*
sso/static/directory_components/* 

International should be managed by international one not sure why GDUI is intercepting that.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-3345
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [x] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
