### PR TITLE
GLS-113 Add command to update all factsheets links from govuk content API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 - GLS-113 - add extra items and heading to Country Guide CTA links
+- GLS-113 - add command to update factsheets links from govuk content API
 - GLS-112 - add Trade barriers and Duties and customs content
 
 ## [2.4.1](https://github.com/uktrade/great-cms/releases/tag/2.4.1)

--- a/domestic/management/commands/update_factsheets_cta_links.py
+++ b/domestic/management/commands/update_factsheets_cta_links.py
@@ -41,19 +41,22 @@ class Command(BaseCommand):
 
         parens_regex = re.compile(r'(The |\(.*\)|,.*)')
         for guide in CountryGuidePage.objects.all():
-            # Remove extra info in parens or after comma, or any preceding 'The ' (e.g. 'The Netherlands')
-            trimmed_title = parens_regex.sub('', guide.title).strip()
-
-            # Ensure name is matched exactly (e.g. do not match 'Indian' for 'India')
-            pdf = next((x for x in attachments if re.search(rf'{trimmed_title}(?!\w)', x['title'])), None)
-
-            if pdf is not None:
-                if not options['dry_run']:
-                    guide.intro_cta_three_link = pdf['url']
-                    guide.save()
-                    updated += 1
+            if guide.intro_cta_three_title != 'View latest trade statistics':
+                self.stdout.write(f'{guide.title}: CTA not present or modified, not updating')
             else:
-                self.stdout.write(f'{guide.title}: no factsheet found')
+                # Remove extra info in parens or after comma, or any preceding 'The ' (e.g. 'The Netherlands')
+                trimmed_title = parens_regex.sub('', guide.title).strip()
+
+                # Ensure name is matched exactly (e.g. do not match 'Indian' for 'India')
+                pdf = next((x for x in attachments if re.search(rf'{trimmed_title}(?!\w)', x['title'])), None)
+
+                if pdf is not None:
+                    if not options['dry_run']:
+                        guide.intro_cta_three_link = pdf['url']
+                        guide.save()
+                        updated += 1
+                else:
+                    self.stdout.write(f'{guide.title}: no factsheet found')
 
         if options['dry_run'] is True:
             self.stdout.write(self.style.WARNING('Dry run -- no data updated.'))

--- a/domestic/management/commands/update_factsheets_cta_links.py
+++ b/domestic/management/commands/update_factsheets_cta_links.py
@@ -1,0 +1,63 @@
+import argparse
+import re
+
+import requests
+from django.core.management import BaseCommand, CommandError
+
+from domestic.models import CountryGuidePage
+
+CONTENT_API_FACTSHEETS_LANDING = 'https://www.gov.uk/api/content/government/collections/trade-and-investment-factsheets'
+
+
+class Command(BaseCommand):
+    help = 'Update factsheets CTA links based on gov.uk content API'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry_run',
+            action=argparse.BooleanOptionalAction,
+            default=False,
+            help='Show summary output only, do not update data',
+        )
+
+    def handle(self, *args, **options):  # noqa: C901
+        # Get all links from the API
+        attachments = []
+        landing_page = requests.get(CONTENT_API_FACTSHEETS_LANDING)
+
+        if landing_page.status_code != 200:
+            raise CommandError('Could not get data from GOVUK content API.')
+
+        for doc in landing_page.json()['links']['documents']:
+            if doc['document_type'] == 'official_statistics':
+                collection = requests.get(doc['api_url'])
+                if collection.status_code != 200:
+                    raise CommandError('Could not get data from GOVUK content API.')
+                attachments += collection.json()['details']['attachments']
+
+        updated = 0
+
+        self.stdout.write(f'Loaded {len(attachments)} factsheets details from API')
+
+        parens_regex = re.compile(r'(The |\(.*\)|,.*)')
+        for guide in CountryGuidePage.objects.all():
+            # Remove extra info in parens or after comma, or any preceding 'The ' (e.g. 'The Netherlands')
+            trimmed_title = parens_regex.sub('', guide.title).strip()
+
+            # Ensure name is matched exactly (e.g. do not match 'Indian' for 'India')
+            pdf = next((x for x in attachments if re.search(rf'{trimmed_title}(?!\w)', x['title'])), None)
+
+            if pdf is not None:
+                if not options['dry_run']:
+                    guide.intro_cta_three_link = pdf['url']
+                    guide.save()
+                    updated += 1
+            else:
+                self.stdout.write(f'{guide.title}: no factsheet found')
+
+        if options['dry_run'] is True:
+            self.stdout.write(self.style.WARNING('Dry run -- no data updated.'))
+        else:
+            self.stdout.write(self.style.SUCCESS(f'Successfully updated {updated} Country Guides'))
+
+        self.stdout.write(self.style.SUCCESS('All done, bye!'))

