### PR TITLE
KLS-266 - Get survey details from directory API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 * KLS-32 - Update content in signup confirmation page
 * KLS-213 - Add phone number field to trade office contact forms
+* KLS-266 - Get survey details from directory API
 
 ## [2.20.0](https://github.com/uktrade/great-cms/releases/tag/2.20.0)
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -137,6 +137,7 @@ urlpatterns = [
         skip_ga360(views_api.CompaniesHouseAPIView.as_view()),
         name='api-companies-house',
     ),
+    path('api/survey/<str:id>/', skip_ga360(views_api.SurveyDetailView.as_view()), name='api-survey'),
     path(
         'subtitles/<int:great_media_id>/<str:language>/content.vtt',
         login_required(

--- a/core/views_api.py
+++ b/core/views_api.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 
 from core import helpers, serializers
 from core.fern import Fern
+from directory_api_client import api_client
 from directory_constants import choices
 
 logger = logging.getLogger(__name__)
@@ -148,4 +149,12 @@ class CompaniesHouseAPIView(generics.GenericAPIView):
                 company_number=request.GET.get('company_number')
             )
         response.raise_for_status()
+        return Response(response.json())
+
+
+class SurveyDetailView(generics.GenericAPIView):
+    permission_classes = []
+
+    def get(self, request, *args, **kwargs):
+        response = api_client.survey.get_survey_details(id=kwargs['id'])
         return Response(response.json())

--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ sentry-sdk==0.13.*
 # DIT packages
 # ------------
 great-components>=1.1.*
-directory-api-client==26.0.0
+directory-api-client==26.1.1
 directory-constants==21.1.*
 directory-healthcheck==2.0.0
 directory-forms-api-client==6.1.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via pyhanko
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements.in
     #   pyhanko
@@ -61,9 +61,7 @@ cssselect2==0.7.0
     # via svglib
 dateparser==0.7.2
     # via -r requirements.in
-deprecated==1.2.13
-    # via redis
-directory-api-client==26.0.0
+directory-api-client==26.1.1
     # via -r requirements.in
 directory-ch-client==2.1.0
     # via -r requirements.in
@@ -162,7 +160,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements.in
     #   wagtail-factories
-faker==15.3.1
+faker==15.3.4
     # via factory-boy
 future==0.18.2
     # via arabic-reshaper
@@ -223,10 +221,8 @@ openpyxl==3.0.10
     # via tablib
 oscrypto==1.3.0
     # via pyhanko-certvalidator
-packaging==21.3
-    # via
-    #   redis
-    #   sphinx
+packaging==22.0
+    # via sphinx
 pillow==9.3.0
     # via
     #   -r requirements.in
@@ -244,12 +240,10 @@ pygments==2.13.0
     # via sphinx
 pyhanko==0.15.1
     # via xhtml2pdf
-pyhanko-certvalidator==0.19.6
+pyhanko-certvalidator==0.19.7
     # via
     #   pyhanko
     #   xhtml2pdf
-pyparsing==3.0.9
-    # via packaging
 pypdf3==1.0.6
     # via xhtml2pdf
 pyquery==1.4.3
@@ -283,7 +277,7 @@ qrcode==7.3.1
     # via pyhanko
 readtime==1.1.1
     # via -r requirements.in
-redis==4.3.4
+redis==4.4.0
     # via django-redis
 regex==2022.10.31
     # via dateparser
@@ -338,7 +332,7 @@ sqlparse==0.4.3
     # via django
 svglib==1.4.1
     # via xhtml2pdf
-tablib[xls,xlsx]==3.2.1
+tablib[xls,xlsx]==3.3.0
     # via wagtail
 tinycss2==1.2.1
     # via
@@ -346,7 +340,7 @@ tinycss2==1.2.1
     #   svglib
 tqdm==4.64.1
     # via pypdf3
-tzdata==2022.6
+tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via
@@ -358,7 +352,7 @@ unidecode==1.3.6
     # via wagtail
 uritools==4.0.0
     # via pyhanko-certvalidator
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   -r requirements.in
     #   botocore
@@ -367,7 +361,7 @@ urllib3==1.26.12
     #   elasticsearch
     #   requests
     #   sentry-sdk
-w3lib==2.0.1
+w3lib==2.1.1
     # via directory-client-core
 wagtail==2.11.9
     # via
@@ -401,8 +395,6 @@ whitenoise==4.1.4
     # via -r requirements.in
 willow==1.4.1
     # via wagtail
-wrapt==1.14.1
-    # via deprecated
 xhtml2pdf==0.2.8
     # via -r requirements.in
 xlrd==2.0.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,9 +10,9 @@ airtable-python-wrapper==0.13.0
     # via -r requirements.in
 alabaster==0.7.12
     # via sphinx
-allure-pytest==2.11.1
+allure-pytest==2.12.0
     # via -r requirements_test.in
-allure-python-commons==2.11.1
+allure-python-commons==2.12.0
     # via allure-pytest
 anyascii==0.3.1
     # via wagtail
@@ -23,9 +23,9 @@ asn1crypto==1.5.1
     #   oscrypto
     #   pyhanko
     #   pyhanko-certvalidator
-astroid==2.12.12
+astroid==2.12.13
     # via pylint
-asttokens==2.1.0
+asttokens==2.2.1
     # via stack-data
 async-generator==1.10
     # via
@@ -50,7 +50,7 @@ beautifulsoup4==4.8.2
     #   great-components
     #   readtime
     #   wagtail
-black==22.10.0
+black==22.12.0
     # via
     #   -r requirements_test.in
     #   blacken-docs
@@ -96,7 +96,7 @@ coverage[toml]==6.5.0
     # via
     #   codecov
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements.in
     #   pyhanko
@@ -113,11 +113,9 @@ decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-deprecated==1.2.13
-    # via redis
 dill==0.3.6
     # via pylint
-directory-api-client==26.0.0
+directory-api-client==26.1.1
     # via -r requirements.in
 directory-ch-client==2.1.0
     # via -r requirements.in
@@ -217,7 +215,7 @@ elasticsearch-dsl==7.4.0
     # via -r requirements.in
 et-xmlfile==1.1.0
     # via openpyxl
-exceptiongroup==1.0.1
+exceptiongroup==1.0.4
     # via
     #   pytest
     #   trio
@@ -227,9 +225,9 @@ factory-boy==2.12.0
     # via
     #   -r requirements.in
     #   wagtail-factories
-faker==15.3.1
+faker==15.3.4
     # via factory-boy
-filelock==3.8.0
+filelock==3.8.2
     # via virtualenv
 flake8==3.9.2
     # via
@@ -284,7 +282,7 @@ html5lib==1.1
     # via
     #   wagtail
     #   xhtml2pdf
-identify==2.5.8
+identify==2.5.9
     # via pre-commit
 idna==3.4
     # via
@@ -292,13 +290,13 @@ idna==3.4
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.0.0
+importlib-metadata==5.1.0
     # via flask
 iniconfig==1.1.1
     # via pytest
 ipdb==0.13.9
     # via -r requirements_test.in
-ipython==8.6.0
+ipython==8.7.0
     # via ipdb
 iso3166==1.0.1
     # via -r requirements.in
@@ -308,7 +306,7 @@ isort==5.6.4
     #   pylint
 itsdangerous==2.1.2
     # via flask
-jedi==0.18.1
+jedi==0.18.2
     # via ipython
 jinja2==3.1.2
     # via
@@ -324,7 +322,7 @@ l18n==2021.3
     # via wagtail
 lazy-object-proxy==1.8.0
     # via astroid
-locust==2.13.0
+locust==2.13.2
     # via -r requirements_test.in
 lxml==4.9.1
     # via
@@ -371,16 +369,15 @@ oscrypto==1.3.0
     # via pyhanko-certvalidator
 outcome==1.2.0
     # via trio
-packaging==21.3
+packaging==22.0
     # via
     #   build
     #   pytest
     #   pytest-sugar
-    #   redis
     #   sphinx
 parso==0.8.3
     # via jedi
-pathspec==0.10.1
+pathspec==0.10.3
     # via black
 pep517==0.13.0
     # via build
@@ -398,11 +395,11 @@ pillow==9.3.0
     #   reportlab
     #   wagtail
     #   xhtml2pdf
-pip-tools==6.9.0
+pip-tools==6.11.0
     # via -r requirements_test.in
 pisa==3.0.33
     # via -r requirements.in
-platformdirs==2.5.3
+platformdirs==2.6.0
     # via
     #   black
     #   pylint
@@ -415,7 +412,7 @@ pre-commit==2.20.0
     # via -r requirements_test.in
 pre-commit-hooks==3.3.0
     # via -r requirements_test.in
-prompt-toolkit==3.0.32
+prompt-toolkit==3.0.36
     # via ipython
 psutil==5.9.4
     # via locust
@@ -440,11 +437,11 @@ pygments==2.13.0
     #   sphinx
 pyhanko==0.15.1
     # via xhtml2pdf
-pyhanko-certvalidator==0.19.6
+pyhanko-certvalidator==0.19.7
     # via
     #   pyhanko
     #   xhtml2pdf
-pylint==2.15.5
+pylint==2.15.8
     # via
     #   pylint-django
     #   pylint-plugin-utils
@@ -452,8 +449,6 @@ pylint-django==2.5.3
     # via -r requirements_test.in
 pylint-plugin-utils==0.7
     # via pylint-django
-pyparsing==3.0.9
-    # via packaging
 pypdf3==1.0.6
     # via xhtml2pdf
 pyquery==1.4.3
@@ -507,7 +502,7 @@ qrcode==7.3.1
     # via pyhanko
 readtime==1.1.1
     # via -r requirements.in
-redis==4.3.4
+redis==4.4.0
     # via django-redis
 regex==2022.10.31
     # via dateparser
@@ -542,7 +537,7 @@ ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 s3transfer==0.4.2
     # via boto3
-selenium==4.6.0
+selenium==4.7.2
     # via -r requirements_test.in
 sentry-sdk==0.13.5
     # via -r requirements.in
@@ -584,13 +579,13 @@ sqlparse==0.4.3
     # via
     #   django
     #   django-debug-toolbar
-stack-data==0.6.0
+stack-data==0.6.2
     # via ipython
 svglib==1.4.1
     # via xhtml2pdf
-tablib[xls,xlsx]==3.2.1
+tablib[xls,xlsx]==3.3.0
     # via wagtail
-termcolor==2.1.0
+termcolor==2.1.1
     # via pytest-sugar
 tinycss2==1.2.1
     # via
@@ -613,7 +608,7 @@ tomlkit==0.11.6
     # via pylint
 tqdm==4.64.1
     # via pypdf3
-traitlets==5.5.0
+traitlets==5.7.0
     # via
     #   ipython
     #   matplotlib-inline
@@ -629,7 +624,7 @@ typing-extensions==4.4.0
     #   black
     #   locust
     #   pylint
-tzdata==2022.6
+tzdata==2022.7
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via
@@ -641,7 +636,7 @@ unidecode==1.3.6
     # via wagtail
 uritools==4.0.0
     # via pyhanko-certvalidator
-urllib3[socks]==1.26.12
+urllib3[socks]==1.26.13
     # via
     #   -r requirements.in
     #   botocore
@@ -651,9 +646,9 @@ urllib3[socks]==1.26.12
     #   requests
     #   selenium
     #   sentry-sdk
-virtualenv==20.16.6
+virtualenv==20.17.1
     # via pre-commit
-w3lib==2.0.1
+w3lib==2.1.1
     # via directory-client-core
 wagtail==2.11.9
     # via
@@ -690,16 +685,14 @@ werkzeug==2.2.2
     #   -r requirements_test.in
     #   flask
     #   locust
-wheel==0.38.3
+wheel==0.38.4
     # via pip-tools
 whitenoise==4.1.4
     # via -r requirements.in
 willow==1.4.1
     # via wagtail
 wrapt==1.14.1
-    # via
-    #   astroid
-    #   deprecated
+    # via astroid
 wsproto==1.2.0
     # via trio-websocket
 xhtml2pdf==0.2.8
@@ -710,11 +703,11 @@ xlsxwriter==1.4.5
     # via wagtail
 xlwt==1.3.0
     # via tablib
-zipp==3.10.0
+zipp==3.11.0
     # via importlib-metadata
 zope-event==4.5.0
     # via gevent
-zope-interface==5.5.1
+zope-interface==5.5.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -549,6 +549,14 @@ def patch_get_suggested_markets():
 
 
 @pytest.fixture
+def mock_get_survey():
+    yield mock.patch(
+        'directory_api_client.api_client.survey.get_survey_details',
+        return_value=create_response(status_code=200, json_body={'result': 'ok'}),
+    ).start()
+
+
+@pytest.fixture
 def mock_trading_blocs():
     body = [
         {

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -1031,3 +1031,11 @@ def test_serve_subtitles__login_required(client):
 
     assert resp.status_code == 302
     assert resp._headers['location'] == ('Location', reverse('core:login') + f'?next={dest}')
+
+
+@pytest.mark.django_db
+def test_get_survey_view_api_view(client, mock_get_survey):
+    url = reverse('core:api-survey', kwargs={'id': '123'})
+    client.get(url)
+    assert mock_get_survey.call_count == 1
+    assert mock_get_survey.call_args == mock.call(id='123')


### PR DESCRIPTION
This PR adds a view which, given a survey id, fetches a survey's details from directory API via the API client.

This is the first piece of work towards creating a new survey for potential exporters on the site.

**To test**
- Add a survey to your local directory API instance, copy the ID of the survey
- In your browser go to `http://greatcms.trade.great:8020/api/survey/<ID>`

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-266
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Housekeeping

- [ ] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
