### PR TITLE
Remove admin paths from robots disallowed list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Enhancements
 
+* GLS-345 - Remove admin paths from robots.txt
+
 ## [2.13.0](https://github.com/uktrade/great-cms/releases/tag/2.13.0)
 
 [Full Changelog](https://github.com/uktrade/great-cms/compare/2.12.0...2.13.0)

--- a/core/templates/robots.txt
+++ b/core/templates/robots.txt
@@ -1,7 +1,5 @@
 User-agent: *
 
-Disallow: /admin/
-Disallow: /django-admin/
 Disallow: /api/
 Disallow: /activity-stream/
 

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -38,4 +38,6 @@ domestic/sass/partials/_colours.scss
 README.md
 tests/unit/contact/test_helpers.py
 tests/unit/contact/test_views.py
+tests/unit/core/test_views.py
 core/views.py
+core/templates/robots.txt

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -972,8 +972,6 @@ def test_robots_txt(client, base_url, expected_sitemap_url):
             [
                 b'User-agent: *\n',
                 b'\n',
-                b'Disallow: /admin/\n',
-                b'Disallow: /django-admin/\n',
                 b'Disallow: /api/\n',
                 b'Disallow: /activity-stream/\n',
                 b'\n',


### PR DESCRIPTION
This PR removes the `/admin` and `/django-admin` paths from the robots.txt file.

This is based on advice from our pen test, as these routes are behind our IP filter anyway, so are not accessible by robots anyway. 

Because `/api` and `/activity-stream` are only accessible via API key and not through a browser, we are okay to leave these in.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
