### PR TITLE
GLS-180 visualisation tweaks

### DIFF
--- a/core/templates/core/includes/data_source.html
+++ b/core/templates/core/includes/data_source.html
@@ -1,8 +1,19 @@
-Source:
-{% spaceless %}
-  {% if source.url %}
-    <a class="link" href="{{ source.url }}">{{ source.label }}</a>
-  {% else %}
-    {{ source.label }}
-  {% endif %}
-{% endspaceless %}
+<p class="font-xsmall statistic-smallprint">
+  Source:
+  {% spaceless %}
+    {% if source.url %}
+      <a class="link" href="{{ source.url }}">{{ source.label }}</a>
+    {% else %}
+      {{ source.label }}
+    {% endif %}
+    {% if source.next_release %}
+    <br/>Next release: {{ source.next_release }}
+    {% endif %}
+    {% if source.notes %}
+      {% for note in source.notes %}
+      <br/>{{ note }}
+      {% endfor %}
+    {% endif %}
+  {% endspaceless %}
+</p>
+<hr class="margin-vertical-15" style="background: #d8d8d8">

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -919,11 +919,14 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
                 'highlights': {
                     'metadata': {
                         'source': {
-                            'label': 'ONS UK Trade',
+                            'label': 'ONS UK total trade: all countries',
                             'url': 'https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets'
                             '/uktotaltradeallcountriesseasonallyadjusted',
+                            'next_release': '28 April 2022',
+                            'notes': [
+                                'Data includes goods and services combined in the four quarters to the end of Q3 2021.'
+                            ],
                         },
-                        'accessed': 'January 2022',
                         'reference_period': {'resolution': 'quarter', 'period': 3, 'year': 2021},
                     },
                     'data': {'total_uk_exports': 26100000000, 'trading_position': 3, 'percentage_of_uk_trade': 7.5},
@@ -931,11 +934,12 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
                 'market_trends': {
                     'metadata': {
                         'source': {
-                            'label': 'ONS UK total trade: all countries, Q3 2021',
+                            'label': 'ONS UK total trade: all countries',
                             'url': 'https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets'
-                            '/uktotaltradeallcountriesseasonallyadjusted',
+                            '/uktotaltradeallcountriesseasonallyadjusted ',
+                            'next_release': '28 April 2022',
+                            'notes': ['Data includes goods and services combined.'],
                         },
-                        'accessed': 'January 2022',
                     },
                     'data': [
                         {'year': 2011, 'imports': 32000000000, 'exports': 14800000000},
@@ -953,11 +957,11 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
                 'goods_exports': {
                     'metadata': {
                         'source': {
-                            'label': 'ONS UK trade, February 2022',
+                            'label': 'ONS UK trade',
                             'url': 'https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/bulletins'
-                            '/uktrade/february2022',
+                            '/uktrade/latest',
+                            'next_release': '12 May 2022',
                         },
-                        'accessed': 'February 2022',
                         'reference_period': {
                             'resolution': 'quarter',
                             'period': 3,
@@ -975,11 +979,11 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
                 'services_exports': {
                     'metadata': {
                         'source': {
-                            'label': 'ONS UK trade in services: service type by partner country, Q3 2021',
+                            'label': 'ONS UK trade in services: service type by partner country',
                             'url': 'https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/datasets'
                             '/uktradeinservicesservicetypebypartnercountrynonseasonallyadjusted',
+                            'next_release': '28 April 2022',
                         },
-                        'accessed': 'February 2022',
                         'reference_period': {
                             'resolution': 'quarter',
                             'period': 3,

--- a/domestic/templates/domestic/country_guide.html
+++ b/domestic/templates/domestic/country_guide.html
@@ -52,10 +52,12 @@
 
         .barchart td,
         .barchart th {
+            font-size: 1rem;
             border: 0;
         }
 
         .barchart__legend {
+            padding: 0;
             font-weight: normal;
         }
 
@@ -70,17 +72,15 @@
         }
 
         .barchart__title-cell {
-            padding: .5em .5em .5em 0;
+            padding: 0 .5em 0 0;
             width: 40%;
-            max-width: 0;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
             text-align: right;
+            vertical-align: middle;
         }
 
         .barchart__bar-cell {
-            padding: 2px 0;
+            padding: 3px 0;
+            vertical-align: middle;
         }
 
         .barchart__bar {

--- a/domestic/templates/domestic/country_guide.html
+++ b/domestic/templates/domestic/country_guide.html
@@ -157,11 +157,7 @@
             </div>
 
             {% if highlights.metadata.source %}
-              <p class="font-xsmall statistic-smallprint">
-                {% include 'core/includes/data_source.html' with source=highlights.metadata.source %}<br/>
-                Data includes goods and services combined in the {% reference_period highlights.metadata.reference_period %}, correct as of January 2022
-              </p>
-              <hr class="margin-vertical-15" style="background: #d8d8d8">
+              {% include 'core/includes/data_source.html' with source=highlights.metadata.source %}
             {% endif %}
           </div>
           {% endwith %}
@@ -252,11 +248,7 @@
               </table>
 
               {% if page.stats.goods_exports.metadata.source %}
-                <p class="font-xsmall statistic-smallprint">
-                  {% include 'core/includes/data_source.html' with source=page.stats.goods_exports.metadata.source %}<br/>
-                  Data correct as of {{ page.stats.goods_exports.metadata.accessed }}
-                </p>
-                <hr class="margin-vertical-15" style="background: #d8d8d8">
+                {% include 'core/includes/data_source.html' with source=page.stats.goods_exports.metadata.source %}
               {% endif %}
             </div>
             {% endif %}
@@ -290,11 +282,7 @@
               </table>
 
               {% if page.stats.services_exports.metadata.source %}
-                <p class="font-xsmall statistic-smallprint">
-                  {% include 'core/includes/data_source.html' with source=page.stats.services_exports.metadata.source %}<br/>
-                  Data correct as of {{ page.stats.services_exports.metadata.accessed }}
-                </p>
-                <hr class="margin-vertical-15" style="background: #d8d8d8">
+                {% include 'core/includes/data_source.html' with source=page.stats.services_exports.metadata.source %}
               {% endif %}
             </div>
             {% endif %}
@@ -303,14 +291,10 @@
             <div id="tab-market-trends" class="tabs__tab">
               <h2 class="heading-medium">Total import and export values between {{ page.heading }} and the UK (£{{ page.stats.market_trends.metadata.unit }})</h2>
 
-              <div id="plotly-market-trends"></div>
+              <div id="plotly-market-trends" class="margin-bottom-15"></div>
 
               {% if page.stats.market_trends.metadata.source %}
-                <p class="font-xsmall statistic-smallprint margin-top-15">
-                  {% include 'core/includes/data_source.html' with source=page.stats.market_trends.metadata.source %}<br/>
-                  Data correct as of {{ page.stats.market_trends.metadata.accessed }}
-                </p>
-                <hr class="margin-vertical-15" style="background: #d8d8d8">
+                {% include 'core/includes/data_source.html' with source=page.stats.market_trends.metadata.source %}
               {% endif %}
 
               {{ page.stats.market_trends.data|json_script:"market-trends-data" }}

--- a/domestic/templates/domestic/country_guide.html
+++ b/domestic/templates/domestic/country_guide.html
@@ -399,7 +399,8 @@
                     }
                     return (x) => {
                       if (exponents.hasOwnProperty(marketTrendsUnit)) {
-                        return `${x / exponents[marketTrendsUnit]}`
+                        var output = `${x / exponents[marketTrendsUnit]}`
+                        return output.includes('.') ? output : `${output}.0`
                       }
                       return `${x}`;
                     }


### PR DESCRIPTION
Some more tweaks and updates to the country guide page:

- Tweak bar charts so label is always shown fully (font-size decreased, adjusted spacing to fit more text)
- Update 'Data Source' template to include:
  - Next release
  - Notes
- Updated data hardcoded for China (this updates the metadata schema slightly!)

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GLS-180
- [x] Jira ticket has the correct status.
- [ ] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [x] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
