### PR TITLE
Always show economic highlights stats - not dependent on feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Hotfix
 
 ### Bugs fixed
+* GLS-454 - Always show GDP per capita & economic data stats
 
 ### Enhancements
 

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -476,7 +476,15 @@ def get_stats_by_country(iso2):
     }
 
     stats = {k: v for k, v in stats.items() if v and v['data']}
+    return stats or None
 
+
+# Remove once FEATURE_SHOW_MARKET_GUIDE_VISUALISATIONS flag turned off
+def get_stats_economic_highlights_by_country(iso2):
+    stats = {
+        'economic_highlights': get_economic_highlights_by_country(iso2=iso2),
+    }
+    stats = {k: v for k, v in stats.items() if v and v['data']}
     return stats or None
 
 

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -909,15 +909,15 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
 
     @cached_property
     def stats(self):
-        if not settings.FEATURE_SHOW_MARKET_GUIDE_VISUALISATIONS:
-            return None
-
         iso2 = getattr(self.country, 'iso2', None)
 
-        if iso2:
+        if not iso2:
+            return None
+
+        elif settings.FEATURE_SHOW_MARKET_GUIDE_VISUALISATIONS:
             return helpers.get_stats_by_country(iso2=iso2)
 
-        return None
+        return helpers.get_stats_economic_highlights_by_country(iso2=iso2)
 
     @property
     def related_pages(self):

--- a/tests/unit/core/test_helpers.py
+++ b/tests/unit/core/test_helpers.py
@@ -811,7 +811,12 @@ def test_get_economic_highlights_by_country(mock_economic_highlights, client):
 
 @pytest.mark.django_db
 def test_get_stats_by_country(
-    mock_trade_highlights, mock_market_trends, mock_top_goods_exports, mock_top_services_exports, client
+    mock_trade_highlights,
+    mock_market_trends,
+    mock_top_goods_exports,
+    mock_top_services_exports,
+    mock_economic_highlights,
+    client,
 ):
     stats = helpers.get_stats_by_country(iso2='FR')
 
@@ -819,6 +824,7 @@ def test_get_stats_by_country(
     assert len(stats['market_trends']['data']) == 2
     assert len(stats['goods_exports']['data']) == 3
     assert len(stats['services_exports']['data']) == 2
+    assert len(stats['economic_highlights']['data']) == 2
 
 
 @pytest.mark.django_db

--- a/tests/unit/domestic/test_models.py
+++ b/tests/unit/domestic/test_models.py
@@ -550,6 +550,7 @@ def test_stats(
     mock_market_trends,
     mock_top_goods_exports,
     mock_top_services_exports,
+    mock_economic_highlights,
     domestic_homepage,
     settings,
 ):
@@ -567,10 +568,11 @@ def test_stats(
     assert len(page.stats['market_trends']['data']) == 2
     assert len(page.stats['goods_exports']['data']) == 3
     assert len(page.stats['services_exports']['data']) == 2
+    assert len(page.stats['economic_highlights']['data']) == 2
 
 
 @pytest.mark.django_db
-def test_stats_feature_off(domestic_homepage, settings):
+def test_stats_feature_off(mock_economic_highlights, domestic_homepage, settings):
     settings.FEATURE_SHOW_MARKET_GUIDE_VISUALISATIONS = False
 
     country = CountryFactory(name='China', slug='china', iso2='CN')
@@ -581,7 +583,8 @@ def test_stats_feature_off(domestic_homepage, settings):
         country=country,
     )
 
-    assert page.stats is None
+    assert len(page.stats) == 1
+    assert len(page.stats['economic_highlights']['data']) == 2
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR makes a fix to the logic around getting statistics for the country guide page.

Currently all stats are fetched from the API only when the feature flag `FEATURE_SHOW_MARKET_GUIDE_VISUALISATIONS` is enabled. However, the GDP per capita and economic growth stats should always show - regardless of whether the flag is set to true or false. This PR updates this logic so that these stats always show.

Once the flag is turned on permanently, the additional helper function I have added will be removed.

**To test**
1.  Set `FEATURE_SHOW_MARKET_GUIDE_VISUALISATIONS` to false in `secrets-do-not-commit`
2. Go to http://greatcms.trade.great:8020/markets/fiji/
3. You should still see the GDP per capita and Economic growth stats in the 'At a glance panel'

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GLS-454
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
