### PR TITLE
Post release changelog update - 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Enhancements
 
+## [2.5.0](https://github.com/uktrade/great-cms/releases/tag/2.5.0)
+
+[Full Changelog](https://github.com/uktrade/great-cms/compare/2.4.1...2.5.0)
+
+### Enhancements
+
 - GLS-113 - add extra items and heading to Country Guide CTA links
 - GLS-113 - add command to update factsheets links from govuk content API
 - GLS-112 - add Trade barriers and Duties and customs content


### PR DESCRIPTION
- GLS-113 - add extra items and heading to Country Guide CTA links
- GLS-113 - add command to update factsheets links from govuk content API
- GLS-112 - add Trade barriers and Duties and customs content