### PR TITLE
GP2-3834 PDF: Force order of existing export plan business trips 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - GP2-3844 - [HOTFIX] savingcms pages
 
 ### Bugs fixed
-- GP2-2834 - Export plan - sort risks and trips
+- GP2-3834 - Export plan - sort risks and trips
 - GP2-3818 - WTE mobile layout without flex for safari
 - GP2-3846 - Remove html encoding from apostrophes in to_json tag
 - GP2-3823 - Remove EP business objectives date validation

--- a/exportplan/context.py
+++ b/exportplan/context.py
@@ -130,4 +130,6 @@ class PDFContextProvider(BaseContextProvider):
                 'contact_detail': contact_dict,
             }
         )
+        # GP2-2834 - Fix any mis-ordering of existing EP trips
+        (context['export_plan'].data.get('business_trips') or []).sort(key=lambda trip: trip.get('pk'))
         return context


### PR DESCRIPTION
Another PR on this ticket added ordering of business objectives and trips to the FE so that the lists are always displayed and saved in the right order.
This however doesn't fix the export plan for existing export plans which may be wrongly ordered. This PR fixes that.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-3834
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
