### PR TITLE
Disable autocomplete for user creation and password reset forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Enhancements
 
+* GLS-349 - Disable autocomplete for user creation and password reset forms
+
 ## [2.11.0](https://github.com/uktrade/great-cms/releases/tag/2.11.0)
 
 [Full Changelog](https://github.com/uktrade/great-cms/compare/2.10.0...2.11.0)

--- a/core/admin.py
+++ b/core/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
 from wagtail.contrib.modeladmin import views
 from wagtail.contrib.modeladmin.mixins import ThumbnailMixin
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
@@ -50,3 +51,10 @@ class ImageAdmin(ModelAdmin, ThumbnailMixin):
 
     size.short_description = 'Size'
     size.admin_order_field = 'file_size'
+
+
+# Disable autocomplete for user creation and password reset forms.
+UserAdmin.add_form.base_fields['password1'].widget.attrs['autocomplete'] = 'off'
+UserAdmin.add_form.base_fields['password2'].widget.attrs['autocomplete'] = 'off'
+UserAdmin.change_password_form.base_fields['password1'].widget.attrs['autocomplete'] = 'off'
+UserAdmin.change_password_form.base_fields['password2'].widget.attrs['autocomplete'] = 'off'


### PR DESCRIPTION
Disable autocomplete for user creation and password reset forms, as per the pen test recommendations.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GLS-349
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