--- a/tests/unit/domestic/management/commands/test_update_factsheets_cta_links.py
+++ b/tests/unit/domestic/management/commands/test_update_factsheets_cta_links.py
@@ -67,6 +67,7 @@ CONTENT_API_M_TO_Z_RESPONSE = {
 @pytest.mark.parametrize(
     'data, expected',
     (
+        ({'title': 'Antigua and Barbuda', 'intro_cta_three_title': '', 'intro_cta_three_link': ''}, ''),
         (
             {'title': 'Antigua and Barbuda', 'intro_cta_three_link': 'http://original-link'},
             'https://assets.publishing.service.gov.uk/124/antigua-and-barbuda-factsheet-2022-02-18.pdf',
@@ -103,7 +104,8 @@ def test_update_factsheets_cta_links(data, expected, domestic_homepage, requests
     requests_mock.get('https://www.gov.uk/api/factsheets-a-to-l', json=CONTENT_API_A_TO_L_RESPONSE)
     requests_mock.get('https://www.gov.uk/api/factsheets-m-to-z', json=CONTENT_API_M_TO_Z_RESPONSE)
 
-    guide = CountryGuidePageFactory(parent=domestic_homepage, **data)
+    intro_cta_three_title = data.pop('intro_cta_three_title', 'View latest trade statistics')
+    guide = CountryGuidePageFactory(parent=domestic_homepage, intro_cta_three_title=intro_cta_three_title, **data)
     guide.save()
 
     call_command('update_factsheets_cta_links', stdout=StringIO())

--- a/tests/unit/domestic/management/commands/test_update_factsheets_cta_links.py
+++ b/tests/unit/domestic/management/commands/test_update_factsheets_cta_links.py
@@ -1,0 +1,113 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from tests.unit.domestic.factories import CountryGuidePageFactory
+
+CONTENT_API_LANDING_RESPONSE = {
+    'links': {
+        'documents': [
+            {
+                'document_type': 'official_statistics',
+                'api_url': 'https://www.gov.uk/api/factsheets-a-to-l',
+            },
+            {'document_type': 'official_statistics', 'api_url': 'https://www.gov.uk/api/factsheets-m-to-z'},
+            {'document_type': 'research', 'api_url': 'https://www.gov.uk/api/methodology-report'},
+        ]
+    }
+}
+CONTENT_API_A_TO_L_RESPONSE = {
+    'details': {
+        'attachments': [
+            {
+                'url': 'https://assets.publishing.service.gov.uk/123/afghanistan-factsheet-2022-02-18.pdf',
+                'title': 'Trade and investment factsheets: Afghanistan',
+            },
+            {
+                'url': 'https://assets.publishing.service.gov.uk/124/antigua-and-barbuda-factsheet-2022-02-18.pdf',
+                'title': 'Trade and investment factsheets: Antigua and Barbuda',
+            },
+            {
+                'url': 'https://assets.publishing.service.gov.uk/130/hong-kong-sar-factsheet-2022-02-18.pdf',
+                'title': 'Trade and investment factsheets: Hong Kong, SAR',
+            },
+            {
+                'url': 'https://assets.publishing.service.gov.uk/126/ivory-coast-factsheet-2022-02-18.pdf',
+                'title': 'Trade and investment factsheets: Ivory Coast',
+            },
+            {
+                'url': 'https://assets.publishing.service.gov.uk/127'
+                '/british-indian-ocean-territory-factsheet-2022-02-18.pdf',
+                'title': 'Trade and investment factsheets: British Indian Ocean Territory',
+            },
+            {
+                'url': 'https://assets.publishing.service.gov.uk/128/india-factsheet-2022-02-18.pdf',
+                'title': 'Trade and investment factsheets: India',
+            },
+        ]
+    }
+}
+CONTENT_API_M_TO_Z_RESPONSE = {
+    'details': {
+        'attachments': [
+            {
+                'url': 'https://assets.publishing.service.gov.uk/129/netherlands-factsheet-2022-02-18.pdf',
+                'title': 'Trade and investment factsheets: Netherlands',
+            },
+            {
+                'url': 'https://assets.publishing.service.gov.uk/125/united-states-factsheet-2022-02-18.pdf',
+                'title': 'Trade and investment factsheets: United States',
+            },
+        ]
+    }
+}
+
+
+@pytest.mark.parametrize(
+    'data, expected',
+    (
+        (
+            {'title': 'Antigua and Barbuda', 'intro_cta_three_link': 'http://original-link'},
+            'https://assets.publishing.service.gov.uk/124/antigua-and-barbuda-factsheet-2022-02-18.pdf',
+        ),
+        (
+            {'title': 'United States (US)', 'intro_cta_three_link': 'http://original-link'},
+            'https://assets.publishing.service.gov.uk/125/united-states-factsheet-2022-02-18.pdf',
+        ),
+        (
+            {'title': 'Ivory Coast  (The Republic of Côte D’Ivoire)', 'intro_cta_three_link': 'http://original-link'},
+            'https://assets.publishing.service.gov.uk/126/ivory-coast-factsheet-2022-02-18.pdf',
+        ),
+        ({'title': 'Will not be found', 'intro_cta_three_link': 'http://original-link'}, 'http://original-link'),
+        (
+            {'title': 'India', 'intro_cta_three_link': 'http://original-link'},
+            'https://assets.publishing.service.gov.uk/128/india-factsheet-2022-02-18.pdf',
+        ),
+        (
+            {'title': 'The Netherlands', 'intro_cta_three_link': 'http://original-link'},
+            'https://assets.publishing.service.gov.uk/129/netherlands-factsheet-2022-02-18.pdf',
+        ),
+        (
+            {'title': 'Hong Kong, China', 'intro_cta_three_link': 'http://original-link'},
+            'https://assets.publishing.service.gov.uk/130/hong-kong-sar-factsheet-2022-02-18.pdf',
+        ),
+    ),
+)
+@pytest.mark.django_db
+def test_update_factsheets_cta_links(data, expected, domestic_homepage, requests_mock):
+    requests_mock.get(
+        'https://www.gov.uk/api/content/government/collections/trade-and-investment-factsheets',
+        json=CONTENT_API_LANDING_RESPONSE,
+    )
+    requests_mock.get('https://www.gov.uk/api/factsheets-a-to-l', json=CONTENT_API_A_TO_L_RESPONSE)
+    requests_mock.get('https://www.gov.uk/api/factsheets-m-to-z', json=CONTENT_API_M_TO_Z_RESPONSE)
+
+    guide = CountryGuidePageFactory(parent=domestic_homepage, **data)
+    guide.save()
+
+    call_command('update_factsheets_cta_links', stdout=StringIO())
+
+    guide.refresh_from_db()
+
+    assert guide.intro_cta_three_link == expected


### PR DESCRIPTION
Adds a command to automatically update factsheets links based on data from the govuk content API:

```
make manage update_factsheets_cta_links
```

Similar to the `organise_country_guide_ctas` command, a `--dry_run` option can be passed to simulate the update without updating actual data.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GLS-113
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
