### PR TITLE
Gls 112 trade barriers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 - GLS-113 - add extra items and heading to Country Guide CTA links
+- GLS-112 - add Trade barriers and Duties and customs content
 
 ## [2.4.1](https://github.com/uktrade/great-cms/releases/tag/2.4.1)
 

--- a/domestic/management/commands/organise_country_guide_ctas.py
+++ b/domestic/management/commands/organise_country_guide_ctas.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
             # ignore if not already set otherwise reuse
             export_opportunities_cta = next((x for x in intro_ctas if 'live export opportunities' in x['title']), None)
             if export_opportunities_cta:
-                guide.intro_cta_one_title = 'View live export opportunities'
+                guide.intro_cta_one_title = 'View export opportunities'
                 guide.intro_cta_one_link = export_opportunities_cta['link']
             else:
                 guide.intro_cta_one_title = ''
@@ -53,7 +53,7 @@ class Command(BaseCommand):
 
             # Link for Export events should be reused if it doesn't match old url. Derive new link otherwise
             export_events_cta = next((x for x in intro_ctas if 'export events' in x['title']), None)
-            guide.intro_cta_two_title = 'Find export events'
+            guide.intro_cta_two_title = 'Find latest export events'
             if export_events_cta and 'events.great.gov.uk/' not in export_events_cta['link']:
                 guide.intro_cta_two_link = export_events_cta['link']
                 dry_print(f'{guide.heading}: found custom export events link ({guide.intro_cta_two_link})')
@@ -62,7 +62,7 @@ class Command(BaseCommand):
 
             # Link for factsheet is for now based on start letter of country name
             letter_range = factsheets_links[next(x for x in factsheets_links if guide.heading[0] in x)]
-            guide.intro_cta_three_title = 'View trade and investment factsheets'
+            guide.intro_cta_three_title = 'View latest trade statistics'
             guide.intro_cta_three_link = f'https://www.gov.uk/government/statistics/trade-and-investment-factsheets-partner-names-beginning-with-{letter_range}'  # noqa
 
             # Link for online marketplace cannot be derived from existing data,

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -849,7 +849,6 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
         iso2 = getattr(self.country, 'iso2', None)
         if iso2:
             return f'https://www.check-duties-customs-exporting-goods.service.gov.uk/searchproduct?d={iso2}'
-        return None
 
     @property
     def trade_barriers_link(self):
@@ -859,7 +858,11 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
                 f'https://www.check-international-trade-barriers.service.gov.uk/barriers/'
                 f'?resolved=0&location={iso2.lower()}'
             )
-        return None
+
+    @property
+    def trade_barriers_resolved_link(self):
+        if self.trade_barriers_link:
+            return self.trade_barriers_link.replace('resolved=0', 'resolved=1')
 
     @property
     def intro_ctas(self):

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -40,6 +40,9 @@ from domestic import cms_panels, forms as domestic_forms
 from domestic.helpers import build_route_context, get_lesson_completion_status
 from exportplan.core import helpers as exportplan_helpers
 
