### PR TITLE
GP2-3846 - Remove html encoding from apostrophes in to_json tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - GP2-3844 - [HOTFIX] savingcms pages
 
 ### Bugs fixed
+- GP2-3846 - Remove html encoding from apostrophes in to_json tag
 - GP2-3823 - Remove EP business objectives date validation
 - GP2-3788 - Restructure of lesson page to make it responsive
 - GP2-3307 - Fix sticky components (EP sidebar and lesson return links)

--- a/core/templatetags/to_json.py
+++ b/core/templatetags/to_json.py
@@ -17,5 +17,5 @@ Usage:
 @register.filter
 def to_json(data, indent=None):
     return mark_safe(
-        json.dumps(data, sort_keys=True, indent=indent, cls=DjangoJSONEncoder).replace("'", '&#39;'),
+        json.dumps(data, sort_keys=True, indent=indent, cls=DjangoJSONEncoder),
     )

--- a/exportplan/templates/exportplan/includes/pdf/pdf_section_adapting_your_product.html
+++ b/exportplan/templates/exportplan/includes/pdf/pdf_section_adapting_your_product.html
@@ -1,5 +1,4 @@
 
-{% load to_json %}
 <pdf:nexttemplate name="section_page" /><pdf:nextpage>
 <h1>Adapting our product</h1>
 <h3>

--- a/exportplan/templates/exportplan/includes/pdf/pdf_section_business_objectives.html
+++ b/exportplan/templates/exportplan/includes/pdf/pdf_section_business_objectives.html
@@ -1,5 +1,4 @@
 {% load content_tags %}
-{% load to_json %}
 {% load set %}
 {% load int_to_range %}
 

--- a/exportplan/templates/exportplan/includes/pdf/pdf_section_funding_and_credit.html
+++ b/exportplan/templates/exportplan/includes/pdf/pdf_section_funding_and_credit.html
@@ -3,7 +3,6 @@
 {% load tz %}
 {% load object_tags %}
 {% load content_tags %}
-{% load to_json %}
 <!-- P10 funding and credit -->
 <pdf:nexttemplate name="section_page" /><pdf:nextpage>
 

