### PR TITLE
Only show Want to know more banner on advice pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bugs fixed
 * GLS-401 - Remove duplicate meta tags from domestic templates
+* GLS-422 - Only show 'Want to know more' banner on advice article pages
 
 ### Enhancements
 

--- a/domestic/templates/domestic/includes/article_detail_content.html
+++ b/domestic/templates/domestic/includes/article_detail_content.html
@@ -78,6 +78,7 @@
           </div>
         </section>
       </div>
+      {% if page.type_of_article|lower == 'advice' %}
         <section class="grid-row background-stone-30">
           <div class="column-full-m">
             <div class="learn-more-container padding-top-45">
@@ -87,7 +88,7 @@
             <a href="/signup/" class="button learn-more-button margin-bottom-60">Sign up for free</a>
           </div>
         </section>
-
+      {% endif %}
       {% block related_content %}
         {% include 'domestic/includes/article_related_content_list.html' %}
       {% endblock %}


### PR DESCRIPTION
This PR fixes a bug in which the 'Tell me more banner' appears on all types of article page.

The banner should now only appear on advice article pages.

**Test locally:**
- After pulling branch go to `campaigns/local-export-support/` - there should be no 'Tell me more banner' at the bottom of this page
- Go to `/advice/create-export-plan/how-create-export-plan/` - you should see the 'Tell me more banner' at the bottom of the page

**Screenshot - advice page**
![Screenshot 2022-09-12 at 09 29 13](https://user-images.githubusercontent.com/22460823/189611151-5cfb5158-df63-4472-bd4c-c837e9d1bc29.png)

**Screenshot - campaign page**
![Screenshot 2022-09-12 at 09 30 29](https://user-images.githubusercontent.com/22460823/189611209-da3a679a-d706-47bb-bdc6-d05122c335a5.png)

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GLS-422
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
