### PR TITLE
[GP2-3406] Suppress error when user is already registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 - GP2-3433 - WTE routing block
+- GP2-3406 - Supress error message when signing up user is already registered
 - GP2-3336 - Product classification expander on dashboard overview page plus content changes
 - GP2-3395 - Content changes and move hs code on product finder
 - GP2-3162 - Chapter name in suggested countries

--- a/sso/views.py
+++ b/sso/views.py
@@ -1,6 +1,7 @@
 import requests
 from django.conf import settings
 from django.contrib import auth
+from requests import HTTPError
 from rest_framework import generics
 from rest_framework.response import Response
 
@@ -58,6 +59,9 @@ class SSOBusinessUserCreateView(generics.GenericAPIView):
     def handle_exception(self, exc):
         if isinstance(exc, helpers.CreateUserException):
             return Response(exc.detail, status=400)
+        # 409 means that an email already exists, so we send back a plain response
+        elif isinstance(exc, HTTPError) and exc.response.status_code == 409:
+            return Response({})
         return super().handle_exception(exc)
 
     def get_verification_link(self, uidb64, token):


### PR DESCRIPTION
Suppress error message when signing up a user whose email is already registered.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-3406
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [X] This PR can be merged by reviewers.
