### PR TITLE
Add source information to market guides

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -71,3 +71,5 @@ CONSENT_CHOICES = (
 )
 
 USER_DATA_NAMES = {'ComparisonMarkets': 16384, 'UserProducts': 16384, 'UserMarkets': 16384, 'ActiveProduct': 256}
+
+COUNTRY_FACTSHEET_CTA_TITLE = 'View latest trade statistics'

--- a/core/templates/components/statistics_card_grid.html
+++ b/core/templates/components/statistics_card_grid.html
@@ -19,7 +19,7 @@
         >
           <p class="statistic-heading font-xsmall">Economic growth</p>
           {% with economic_highlights.data.economic_growth as economic_growth %}
-            <p class="active-blue-text statistic-number bold-large">
+            <p class="statistic-number bold-large">
               {{ economic_growth.value|floatformat }}%
             </p>
             <figcaption>
@@ -37,7 +37,7 @@
         >
           <p class="statistic-heading font-xsmall">GDP per capita</p>
           {% with economic_highlights.data.gdp_per_capita as gdp_per_capita %}
-            <p class="active-blue-text statistic-number bold-large">
+            <p class="statistic-number bold-large">
               ${{ gdp_per_capita.value|floatformat:0|intcomma }}
             </p>
             {% with economic_highlights.metadata.uk_data.gdp_per_capita as uk_gdp_per_capita %}
@@ -65,7 +65,7 @@
                 {% endif %}
 
                 <p
-                  class="active-blue-text statistic-number {% if statistics_block.value.number|length > 8 %} bold-medium{% else %} bold-large{% endif %}"
+                  class="statistic-number {% if statistics_block.value.number|length > 8 %} bold-medium{% else %} bold-large{% endif %}"
                 >
                   {{ statistics_block.value.number }}
                 </p>

--- a/core/templates/core/includes/bar_chart.html
+++ b/core/templates/core/includes/bar_chart.html
@@ -22,5 +22,5 @@
 </table>
 
 {% if content.metadata.source %}
-  {% include 'core/includes/data_source.html' with source=content.metadata.source %}
+  {% include 'domestic/includes/market_guide_graph_data_source.html' with source=content.metadata.source country=country %}
 {% endif %}

--- a/core/templates/core/includes/data_source.html
+++ b/core/templates/core/includes/data_source.html
@@ -1,22 +1,12 @@
-<p class="font-xsmall statistic-smallprint">
-  Source:
+{% load content_tags %}
+<p class="font-xsmall statistic-smallprint margin-top-0 padding-top-15">
+  (Source:
   {% spaceless %}
     {% if source.url %}
-      <a class="link" href="{{ source.url }}">{{ source.label }}</a>
+      <a class="link" target="_blank" href="{{ source.url }}">{{ source.organisation }} {{ source.label }}</a>
     {% else %}
       {{ source.label }}
     {% endif %}
-    <br/>Last release:
-    {% if source.label == 'ONS UK trade' %}
-    13 June 2022
-    {% elif source.label == 'ONS UK total trade: all countries' %}
-    28 April 2022
-    {% elif source.label == 'ONS UK trade in services: service type by partner country' %}
-    28 April 2022
-    {% endif %}
-    {% if source.notes %}
-    <br/>{{ source.notes|join:" " }}
-    {% endif %}
+    <br/>Last updated: {{ source.last_release|str_to_datetime|date:"F Y"}})
   {% endspaceless %}
 </p>
-<hr class="margin-vertical-15" style="background: #d8d8d8">

--- a/domestic/management/commands/update_factsheets_cta_links.py
+++ b/domestic/management/commands/update_factsheets_cta_links.py
@@ -4,6 +4,7 @@ import re
 import requests
 from django.core.management import BaseCommand, CommandError
 
+from core.constants import COUNTRY_FACTSHEET_CTA_TITLE
 from domestic.models import CountryGuidePage
 
 CONTENT_API_FACTSHEETS_LANDING = 'https://www.gov.uk/api/content/government/collections/trade-and-investment-factsheets'
