### PR TITLE
HOTFIX - adjust styling for emergency banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Hotfix
 
 * GLS-395 - [HOTFIX] Logo not uploading to business profile
+* GLS-416 - [HOTFIX] Update styling for emergency banner on homepage
 
 ### Bugs fixed
 

--- a/core/templates/components/landing_hero_with_cta.html
+++ b/core/templates/components/landing_hero_with_cta.html
@@ -48,11 +48,10 @@
   class="great-hero {% if not hero_image %}great-hero-no-image{% endif %}" id="hero"
   {% if hero_image and not 'WebHeader_v26' in rendition.url %}style="background-image: url({{ rendition.url }})"{% endif %}
 >
-  <div class="container padding-top-90-l padding-top-45 padding-bottom-45-l">
+  <div class="container padding-top-90-l padding-top-45 padding-bottom-45-l" style="margin-top: 3px;">
     <div class="great-hero-text width-half-xl width-two-thirds-l width-full">
       <h1
         class="heading-xlarge {% if subheading or subtitle %} margin-bottom-0 {% else %} margin-bottom-30 {% endif %}"
-        style="max-width: 500px;"
       >{{ heading }}</h1>
       {% block content %}
         {% if subheading %}


### PR DESCRIPTION
This PR adds a hotfix for styling on the emergency banner on the homepage.

It brings the header onto one line on larger screen sizes, and adds a small margin at the top of the hero.

![Screenshot 2022-09-09 at 12 22 54](https://user-images.githubusercontent.com/22460823/189339313-30c201c0-c27f-480d-9854-70758f0cf933.png)


_Tick or delete as appropriate:_

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [ ] Jira ticket has the correct status.
- [ ] [Changelog](CHANGELOG.md) entry added.

### Reviewing help
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
