### PR TITLE
GP2-3844-hotfix-savingcms-pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Hotfix
+- GP2-3844 - [HOTFIX] saving cms pages
+
 ## Pre release
 
 ### Bugs fixed

--- a/core/utils.py
+++ b/core/utils.py
@@ -86,8 +86,13 @@ def get_personalised_choices(user):
     """
     from core.helpers import get_trading_blocs_name
 
-    products = user.get_user_data(name='UserProducts').get('UserProducts') or []
-    markets = user.get_user_data(name='UserMarkets').get('UserMarkets') or []
+    products = []
+    markets = []
+    if user:
+        # If a page is loading with wagtail user then no user will be in context
+        products = user.get_user_data(name='UserProducts').get('UserProducts') or []
+        markets = user.get_user_data(name='UserMarkets').get('UserMarkets') or []
+
     trading_blocs = set()
     for market in markets:
         for bloc in get_trading_blocs_name(market.get('country_iso2_code')):

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -207,6 +207,15 @@ def test_selected_personalised_choices(rf, user, mock_get_user_data, mock_tradin
     assert 'European Union (EU)' in blocs
 
 
+@pytest.mark.django_db
+def test_selected_personalised_choices_no_user():
+    commodity_codes, countries, regions, blocs = get_personalised_choices(None)
+
+    assert commodity_codes == []
+    assert countries == []
+    assert regions == []
+
+
 def test_tuple_to_key_value_dict():
     key_value_dict = [{'value': key, 'label': label} for key, label in MARKET_ROUTE_CHOICES]
     assert choices_to_key_value(MARKET_ROUTE_CHOICES) == key_value_dict


### PR DESCRIPTION
When a wagtail logged in user saves a lesson. get_personalised_choices method falls over since no sso user is present. I've assumed this is because a page load is triggered during lesson save causing case studies to load with personalised content.

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [ ] Jira ticket has the correct status.
- [ ] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
