### PR TITLE
Update date input test to get current year dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre release
 
 ### Bugs fixed
+* Update MonthYearInput test to get current year dynamically
 
 ### Hotfix
 

--- a/react-components/src/components/Form/MonthYearInput/MonthYearInput.test.jsx
+++ b/react-components/src/components/Form/MonthYearInput/MonthYearInput.test.jsx
@@ -4,6 +4,9 @@ import { MonthYearInput } from '.'
 
 const mockOnChange = jest.fn()
 
+const currentYear = new Date().getFullYear()
+const nextYear = currentYear + 1
+
 describe('MonthYearInput', () => {
   afterEach(() => {
     jest.clearAllMocks()
@@ -21,11 +24,11 @@ describe('MonthYearInput', () => {
     )
 
     act(() => {
-      getByText('2022').click()
+      getByText(currentYear.toString()).click()
     })
 
     await waitFor(() =>
-      expect(mockOnChange).toHaveBeenCalledWith({ year: '2022' })
+      expect(mockOnChange).toHaveBeenCalledWith({ year: currentYear.toString() })
     )
   })
 
@@ -46,11 +49,11 @@ describe('MonthYearInput', () => {
     )
 
     act(() => {
-      getByText('2023').click()
+      getByText(nextYear.toString()).click()
     })
 
     await waitFor(() =>
-      expect(mockOnChange).toHaveBeenCalledWith({ end_year: '2023' })
+      expect(mockOnChange).toHaveBeenCalledWith({ end_year: nextYear.toString() })
     )
   })
 


### PR DESCRIPTION
This PR updates the `MonthYearInput` react component test. Previously, it relied on the current calendar year being hardcoded in order to pass. It now calculates the current and next calendar years in the test file, and tests for these values.

The test tests a dropdown field to select a year, which allows a user to choose a year between the current year and 10 years from now.

### Workflow

- [x] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
