### PR TITLE
Remove duplicate and empty meta tags from domestic templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Hotfix
 
 ### Bugs fixed
+* GLS-401 - Remove duplicate meta tags from domestic templates
 
 ### Enhancements
 

--- a/core/templates/core/header.html
+++ b/core/templates/core/header.html
@@ -7,7 +7,11 @@
 {% endif %}
 
 <header class="magna-header clearfix" id="header" dir="ltr" data-ga-section="header">
-  {% include "wagtailseo/meta.html" %}
+  {% with is_wagtail_page=page %}
+    {% if is_wagtail_page %}
+      {% include "wagtailseo/meta.html" %}
+    {% endif %}
+  {% endwith %}
   {% path_match "^\/export-plan\/" as in_exportplan %}
   <nav class="container">
     <a id="header-logo-link" class="magna-header__logo" href="/">

--- a/domestic/templates/domestic/base.html
+++ b/domestic/templates/domestic/base.html
@@ -14,20 +14,12 @@
   <meta charset="utf-8" />
   {% block sharing_description %}
     <meta
-      name="description" content="
-
-
-
-      {% block meta_description %}{% firstof page.search_description content_snippet.search_description page.teaser page.featured_description page.seo_title page.title content_snippet.search_description %}{% endblock %}"
+      name="description" content="{% block meta_description %}{% firstof page.search_description content_snippet.search_description page.teaser page.featured_description page.seo_title page.title content_snippet.search_description %}{% endblock %}"
     >
   {% endblock %}
   {% block sharing_title %}
     <meta
-      name="title" content="
-
-
-
-      {% block meta_title %}{% firstof page.seo_title page.title content_snippet.seo_title content_snippet.title %}{% endblock %}"
+      name="title" content="{% block meta_title %}{% firstof page.title %}{% endblock %}"
     >
   {% endblock %}
   <meta name="msvalidate.01" content="76D322F181AE9F91C43419E5CD511BBC" />

--- a/domestic/templates/domestic/base.html
+++ b/domestic/templates/domestic/base.html
@@ -30,7 +30,6 @@
       {% block meta_title %}{% firstof page.seo_title page.title content_snippet.seo_title content_snippet.title %}{% endblock %}"
     >
   {% endblock %}
-  {% include "wagtailseo/meta.html" %}
   <meta name="msvalidate.01" content="76D322F181AE9F91C43419E5CD511BBC" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% block head_google_tag_manager %}


### PR DESCRIPTION
This PR addresses the duplication of meta tags and rendering of empty meta tags in pages which extend from `domestic/base.html`. This is done by:

- Removing the inclusion of `wagtailseo/meta.html` in the base template, as it's already included in `header.html` which is used in the base template.
- Only including `wagtailseo/meta.html` in Wagtail pages, because if the page doesn't use wagtail all meta/title tags will be empty, as they are taken from the Wagtail `page` object ([see docs](https://docs.coderedcorp.com/wagtail-seo/getting-started/edit-meta.html#specifying-metadata-per-page)).

**To test**:
- Pull branch, and visit http://greatcms.trade.great:8020/get-finance/
- Inspect the html, there should only be one of each of these tags `<title>, <meta name="title"> and <meta name="description">` and no empty social media meta tags (e.g `og:title`, `twittercard`)

**TODO**
- Address the many domestic pages which are missing meta descriptions and titles.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
