### PR TITLE
GP2-3192 downgrade es client

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -65,3 +65,4 @@ uk-postcode-utils==1.1
 urllib3>=1.26.5<2.0.0
 hashids==0.8.4
 elasticsearch-dsl==7.3.0
+elasticsearch==7.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -135,8 +135,10 @@ draftjs-exporter==2.1.7
     # via wagtail
 elastic-apm==6.1.3
     # via -r requirements.in
-elasticsearch==7.15.0
-    # via elasticsearch-dsl
+elasticsearch==7.9.1
+    # via
+    #   -r requirements.in
+    #   elasticsearch-dsl
 elasticsearch-dsl==7.3.0
     # via -r requirements.in
 et-xmlfile==1.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -16,8 +16,6 @@ allure-python-commons==2.9.44
     # via allure-pytest
 anyascii==0.3.0
     # via wagtail
-appnope==0.1.2
-    # via ipython
 arabic-reshaper==2.1.3
     # via xhtml2pdf
 astroid==2.8.0
@@ -186,8 +184,10 @@ draftjs-exporter==2.1.7
     # via wagtail
 elastic-apm==6.1.3
     # via -r requirements.in
-elasticsearch==7.15.0
-    # via elasticsearch-dsl
+elasticsearch==7.9.1
+    # via
+    #   -r requirements.in
+    #   elasticsearch-dsl
 elasticsearch-dsl==7.3.0
     # via -r requirements.in
 et-xmlfile==1.1.0
@@ -240,7 +240,7 @@ gevent==21.8.0
     # via
     #   geventhttpclient
     #   locust
-geventhttpclient==1.5.1
+geventhttpclient==1.5.2
     # via locust
 great-components==1.2.3
     # via -r requirements.in


### PR DESCRIPTION
Our elasticsearch instance won't work with client versions later than 7.13.4
This pins at 7.9.1 - a known working version

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-3192
- [x] Jira ticket has the correct status.
- [ ] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [x] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