@@ -41,7 +42,7 @@ class Command(BaseCommand):
 
         parens_regex = re.compile(r'(The |\(.*\)|,.*)')
         for guide in CountryGuidePage.objects.all():
-            if guide.intro_cta_three_title != 'View latest trade statistics':
+            if guide.intro_cta_three_title != COUNTRY_FACTSHEET_CTA_TITLE:
                 self.stdout.write(f'{guide.title}: CTA not present or modified, not updating')
             else:
                 # Remove extra info in parens or after comma, or any preceding 'The ' (e.g. 'The Netherlands')

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -30,6 +30,7 @@ from core import blocks as core_blocks, cache_keys, helpers, mixins, service_url
 from core.blocks import AdvantageBlock
 from core.constants import (
     ARTICLE_TYPES,
+    COUNTRY_FACTSHEET_CTA_TITLE,
     RICHTEXT_FEATURES__REDUCED,
     RICHTEXT_FEATURES__REDUCED__ALLOW_H1,
     TABLEBLOCK_OPTIONS,
@@ -952,6 +953,14 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
             if page:
                 output.append(page.specific)
         return output
+
+    @property
+    def country_fact_sheet_link(self):
+        factsheet_link = next(
+            (intro_cta['link'] for intro_cta in self.intro_ctas if intro_cta['title'] == COUNTRY_FACTSHEET_CTA_TITLE),
+            None,
+        )
+        return factsheet_link
 
 
 class ArticlePage(

--- a/domestic/templates/domestic/country_guide.html
+++ b/domestic/templates/domestic/country_guide.html
@@ -38,19 +38,21 @@
             <div class="flex-grid margin-bottom-30">
               {% if highlights.data.total_uk_exports %}
               <figure class="statistics-card__column padding-vertical-15">
-                <h3 class="statistic-heading font-xsmall">Total UK exports to {{ page.heading }}</h3>
-
-                <span class="active-blue-text statistic-number bold-large">
+                <span class="statistic-number bold-large">
                   £{{ highlights.data.total_uk_exports|intword }}
                 </span>
+                <span class="font-small statistic-smallprint">
+                total UK exports to {{ page.heading }} for the {% reference_period highlights.metadata.reference_period %}
+                </span>
+                {% if highlights.metadata.source %}
+                  {% include 'core/includes/data_source.html' with source=highlights.metadata.source %}
+                {% endif %}
               </figure>
               {% endif %}
 
               {% if highlights.data.trading_position %}
               <figure class="statistics-card__column padding-vertical-15">
-                <h3 class="statistic-heading font-xsmall">The UK's</h3>
-
-                <span class="active-blue-text statistic-number bold-large">
+                <span class="statistic-number bold-large">
                   {% if highlights.data.trading_position == 1 %}
                     largest
                   {% else %}
@@ -58,34 +60,33 @@
                   {% endif %}
                 </span>
 
-                <span class="font-xsmall statistic-smallprint">
-                  {% if highlights.data.trading_position != 1 %}largest{% endif %} export market
+                <span class="font-small statistic-smallprint">
+                  {% if highlights.data.trading_position != 1 %}largest{% endif %} UK export market
                 </span>
+                {% if highlights.metadata.source %}
+                  {% include 'core/includes/data_source.html' with source=highlights.metadata.source %}
+                {% endif %}
               </figure>
               {% endif %}
 
               {% if highlights.data.percentage_of_uk_trade %}
               <figure class="statistics-card__column padding-vertical-15">
-                <h3 class="statistic-heading font-xsmall">Accounting for</h3>
-
-                <span class="active-blue-text statistic-number bold-large">
+                <span class="statistic-number bold-large">
                   {% if highlights.data.percentage_of_uk_trade < 0.05 %}
                     less than 0.1%
                   {% else %}
                     {{ highlights.data.percentage_of_uk_trade|floatformat:"1" }}%
                   {% endif %}
                 </span>
-
-                <span class="font-xsmall statistic-smallprint">
-                  of total UK exports
+                <span class="font-small statistic-smallprint">
+                  of total UK exports for the {% reference_period highlights.metadata.reference_period %}
                 </span>
+                {% if highlights.metadata.source %}
+                  {% include 'core/includes/data_source.html' with source=highlights.metadata.source %}
+                {% endif %}
               </figure>
               {% endif %}
             </div>
-
-            {% if highlights.metadata.source %}
-              {% include 'core/includes/data_source.html' with source=highlights.metadata.source %}
-            {% endif %}
           </div>
           {% endwith %}
         {% endif %}
@@ -113,7 +114,6 @@
   </div>
 </section>
 {% endif %}
-
 <section id="country-guide-section-one" class="section-one padding-vertical-60">
   <div class="container">
     <div class="grid-row">

--- a/domestic/templates/domestic/country_guide.html
+++ b/domestic/templates/domestic/country_guide.html
@@ -148,29 +148,29 @@
 
             {% if page.stats.goods_exports.data %}
             <div id="tab-goods" class="reveal-content">
-              <h2 class="heading-medium">
-                Top {{ page.stats.goods_exports.data|length }} UK goods exports to {{ page.heading }}{% if page.stats.goods_exports.metadata.reference_period %},
+              <h2 class="body padding-top-30">
+                Top {{ page.stats.goods_exports.data|length|apnumber }} UK goods exported to {{ page.heading }}{% if page.stats.goods_exports.metadata.reference_period %},
                 in the {% reference_period page.stats.goods_exports.metadata.reference_period %}{% endif %}
               </h2>
 
-              {% include 'core/includes/bar_chart.html' with content=page.stats.goods_exports labels_heading='Goods' %}
+              {% include 'core/includes/bar_chart.html' with content=page.stats.goods_exports labels_heading='Goods' country=page.heading factsheet_link=page.country_fact_sheet_link %}
             </div>
             {% endif %}
 
             {% if page.stats.services_exports.data %}
             <div id="tab-services" class="reveal-content">
-              <h2 class="heading-medium">
-                Top {{ page.stats.services_exports.data|length }} UK services exports to {{ page.heading }}{% if page.stats.services_exports.metadata.reference_period %},
+              <h2 class="body padding-top-30">
+                Top {{ page.stats.services_exports.data|length|apnumber }} UK services exported to {{ page.heading }}{% if page.stats.services_exports.metadata.reference_period %},
                 in the {% reference_period page.stats.services_exports.metadata.reference_period %}{% endif %}
               </h2>
 
-              {% include 'core/includes/bar_chart.html' with content=page.stats.services_exports labels_heading='Service' %}
+              {% include 'core/includes/bar_chart.html' with content=page.stats.services_exports labels_heading='Service' country=page.heading factsheet_link=page.country_fact_sheet_link %}
             </div>
             {% endif %}
 
             {% if page.stats.market_trends.data %}
             <div id="tab-market-trends" class="reveal-content">
-              <h2 class="heading-medium">Total import and export values between {{ page.heading }} and the UK</h2>
+              <h2 class="body padding-top-30">Total import value (into the UK from {{ page.heading }}) and export value (from the UK into {{ page.heading }}) over time</h2>
 
               <div id="market-trends-table" class="reveal-content">
                 <button class="link margin-bottom-15 font-small" data-reveal-button aria-controls="market-trends-chart" data-reveal-tabs="market-trends-view">Change to chart view</button>
@@ -320,7 +320,7 @@
               </div>
 
               {% if page.stats.market_trends.metadata.source %}
-                {% include 'core/includes/data_source.html' with source=page.stats.market_trends.metadata.source %}
+                {% include 'domestic/includes/market_guide_graph_data_source.html' with source=page.stats.market_trends.metadata.source country=page.heading additional_source_text='Total trade is the sum of all exports and imports over the same time period.' factsheet_link=page.country_fact_sheet_link%}
               {% endif %}
             </div>
             {% endif %}

--- a/domestic/templates/domestic/includes/market_guide_graph_data_source.html
+++ b/domestic/templates/domestic/includes/market_guide_graph_data_source.html
@@ -1,0 +1,18 @@
+{% load content_tags %}
+<p class="font-xsmall statistic-smallprint margin-top-0 padding-top-15">
+  Source:
+  {% spaceless %}
+    {% if source.url %}
+      <a class="link" target="_blank" href="{{ source.url }}">{{ source.organisation }} {{ source.label }}</a>
+    {% else %}
+      {{ source.label }}
+    {% endif %}
+    <br/>Last updated: {{ source.last_release|str_to_datetime|date:"F Y"}}
+    {% if additional_source_text %}
+        <br/>{{ additional_source_text }}
+    {% endif %}
+    {% if factsheet_link %}
+      <br/><a class='link' target="_blank" href={{ factsheet_link }}>Download</a> the latest trade and investment factsheet for {{ country }}.
+    {% endif %}
+    {% endspaceless %}
+</p>

--- a/tests/unit/domestic/test_models.py
+++ b/tests/unit/domestic/test_models.py
@@ -706,6 +706,36 @@ def test_industry_accordions_validation(blocks_to_create, expected_exception_mes
             assert False, f'Should not have got a {e}'
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'intro_ctas,expected_factsheet_link_value',
+    (
+        (
+            {
+                'intro_cta_one_title': 'View latest trade statistics',
+                'intro_cta_one_link': 'www.test-factsheet.gov.uk',
+                'intro_cta_two_title': 'Another title',
+                'intro_cta_two_link': 'www.test.gov.uk',
+            },
+            'www.test-factsheet.gov.uk',
+        ),
+        (
+            {
+                'intro_cta_one_title': 'A nice title',
+                'intro_cta_one_link': 'www.test-title.gov.uk',
+                'intro_cta_two_title': 'Another title',
+                'intro_cta_two_link': 'www.test.gov.uk',
+            },
+            None,
+        ),
+        ({}, None),
+    ),
+)
+def test_country_fact_sheet_link(domestic_homepage, intro_ctas, expected_factsheet_link_value):
+    page = CountryGuidePageFactory(parent=domestic_homepage, **intro_ctas)
+    assert page.country_fact_sheet_link == expected_factsheet_link_value
+
+
 # BaseContentPage is abstract but had some methods on it
 
 


### PR DESCRIPTION
This PR updates the market guide pages to:
- Pull in data on the source of our statistics from the API
- Display the source data on the trade highlights statistics and three graphs
- Have a property `country_fact_sheet_link` in order for this to be downloadable for each country
- Have more consistent styling

To test locally:
- Switch `FEATURE_SHOW_MARKET_GUIDE_VISUALISATIONS` to True
- Go to http://greatcms.trade.great:8020/markets/china/

**Screenshots - BEFORE**
![Screenshot 2022-10-06 at 09 23 32](https://user-images.githubusercontent.com/22460823/194260987-bb57505f-4efd-42e3-8b9d-3881da0a111b.png)

![Screenshot 2022-10-06 at 09 23 23](https://user-images.githubusercontent.com/22460823/194260977-5bacd83e-2180-47d7-a6b3-b9838c22380f.png)

**Screenshots - AFTER**
![Screenshot 2022-10-06 at 09 24 41](https://user-images.githubusercontent.com/22460823/194261217-6ee5830f-a193-433d-88bc-8ed48bdf3c9b.png)

![Screenshot 2022-10-06 at 09 24 55](https://user-images.githubusercontent.com/22460823/194261262-d70cc4e7-5ecb-42dd-9f6b-bdd30243f9e0.png)


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GLS-456
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