--- a/exportplan/templates/exportplan/includes/section_data/travel-and-business-policies__data.html
+++ b/exportplan/templates/exportplan/includes/section_data/travel-and-business-policies__data.html
@@ -13,7 +13,7 @@
   magna.travelPlanCultureRules({
     element: document.getElementById('culture-and-rules'),
     field: 'travel_business_policies',
-    formData: {{ travel_business_policies|to_json|safe }},
+    formData: {{ travel_business_policies|to_json }},
     formFields: [
       {
         description: "Find out about any important travel information by using the Foreign and Commonwealth and Development office travel advice.",
@@ -42,7 +42,7 @@
     element: document.getElementById('visa-information'),
     field: 'travel_business_policies',
     name: "visa_information",
-    formData: {{ travel_business_policies.visa_information|to_json|safe }},
+    formData: {{ travel_business_policies.visa_information|to_json }},
     travel_advice_link: "{{ travel_advice_foreign }}",
     formFields: [
       {
@@ -71,7 +71,7 @@
   })
   magna.plannedTravel({
     element: document.getElementById('planned-travel'),
-    formData: {{ business_trips|to_json|safe }},
+    formData: {{ business_trips|to_json }},
     model_name: 'businesstrips',
     companyexportplan: {{ export_plan.pk }},
     tooltip: {

--- a/exportplan/templates/exportplan/pdf_download.html
+++ b/exportplan/templates/exportplan/pdf_download.html
@@ -3,7 +3,6 @@
 {% load tz %}
 {% load object_tags %}
 {% load content_tags %}
-{% load to_json %}
 <html>
 <head><meta http-equiv=Content-Type content="text/html; charset=UTF-8">
 <style>

--- a/exportplan/templates/exportplan/section.html
+++ b/exportplan/templates/exportplan/section.html
@@ -1,6 +1,5 @@
 {% extends "core/base.html" %}
 {% load static %}
-{% load to_json %}
 {% load url_map %}
 
 {% block css_layout_class %}export-plan{% endblock %}

--- a/exportplan/templates/exportplan/sections/adapting-your-product.html
+++ b/exportplan/templates/exportplan/sections/adapting-your-product.html
@@ -1,6 +1,5 @@
 {% extends 'exportplan/section.html' %}
 {% load static %}
-{% load to_json %}
 
 {% block intro_title %}Adapting your product{%endblock %}
 {% block intro_description %}

--- a/exportplan/templates/exportplan/sections/business-objectives.html
+++ b/exportplan/templates/exportplan/sections/business-objectives.html
@@ -55,7 +55,7 @@
     magna.createObjectivesReasons({
       element: document.getElementById('objectives-reasons'),
       field: 'objectives',
-      formData: {{ objectives|to_json|safe }},
+      formData: {{ objectives|to_json }},
       formFields: [
         {
           name: 'rationale',
@@ -65,13 +65,13 @@
           example: {
             content: 'Dove Gin is established and selling well in the UK. However, the domestic gin market is now fiercely competitive. We feel that to realise our goal of doubling turnover in the next 3 years we need to look at new markets to assure this growth. Dove has a uniquely British, crafted appeal that is well placed to attract drinkers in overseas markets. We feel that the potential to widen our customer base, especially in the still-developing Asian and Australasian craft gin scene, is immense.'
           },
-          lesson: magna.formatLessonLearned({{ lesson_details|safe }}, {{ current_section|to_json}}, 0),
+          lesson: magna.formatLessonLearned({{ lesson_details|safe }}, {{ current_section|to_json }}, 0),
         },
       ],
     })
     magna.createObjectivesList({
       element: document.getElementById('objectives-form--objectives'),
-      objectives: {{ company_objectives|to_json|safe }},
+      objectives: {{ company_objectives|to_json }},
       exportPlanID: {{ export_plan.pk }},
       model_name: 'companyobjectives',
       example: {

--- a/exportplan/templates/exportplan/sections/business-risk.html
+++ b/exportplan/templates/exportplan/sections/business-risk.html
@@ -1,5 +1,4 @@
 {% extends 'exportplan/section.html' %}
-{% load to_json %}
 {% load static %}
 
 {% block intro_title %}Business risk{%endblock %}

--- a/exportplan/templates/exportplan/sections/funding-and-credit.html
+++ b/exportplan/templates/exportplan/sections/funding-and-credit.html
@@ -67,7 +67,7 @@ There are however lots of financing options available to help you export, the ri
     element: element,
     currency: 'GBP',
     formData: {{ funding_and_credit|to_json }},
-    currentSection: {{ current_section|to_json}},
+    currentSection: {{ current_section|to_json }},
     lessonDetails: {{ lesson_details|safe }},
   })
 
@@ -79,7 +79,7 @@ There are however lots of financing options available to help you export, the ri
     options: {{ funding_options|to_json }},
     formData: {{ funding_credit_options|to_json }},
     companyexportplan: {{ export_plan.pk }},
-    currentSection: {{ current_section|to_json}},
+    currentSection: {{ current_section|to_json }},
     lessonDetails: {{ lesson_details|safe }},
   })
 </script>

--- a/exportplan/templates/exportplan/sections/getting-paid.html
+++ b/exportplan/templates/exportplan/sections/getting-paid.html
@@ -50,9 +50,9 @@
     magna.createGettingPaid({
       element: document.getElementById('getting-paid'),
       field: 'getting_paid',
-      currentSection: {{ current_section|to_json}},
-      lessonDetails: {{ lesson_details|safe }},
-      formData: {{getting_paid_data|to_json|safe}},
+      currentSection: {{ current_section|to_json }},
+      lessonDetails: {{ lesson_details }},
+      formData: {{ getting_paid_data|to_json }},
       formFields: [
         {
             field: 'payment_method',

--- a/exportplan/templates/exportplan/sections/marketing-approach.html
+++ b/exportplan/templates/exportplan/sections/marketing-approach.html
@@ -77,7 +77,7 @@
       element: document.getElementById('target-age-groups'),
       groups: {{ target_age_group_choices|safe }},
       selected: {{ selected_age_groups|to_json }},
-      currentSection: {{ current_section|to_json}},
+      currentSection: {{ current_section|to_json }},
     })
 
     magna.createSpendingAndResources({

--- a/exportplan/templates/exportplan/sections/target-markets-research.html
+++ b/exportplan/templates/exportplan/sections/target-markets-research.html
@@ -1,6 +1,5 @@
 {% extends 'exportplan/section.html' %}
 {% load static %}
-{% load to_json %}
 
 {% block intro_title %}Target market research{% endblock %}
 {% block intro_description %}In this part of your Export Plan you'll record what you know about the target country and the market it has for your product.{% endblock %}


### PR DESCRIPTION
All the export plan text fields seem to translate an apostrophe to html encoding.

It seems the culprit is the to_json template tag which does a replace of apostrophes with malice aforethought.
As I originally checked that tag in and I've no idea why I put the translation in, seems safe to get rid!

This PR also has a bit of tidying - removing to_json from templates where it's not used and removing the '|safe' filter as to_json already returns a safestring.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-3846
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