+DUTIES_AND_CUSTOMS_SERVICE = 'https://www.check-duties-customs-exporting-goods.service.gov.uk'
+TRADE_BARRIERS_SERVICE = 'https://www.check-international-trade-barriers.service.gov.uk/barriers/'
+
 
 class DataLayerMixin(
     Page,
@@ -846,22 +849,27 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
 
     @property
     def duties_and_customs_link(self):
+        link = DUTIES_AND_CUSTOMS_SERVICE
+
         iso2 = getattr(self.country, 'iso2', None)
         if iso2:
-            return f'https://www.check-duties-customs-exporting-goods.service.gov.uk/searchproduct?d={iso2}'
+            link += f'/searchproduct?d={iso2}'
+
+        return link
 
     @property
     def trade_barriers_link(self):
+        link = TRADE_BARRIERS_SERVICE
+
         iso2 = getattr(self.country, 'iso2', None)
         if iso2:
-            return (
-                f'https://www.check-international-trade-barriers.service.gov.uk/barriers/'
-                f'?resolved=0&location={iso2.lower()}'
-            )
+            link += f'?resolved=0&location={iso2.lower()}'
+
+        return link
 
     @property
     def trade_barriers_resolved_link(self):
-        if self.trade_barriers_link:
+        if 'resolved=0' in self.trade_barriers_link:
             return self.trade_barriers_link.replace('resolved=0', 'resolved=1')
 
     @property

--- a/domestic/templates/domestic/country_guide.html
+++ b/domestic/templates/domestic/country_guide.html
@@ -28,7 +28,7 @@
       {% if page.intro_ctas %}
       <div class="column-quarter-l links">
         {% if FEATURE_SHOW_MARKET_GUIDE_BAU_LINKS %}
-          <h2 class="heading-medium margin-top-0">Related services:</h2>
+          <h2 class="heading-medium margin-top-0">Related services</h2>
           <div class="panel-vertical-narrow content-list padding-top-30">
             <ul id="country-guide-intro-ctas">
               {% for cta in page.intro_ctas %}
@@ -96,25 +96,22 @@
       <div class="grid-row">
         <div class="column-half-l padding-bottom-30">
           <h2 class="heading-large padding-top-0">Check for trade barriers</h2>
+
           <p>Trade barriers, such as tariffs or taxes, can raise costs, cause delays, or even stop you from exporting. Check for any issues that may impact your business when exporting.</p>
 
-          {% if page.trade_barriers_link %}
-            <p><a class="heading-small link" href="{{ page.trade_barriers_link }}">See current trade barriers</a></p>
+          <p><a class="heading-small link" href="{{ page.trade_barriers_link }}">See current trade barriers</a></p>
+
+          {% if page.trade_barriers_resolved_link %}
             <p><a class="heading-small link" href="{{ page.trade_barriers_resolved_link }}">See resolved trade barriers</a></p>
-          {% else %}
-            <p><a class="heading-small link" href="https://www.check-international-trade-barriers.service.gov.uk/active/">Search trade barriers</a></p>
           {% endif %}
         </div>
 
         <div class="column-half-l padding-bottom-30">
           <h2 class="heading-large padding-top-0">Check duties and customs</h2>
+
           <p>Find information on how to export goods from the UK. View the duties, rules, restrictions, and the documents you need for your products.</p>
 
-          {% if page.duties_and_customs_link %}
-            <p><a class="heading-small link" href="{{ page.duties_and_customs_link }}">See current duties and customs procedures</a></p>
-          {% else %}
-            <p><a class="heading-small link" href="https://www.check-duties-customs-exporting-goods.service.gov.uk/selectdest">Search duties and customs procedures</a></p>
-          {% endif %}
+          <p><a class="heading-small link" href="{{ page.duties_and_customs_link }}">See current duties and customs procedures</a></p>
         </div>
       </div>
     </div>

--- a/domestic/templates/domestic/country_guide.html
+++ b/domestic/templates/domestic/country_guide.html
@@ -91,6 +91,35 @@
     {% endif %}
   {% endif %}
 
+  <section class="padding-top-60 padding-bottom-30">
+    <div class="container">
+      <div class="grid-row">
+        <div class="column-half-l padding-bottom-30">
+          <h2 class="heading-large padding-top-0">Check for trade barriers</h2>
+          <p>Trade barriers, such as tariffs or quotas, can add costs, cause delays, or even prevent you exporting to an overseas market. Make sure you check for any current or resolved trade barriers as part of your export planning.</p>
+
+          {% if page.trade_barriers_link %}
+            <p><a class="heading-small link" href="{{ page.trade_barriers_link }}">See current trade barriers</a></p>
+            <p><a class="heading-small link" href="{{ page.trade_barriers_resolved_link }}">See resolved trade barriers</a></p>
+          {% else %}
+            <p><a class="heading-small link" href="https://www.check-international-trade-barriers.service.gov.uk/active/">Search trade barriers</a></p>
+          {% endif %}
+        </div>
+
+        <div class="column-half-l padding-bottom-30">
+          <h2 class="heading-large padding-top-0">Check duties and customs</h2>
+          <p>Find information on GOV.UK about how to move goods from the UK to the rest of the world. Use this service to check: rules and restrictions, tax and duty rates, what exporting documents you need.</p>
+
+          {% if page.duties_and_customs_link %}
+            <p><a class="heading-small link" href="{{ page.duties_and_customs_link }}">Check duties and customs procedures for exporting goods</a></p>
+          {% else %}
+            <p><a class="heading-small link" href="https://www.check-duties-customs-exporting-goods.service.gov.uk/selectdest">Search duties and customs procedures for exporting goods</a></p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </section>
+
 {% if page.fact_sheet_title %}
 <section id="country-guide-section-three" class="section-three background-stone-30 padding-top-90 padding-bottom-60">
   <div class="container">
@@ -135,17 +164,18 @@
       </div>
     </div>
     <div class="grid-row">
-      <div class="column-full column-half-l column-third-xl margin-bottom-30 margin-bottom-0-xl">
-        {% static 'images/country-guide-advice.png' as need_help_image_url %}
-        {% slugurl 'advice' as advice_url %}
-        {% include 'components/cta_card.html' with with_arrow=True image_url=need_help_image_url text="Read more advice about doing business abroad" url=advice_url %}
-      </div>
-      {% if page.duties_and_custom_procedures_cta_link %}
+      {% static 'images/country-guide-gov-uk.png' as market_guide_image_url %}
+      {% if page.trade_barriers_link %}
         <div class="column-full column-half-l column-third-xl margin-bottom-30 margin-bottom-0-xl">
-          {% static 'images/country-guide-gov-uk.png' as market_guide_image_url %}
-          {% include 'components/cta_card.html' with with_arrow=True image_url=market_guide_image_url text='Check duties and customs procedures for exporting goods' url=page.duties_and_custom_procedures_cta_link external_link=True %}
+          {% include 'components/cta_card.html' with with_arrow=True image_url=market_guide_image_url text="Check for current trade barriers" url=page.trade_barriers_link %}
         </div>
       {% endif %}
+      {% if page.duties_and_customs_link %}
+        <div class="column-full column-half-l column-third-xl margin-bottom-30 margin-bottom-0-xl">
+          {% include 'components/cta_card.html' with with_arrow=True image_url=market_guide_image_url text='Check duties and customs procedures for exporting goods' url=page.duties_and_customs_link external_link=True %}
+        </div>
+      {% endif %}
+
       {% if FEATURE_SHOW_MARKET_GUIDE_BAU_LINKS %}
       <div class="column-full column-half-l column-third-xl margin-bottom-0">
         {% static 'images/country-guide-contact.png' as contact_us_image_url %}

--- a/domestic/templates/domestic/country_guide.html
+++ b/domestic/templates/domestic/country_guide.html
@@ -28,7 +28,7 @@
       {% if page.intro_ctas %}
       <div class="column-quarter-l links">
         {% if FEATURE_SHOW_MARKET_GUIDE_BAU_LINKS %}
-          <h2 class="heading-medium margin-top-0">More on {{ page.heading }}</h2>
+          <h2 class="heading-medium margin-top-0">Related services:</h2>
           <div class="panel-vertical-narrow content-list padding-top-30">
             <ul id="country-guide-intro-ctas">
               {% for cta in page.intro_ctas %}
@@ -96,7 +96,7 @@
       <div class="grid-row">
         <div class="column-half-l padding-bottom-30">
           <h2 class="heading-large padding-top-0">Check for trade barriers</h2>
-          <p>Trade barriers, such as tariffs or quotas, can add costs, cause delays, or even prevent you exporting to an overseas market. Make sure you check for any current or resolved trade barriers as part of your export planning.</p>
+          <p>Trade barriers, such as tariffs or taxes, can raise costs, cause delays, or even stop you from exporting. Check for any issues that may impact your business when exporting.</p>
 
           {% if page.trade_barriers_link %}
             <p><a class="heading-small link" href="{{ page.trade_barriers_link }}">See current trade barriers</a></p>
@@ -108,12 +108,12 @@
 
         <div class="column-half-l padding-bottom-30">
           <h2 class="heading-large padding-top-0">Check duties and customs</h2>
-          <p>Find information on GOV.UK about how to move goods from the UK to the rest of the world. Use this service to check: rules and restrictions, tax and duty rates, what exporting documents you need.</p>
+          <p>Find information on how to export goods from the UK. View the duties, rules, restrictions, and the documents you need for your products.</p>
 
           {% if page.duties_and_customs_link %}
-            <p><a class="heading-small link" href="{{ page.duties_and_customs_link }}">Check duties and customs procedures for exporting goods</a></p>
+            <p><a class="heading-small link" href="{{ page.duties_and_customs_link }}">See current duties and customs procedures</a></p>
           {% else %}
-            <p><a class="heading-small link" href="https://www.check-duties-customs-exporting-goods.service.gov.uk/selectdest">Search duties and customs procedures for exporting goods</a></p>
+            <p><a class="heading-small link" href="https://www.check-duties-customs-exporting-goods.service.gov.uk/selectdest">Search duties and customs procedures</a></p>
           {% endif %}
         </div>
       </div>
@@ -164,17 +164,11 @@
       </div>
     </div>
     <div class="grid-row">
-      {% static 'images/country-guide-gov-uk.png' as market_guide_image_url %}
-      {% if page.trade_barriers_link %}
-        <div class="column-full column-half-l column-third-xl margin-bottom-30 margin-bottom-0-xl">
-          {% include 'components/cta_card.html' with with_arrow=True image_url=market_guide_image_url text="Check for current trade barriers" url=page.trade_barriers_link %}
-        </div>
-      {% endif %}
-      {% if page.duties_and_customs_link %}
-        <div class="column-full column-half-l column-third-xl margin-bottom-30 margin-bottom-0-xl">
-          {% include 'components/cta_card.html' with with_arrow=True image_url=market_guide_image_url text='Check duties and customs procedures for exporting goods' url=page.duties_and_customs_link external_link=True %}
-        </div>
-      {% endif %}
+      <div class="column-full column-half-l column-third-xl margin-bottom-30 margin-bottom-0-xl">
+        {% static 'images/country-guide-advice.png' as need_help_image_url %}
+        {% slugurl 'advice' as advice_url %}
+        {% include 'components/cta_card.html' with with_arrow=True image_url=need_help_image_url text="Read more advice about doing business abroad" url=advice_url %}
+      </div>
 
       {% if FEATURE_SHOW_MARKET_GUIDE_BAU_LINKS %}
       <div class="column-full column-half-l column-third-xl margin-bottom-0">

--- a/tests/unit/domestic/management/commands/test_organise_country_guide_ctas.py
+++ b/tests/unit/domestic/management/commands/test_organise_country_guide_ctas.py
@@ -37,17 +37,17 @@ def test_organise_ctas(domestic_homepage):
 
     guide.refresh_from_db()
 
-    assert guide.intro_cta_one_title == 'View live export opportunities'
+    assert guide.intro_cta_one_title == 'View export opportunities'
     assert (
         guide.intro_cta_one_link == 'https://www.great.gov.uk/export-opportunities/opportunities?s=&areas%5B%5D'
         '=antigua-and-barbuda&commit=Find+opportunities'
     )
-    assert guide.intro_cta_two_title == 'Find export events'
+    assert guide.intro_cta_two_title == 'Find latest export events'
     assert (
         guide.intro_cta_two_link == 'https://www.events.great.gov.uk/ehome/trade-events-calendar/all-events'
         '/?keyword=Antigua%20and%20Barbuda'
     )
-    assert guide.intro_cta_three_title == 'View trade and investment factsheets'
+    assert guide.intro_cta_three_title == 'View latest trade statistics'
     assert (
         guide.intro_cta_three_link == 'https://www.gov.uk/government/statistics/trade-and-investment-factsheets'
         '-partner-names-beginning-with-a-or-b'
@@ -81,9 +81,9 @@ def test_organise_ctas_custom_events_link(domestic_homepage):
 
     assert guide.intro_cta_one_title == ''
     assert guide.intro_cta_one_link == ''
-    assert guide.intro_cta_two_title == 'Find export events'
+    assert guide.intro_cta_two_title == 'Find latest export events'
     assert guide.intro_cta_two_link == 'https://example.org/events'
-    assert guide.intro_cta_three_title == 'View trade and investment factsheets'
+    assert guide.intro_cta_three_title == 'View latest trade statistics'
     assert (
         guide.intro_cta_three_link == 'https://www.gov.uk/government/statistics/trade-and-investment-factsheets'
         '-partner-names-beginning-with-a-or-b'

--- a/tests/unit/domestic/test_models.py
+++ b/tests/unit/domestic/test_models.py
@@ -324,7 +324,6 @@ def test_fact_sheet_columns(
     domestic_homepage,
     domestic_site,
 ):
-
     page = CountryGuidePageFactory(
         parent=domestic_homepage,
         title='Test GCP',
@@ -489,6 +488,57 @@ def test_intro_ctas(
     assert page.intro_ctas == expected
 
 
+@pytest.mark.django_db
+def test_trade_and_duties_links(domestic_homepage):
+    country = CountryFactory(name='France', slug='france', iso2='FR')
+
+    page = CountryGuidePageFactory(
+        parent=domestic_homepage,
+        title='Test GCP',
+        country=country,
+    )
+
+    assert (
+        page.duties_and_customs_link == 'https://www.check-duties-customs-exporting-goods.service.gov.uk'
+        '/searchproduct?d=FR'
+    )
+    assert (
+        page.trade_barriers_link == 'https://www.check-international-trade-barriers.service.gov.uk'
+        '/barriers/?resolved=0&location=fr'
+    )
+    assert (
+        page.trade_barriers_resolved_link == 'https://www.check-international-trade-barriers.service.gov.uk'
+        '/barriers/?resolved=1&location=fr'
+    )
+
+
+@pytest.mark.django_db
+def test_trade_and_duties_links_no_iso(domestic_homepage):
+    country = CountryFactory(name='France', slug='france')
+
+    page = CountryGuidePageFactory(
+        parent=domestic_homepage,
+        title='Test GCP',
+        country=country,
+    )
+
+    assert page.duties_and_customs_link == 'https://www.check-duties-customs-exporting-goods.service.gov.uk'
+    assert page.trade_barriers_link == 'https://www.check-international-trade-barriers.service.gov.uk/barriers/'
+    assert page.trade_barriers_resolved_link is None
+
+
+@pytest.mark.django_db
+def test_trade_and_duties_links_no_country(domestic_homepage):
+    page = CountryGuidePageFactory(
+        parent=domestic_homepage,
+        title='Test GCP',
+    )
+
+    assert page.duties_and_customs_link == 'https://www.check-duties-customs-exporting-goods.service.gov.uk'
+    assert page.trade_barriers_link == 'https://www.check-international-trade-barriers.service.gov.uk/barriers/'
+    assert page.trade_barriers_resolved_link is None
+
+
 @pytest.mark.parametrize(
     'related_page_data',
     (
@@ -516,7 +566,6 @@ def test_country_guide_page__related_pages(
     domestic_homepage,
     domestic_site,
 ):
-
     kwargs = {}
 
     for data in related_page_data:
@@ -569,7 +618,6 @@ def test_main_statistics_validation(blocks_to_create, expected_exception_message
     ),
 )
 def test_industry_accordions_validation(blocks_to_create, expected_exception_message):
-
     value = [mock.Mock() for x in range(blocks_to_create)]
 
     if expected_exception_message:
@@ -591,7 +639,6 @@ def test_base_content_page__ancestors_in_app(
     domestic_homepage,
     domestic_site,
 ):
-
     advice_topic_page = TopicLandingPageFactory(
         title='Advice',
         parent=domestic_homepage,
@@ -681,7 +728,6 @@ class TopicLandingPageTests(SetUpLocaleMixin, WagtailPageTests):
         self.assertEqual(retrieved_page_1.slug, 'advice')
 
     def test_child_pages(self):
-
         advice_topic_page = TopicLandingPageFactory(
             title='Advice',
         )
@@ -885,7 +931,6 @@ class MarketsTopicLandingPageTests(SetUpLocaleMixin, WagtailPageTests):
 
 
 class MarketsTopicLandingPageFilteringTests(SetUpLocaleMixin, WagtailPageTests):
-
     fixtures = ['markets_filtering_fixtures.json']
 
     def setUp(self):
@@ -1223,7 +1268,6 @@ class ArticlePageTests(SetUpLocaleMixin, WagtailPageTests):
         )
 
     def test_get_context(self):
-
         request = RequestFactory().get('/example-path/')
 
         page = ArticlePageFactory(
@@ -1284,7 +1328,6 @@ def test_article_page__related_pages(
     domestic_homepage,
     domestic_site,
 ):
-
     kwargs = {}
 
     for data in related_page_data:
@@ -1391,7 +1434,6 @@ class PerformanceDashboardPageTests(SetUpLocaleMixin, WagtailPageTests):
         )
 
     def test_get_child_dashboards(self):
-
         main_dash = PerformanceDashboardPageFactory(
             product_link=service_urls.SERVICES_GREAT_DOMESTIC,
         )
@@ -1498,7 +1540,6 @@ def test_performance_dashboard_auto_population(product_link, expected, en_locale
 
 
 def test_all_domestic_models_implement_ga360_mixins():
-
     from domestic import models as domestic_models
 
     module_attributes = dir(domestic_models)
@@ -1527,7 +1568,6 @@ def test_all_domestic_models_implement_ga360_mixins():
 
 @override_settings(API_CACHE_DISABLED=True)
 class GreatDomesticHomePageTests(SetUpLocaleMixin, WagtailPageTests):
-
     fixtures = ['markets_filtering_fixtures.json']
 
     def setUp(self):
@@ -1793,7 +1833,6 @@ def test_great_domestic_homepage_geo_redirection__integration(
 
 @pytest.mark.django_db
 def test_great_domestic_homepage_magna_ctas_labels(root_page, client, user):
-
     # Show that the CTAs to Magna/personalised content only have labels shown
     # to signed-out users
     homepage = GreatDomesticHomePageFactory(

--- a/tests/unit/domestic/test_models.py
+++ b/tests/unit/domestic/test_models.py
@@ -392,6 +392,14 @@ def test_fact_sheet_columns(
                     'title': 'CTA 3 title',
                     'link': 'https://example.com/3/',
                 },
+                {
+                    'title': 'Check duties and customs',
+                    'link': 'https://www.check-duties-customs-exporting-goods.service.gov.uk',
+                },
+                {
+                    'title': 'Check for trade barriers',
+                    'link': 'https://www.check-international-trade-barriers.service.gov.uk/barriers/',
+                },
             ],
         ),
         (
@@ -404,11 +412,28 @@ def test_fact_sheet_columns(
                     'title': 'CTA 2 title',
                     'link': 'https://example.com/2/',
                 },
+                {
+                    'title': 'Check duties and customs',
+                    'link': 'https://www.check-duties-customs-exporting-goods.service.gov.uk',
+                },
+                {
+                    'title': 'Check for trade barriers',
+                    'link': 'https://www.check-international-trade-barriers.service.gov.uk/barriers/',
+                },
             ],
         ),
         (
             {},
-            [],
+            [
+                {
+                    'title': 'Check duties and customs',
+                    'link': 'https://www.check-duties-customs-exporting-goods.service.gov.uk',
+                },
+                {
+                    'title': 'Check for trade barriers',
+                    'link': 'https://www.check-international-trade-barriers.service.gov.uk/barriers/',
+                },
+            ],
         ),
         (
             {
@@ -421,6 +446,14 @@ def test_fact_sheet_columns(
                 {
                     'title': 'CTA 1 title',
                     'link': 'https://example.com/1/',
+                },
+                {
+                    'title': 'Check duties and customs',
+                    'link': 'https://www.check-duties-customs-exporting-goods.service.gov.uk',
+                },
+                {
+                    'title': 'Check for trade barriers',
+                    'link': 'https://www.check-international-trade-barriers.service.gov.uk/barriers/',
                 },
             ],
         ),


### PR DESCRIPTION
Requires #1745 

Adds the Trade barriers and Duties and customs procedures content underneath the accordion. Updates the 'Next steps' cards to show both Trade barriers and Duties and customs links.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GLS-112
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
