### PR TITLE
GP2-3858 - Fix export plan payment terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - GP2-3844 - [HOTFIX] savingcms pages
 
 ### Bugs fixed
+- GP2-3858 - Fix export plan payment terms
 - GP2-3834 - Export plan - sort risks and trips
 - GP2-3818 - WTE mobile layout without flex for safari
 - GP2-3846 - Remove html encoding from apostrophes in to_json tag

--- a/exportplan/templates/exportplan/sections/business-objectives.html
+++ b/exportplan/templates/exportplan/sections/business-objectives.html
@@ -65,7 +65,7 @@
           example: {
             content: 'Dove Gin is established and selling well in the UK. However, the domestic gin market is now fiercely competitive. We feel that to realise our goal of doubling turnover in the next 3 years we need to look at new markets to assure this growth. Dove has a uniquely British, crafted appeal that is well placed to attract drinkers in overseas markets. We feel that the potential to widen our customer base, especially in the still-developing Asian and Australasian craft gin scene, is immense.'
           },
-          lesson: magna.formatLessonLearned({{ lesson_details|safe }}, {{ current_section|to_json }}, 0),
+          lesson: magna.formatLessonLearned({{ lesson_details|to_json }}, {{ current_section|to_json }}, 0),
         },
       ],
     })

--- a/exportplan/templates/exportplan/sections/costs-and-pricing.html
+++ b/exportplan/templates/exportplan/sections/costs-and-pricing.html
@@ -273,7 +273,7 @@ product. <br /><br />This page will help you plan ahead and keep track of the up
     currencies: {{ currency_choices| safe }},
     currency: 'GBP',
     currentSection: {{ current_section| to_json}},
-    lessonDetails: {{ lesson_details| safe }},
+    lessonDetails: {{ lesson_details| to_json }},
     })
 </script>
 {% endblock %}

--- a/exportplan/templates/exportplan/sections/funding-and-credit.html
+++ b/exportplan/templates/exportplan/sections/funding-and-credit.html
@@ -68,7 +68,7 @@ There are however lots of financing options available to help you export, the ri
     currency: 'GBP',
     formData: {{ funding_and_credit|to_json }},
     currentSection: {{ current_section|to_json }},
-    lessonDetails: {{ lesson_details|safe }},
+    lessonDetails: {{ lesson_details|to_json }},
   })
 
   element = document.getElementById('finance-funding-credit-options');
@@ -80,7 +80,7 @@ There are however lots of financing options available to help you export, the ri
     formData: {{ funding_credit_options|to_json }},
     companyexportplan: {{ export_plan.pk }},
     currentSection: {{ current_section|to_json }},
-    lessonDetails: {{ lesson_details|safe }},
+    lessonDetails: {{ lesson_details|to_json }},
   })
 </script>
 {% endblock %}

--- a/exportplan/templates/exportplan/sections/getting-paid.html
+++ b/exportplan/templates/exportplan/sections/getting-paid.html
@@ -51,7 +51,7 @@
       element: document.getElementById('getting-paid'),
       field: 'getting_paid',
       currentSection: {{ current_section|to_json }},
-      lessonDetails: {{ lesson_details }},
+      lessonDetails: {{ lesson_details|to_json }},
       formData: {{ getting_paid_data|to_json }},
       formFields: [
         {

--- a/exportplan/templates/exportplan/sections/marketing-approach.html
+++ b/exportplan/templates/exportplan/sections/marketing-approach.html
@@ -108,7 +108,7 @@
             label: 'Route to market',
             options: {{ route_choices|to_json }},
             name: 'route',
-            lesson: magna.formatLessonLearned({{ lesson_details|safe }}, {{ current_section|to_json}}, 0),
+            lesson: magna.formatLessonLearned({{ lesson_details|to_json }}, {{ current_section|to_json}}, 0),
           },
           {
             label: 'How will you promote your product?',


### PR DESCRIPTION
Adds a json filter to the rendering of lesson blocks inside script tags on payments page of EP.
The actual instance causing the issue had no filter (I think it was my bad) but I've changed others to use |to_json rather than |safe
We should always use |to_json really as it will correctly render booleans and None values in json rather then the python to-string.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-3858
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
