### PR TITLE
Add project root as load path for build-domestic:dev target

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "webpack --config react-components/webpack.config.js --mode production",
     "build:dev": "webpack --watch --config react-components/webpack.config.js --mode development",
     "build-domestic": "sass --load-path=domestic/sass --load-path=./ --style=compressed domestic/sass:domestic/static/styles",
-    "build-domestic:dev": "sass --watch --load-path=domestic/sass --style=compressed domestic/sass:domestic/static/styles"
+    "build-domestic:dev": "sass --watch --load-path=domestic/sass --load-path=./ --style=compressed domestic/sass:domestic/static/styles"
   },
   "jest": {
     "globalSetup": "react-components/setupJest.js"


### PR DESCRIPTION
`npm run build-domestic:dev` was failing due to the project root not being included in the sass load path.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
