### PR TITLE
Fix incorrect next url being sent when exired verification is entered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs fixed
 
+* GLS-336 - Fix broken next urls when entering expired verification code
+
 ### Enhancements
 
 * GLS-336 - resend-verification-code

--- a/sso/views.py
+++ b/sso/views.py
@@ -1,3 +1,5 @@
+import urllib.parse
+
 import requests
 from django.conf import settings
 from django.contrib import auth
@@ -6,13 +8,15 @@ from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
+from core.cms_slugs import DASHBOARD_URL
 from sso import helpers, serializers
 from sso_profile.enrolment import constants
 
 
 class ResendVerificationMixin:
-    def get_verification_link(self, uidb64, token):
-        next_param = self.request.data.get('next', '')
+    def get_verification_link(self, uidb64, token, next_param=None):
+        if next_param is None:
+            next_param = self.request.data.get('next', '')
         verification_params = f'?uidb64={uidb64}&token={token}'
 
         if next_param:
@@ -159,13 +163,16 @@ class SSOBusinessVerifyCodeView(ResendVerificationMixin, generics.GenericAPIView
         # Resend verification code if it has expired.
         if upstream_response.status_code == 422:
             verification_code = helpers.regenerate_verification_code(email)
-            uidb64 = (serializer.validated_data['uidb64'],)
-            token = (serializer.validated_data['token'],)
+            uidb64 = serializer.validated_data['uidb64']
+            token = serializer.validated_data['token']
+            # must create redirect link as it is not sent by the form in this step
+            next_url = self.request.build_absolute_uri(DASHBOARD_URL)
+            next_param = urllib.parse.quote(next_url, safe='')
             helpers.send_verification_code_email(
                 email=email,
                 verification_code=verification_code,
                 form_url=request.path,
-                verification_link=self.get_verification_link(uidb64, token),
+                verification_link=self.get_verification_link(uidb64, token, next_param=next_param),
                 resend_verification_link=self.get_resend_verification_link(),
             )
             return Response({'code': ['Code has expired']}, status=422)


### PR DESCRIPTION
This change corrects an issue where url parameters were being passed as tuples and were therefore creating incorrect urls.

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GLS-336
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
