### PR TITLE
Correct contact CTA destinations for Scottish trade offices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,17 @@
 ## Pre release
 
 ### Bugs fixed
+* KLS-80 - Correct form destinations and CTA style for Scottish offices
 
 ### Hotfix
 
 ### Enhancements
+
+## [2.19.0](https://github.com/uktrade/great-cms/releases/tag/2.19.0)
+### Enhancements
 * KLS-124 - Remove FTA feature flag
 * KLS-144 - Upgrade cryptography package
 * KLS-149 - Upgrade loader-utils package
-
 
 ## [2.18.1](https://github.com/uktrade/great-cms/releases/tag/2.18.1)
 

--- a/contact/templates/domestic/contact/includes/office-contact-cta.html
+++ b/contact/templates/domestic/contact/includes/office-contact-cta.html
@@ -1,0 +1,5 @@
+{% if office.name|lower == 'scottish enterprise' %}
+    <a href="{{ office.website }}" target="_BLANK" class="{{ link_class }}">Contact {{ office.name }} office</a>
+{% else %}
+    <a href="{% url 'contact:office-finder-contact' postcode=form.cleaned_data.postcode %}" class="{{ link_class }}">Contact {{ office.name }} office</a>
+{% endif %}

--- a/contact/templates/domestic/contact/office-finder.html
+++ b/contact/templates/domestic/contact/office-finder.html
@@ -52,11 +52,7 @@
                     <p><a class="link" href="tel:{{ office.phone_other }}">{{ office.phone_other }}</a></p>
                 {% endif %}
                 <br>
-                {% if office.region_id == 'scotland' %}
-                <a href="http://www.scottish-enterprise.com/contact-us" target="_BLANK" class="link">Contact {{ office.name }} office</a>
-                {% else %}
-                <a href="{% url 'contact:office-finder-contact' postcode=form.cleaned_data.postcode %}" class="button">Contact {{ office.name }} office</a>
-                {% endif %}
+                {% include 'domestic/contact/includes/office-contact-cta.html' with office=office link_class="button" %}
 
             </section>
             {% else %}
@@ -94,7 +90,7 @@
                                 <h3 class="heading-smal">{{ office.phone_other_comment }}</h3>
                                 <p><a class="link" href="tel:{{ office.phone_other }}">{{ office.phone_other }}</a></p>
                             {% endif %}
-                            <a href="{% url 'contact:office-finder-contact' postcode=form.cleaned_data.postcode %}" class="link">Contact {{ office.name }} office</a>
+                            {% include 'domestic/contact/includes/office-contact-cta.html' with office=office link_class="link" %}
                         </div>
 
                     </div>


### PR DESCRIPTION
This PR fixes an error in which the wrong destinations were applied to the Scottish enterprise and DIT Scotland office's contact buttons.

Since both offices need to have a region of `scotland` in directory API to be matched with Scottish postcodes, the logic now checks the name of the office, and if it is the Scottish Enterprise office, uses their website URL as the destination of the contact button.

The styling of the Scottish Enterprise contact us link has also been made consistent with all other offices - showing a button rather than a link. Shown below.

**TODO**
If more offices ask to be contacted via their website rather than our contact form, we should add a field to the [trade office model in directory-api](https://github.com/uktrade/directory-api/blob/develop/exporting/models.py#L6) which sets whether the office wants to be contacted via their website or our form. The template in this repo would then use that logic to determine the destination of the contact button, rather than it being hardcoded to the office name.

**Screenshot - after**
![Screenshot 2022-11-25 at 15 37 35](https://user-images.githubusercontent.com/22460823/204017659-92b78e6d-6155-4b44-9217-408f068e804a.png)


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-80
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
