### PR TITLE
Pass privacy policy url to FTA form template

### DIFF
--- a/contact/views.py
+++ b/contact/views.py
@@ -16,6 +16,7 @@ from formtools.wizard.views import NamedUrlSessionWizardView
 
 from contact import constants, forms as contact_forms, helpers
 from core import mixins as core_mixins, snippet_slugs
+from core.cms_slugs import PRIVACY_POLICY_URL__CONTACT_TRIAGE_FORMS_SPECIAL_PAGE
 from core.datastructures import NotifySettings
 from directory_constants import urls
 from sso.helpers import update_user_profile
@@ -718,3 +719,10 @@ class FTASubscribeFormView(
     notify_settings = NotifySettings(
         user_template=settings.SUBSCRIBE_TO_FTA_UPDATES_NOTIFY_TEMPLATE_ID,
     )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(
+            **kwargs,
+        )
+        context['privacy_url'] = PRIVACY_POLICY_URL__CONTACT_TRIAGE_FORMS_SPECIAL_PAGE
+        return context

--- a/core/templates/core/includes/contact-consent.html
+++ b/core/templates/core/includes/contact-consent.html
@@ -1,5 +1,5 @@
 <div class='contact-consent rich-text'>
-	 {% include 'core/includes/privacy_notice.html' %}
+	 {% include 'core/includes/privacy_notice.html' with privacy_url=privacy_url %}
 	<h3>Additional information</h3>
 	<p>If you would like to receive additional information about export you can opt in below. You can opt out of these updates at any time.</p>
 </div>

--- a/tests/unit/contact/test_views.py
+++ b/tests/unit/contact/test_views.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 
 from contact import constants, forms, helpers, views
 from core import snippet_slugs
+from core.cms_slugs import PRIVACY_POLICY_URL__CONTACT_TRIAGE_FORMS_SPECIAL_PAGE
 from core.constants import CONSENT_EMAIL
 from core.tests.helpers import create_response
 from directory_api_client.exporting import url_lookup_by_postcode
@@ -1436,3 +1437,9 @@ def test_fta_form_submit_success(mock_form_session, client, settings):
             form_session=mock_form_session(),
         ),
     ]
+
+
+def test_privacy_url_passed_to_fta_form_view(client, mock_free_trade_agreements):
+
+    response = client.get(reverse('contact:contact-free-trade-agreements'))
+    assert response.context['privacy_url'] == PRIVACY_POLICY_URL__CONTACT_TRIAGE_FORMS_SPECIAL_PAGE


### PR DESCRIPTION
This PR fixes an issue introduced by #1914 where the `privacy_url` variable is not passed to the FTA form, meaning that currently the privacy notice link at the bottom of the form page just links to the current URL.

![Screenshot 2022-10-26 at 16 16 48](https://user-images.githubusercontent.com/22460823/198066136-1594f575-31e0-4b34-9a78-e88d539461c1.png)


**Before**
![Screenshot 2022-10-26 at 16 14 56](https://user-images.githubusercontent.com/22460823/198065692-b35b6a6e-2cf9-473f-8ef8-6de5f8a205cd.png)


**After**
![Screenshot 2022-10-26 at 16 14 16](https://user-images.githubusercontent.com/22460823/198065502-18516b02-ac9e-4536-8e15-ad589e54e562.png)


### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-54
- [ ] Jira ticket has the correct status.

### Reviewing help

- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
