### PR TITLE
GP2-3822 - Export plan - fix sidebar flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre release
 
 ### Bugs fixed
+- GP2-3822 - Export plan - fix sidebar flicker
 
 ### Enhancements
 

--- a/exportplan/templates/exportplan/includes/sidebar.html
+++ b/exportplan/templates/exportplan/includes/sidebar.html
@@ -1,23 +1,13 @@
 {% load to_json %}
 {% load url_map %}
 
+
 <div id="sidebar-content">
-    <nav class="sidebar p-h-s p-b-m">
+    <nav class="sidebar p-f-s p-r-m p-b-m sidebar__close"
+          id="collapseNav"
+          role="navigation"
+        >
         <div class="sidebar-sticky">
-            <div class="centre-children width-full p-t-m">
-                {% if not request.user.company.logo %}
-                    <img src="https://via.placeholder.com/200/dfd5c5?text=Company logo" alt="Add a business logo" class="w-1-2">
-                {% else %}
-                    <img alt="Your business logo" src="{{ request.user.company.logo }}" class="w-full" />
-                {% endif %}
-            </div>
-            <ul>
-                {% for section in sections %}
-                    <li class="h-s">
-                        <a href="{{ section.url }}" class="link" id="sidebar-{{ section|slugify }}">{{ section.title }}</a>
-                    </li>
-                {% endfor %}
-            </ul>
         </div>
     </nav>
 </div>


### PR DESCRIPTION
Prevent the glitch on loading export plan caused by the sidebar being expanded in the initial template render.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
