### PR TITLE
[HOTFIX] logo not uploading to business profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Hotfix
 
+* GLS-395 - [HOTFIX] Logo not uploading to business profile
+
 ### Bugs fixed
 
 ### Enhancements

--- a/core/validators.py
+++ b/core/validators.py
@@ -20,3 +20,5 @@ def validate_file_infection(file):
 
     if is_file_infected:
         raise ValidationError('Rejected: uploaded file did not pass security scan')
+
+    file.seek(0)

--- a/tests/unit/core/test_validators.py
+++ b/tests/unit/core/test_validators.py
@@ -33,7 +33,7 @@ def test_is_valid_uk_postcode(postcode, raise_expected):
 @override_settings(CLAM_AV_ENABLED=True)
 @mock.patch('core.helpers.ClamAvClient.scan_chunked')
 def test_validate_file_infection_positive_scan(mock_clam_av_client_scan):
-    file = 'file'
+    file = mock.Mock()
     mock_response = create_response({'malware': True, 'reason': 'Win.Test.EICAR_HDB-1', 'time': 0.005419833003543317})
     mock_clam_av_client_scan.return_value = mock_response
 
@@ -46,7 +46,7 @@ def test_validate_file_infection_positive_scan(mock_clam_av_client_scan):
 @override_settings(CLAM_AV_ENABLED=True)
 @mock.patch('core.helpers.ClamAvClient.scan_chunked')
 def test_validate_file_infection_negative_scan(mock_clam_av_client_scan):
-    file = 'file'
+    file = mock.Mock()
     mock_response = create_response({'malware': False, 'reason': None, 'time': 0.011951766995480284})
     mock_clam_av_client_scan.return_value = mock_response
 
@@ -54,3 +54,5 @@ def test_validate_file_infection_negative_scan(mock_clam_av_client_scan):
         validate_file_infection(file)
     except ValidationError:
         pytest.fail('Should not raise a validator error.')
+
+    assert file.seek.call_count == 1


### PR DESCRIPTION
CONTEXT: The logo file uploaded through the business profile form is instantiated as an `InMemoryUploadedFile`, which is read by the file infection validator and sent over to the Clam AV service for scanning. In this process the file object loses the current position and does not get stored.

This hotfix resets the current position of the file so it can be read and stored after being scan-validated. 

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GLS-395
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
