### PR TITLE
KLS 270 - add webinar duration to listing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * KLS-363 - Created Microsite template
 * KLS-437 - Change DIT references to DBT
 * KLS-407 - Add format filters to the Export Academy event listings page
+* KLS-270 - Add webinar duration to event listing template
 
 ## [2.27.0](https://github.com/uktrade/great-cms/releases/tag/2.27.0)
 [Full Changelog](https://github.com/uktrade/great-cms/compare/2.26.0...2.27.0)

--- a/export_academy/templates/export_academy/event_list.html
+++ b/export_academy/templates/export_academy/event_list.html
@@ -39,6 +39,7 @@
                             {% for event in event_by_date.list %}
                             <li>
                                 <h5>{{ event.start_date|date:"fa" }} - {{ event.end_date|date:"fa" }}</h5>
+                                <h6>Duration: {{event.start_date|timesince:event.end_date}}</h6>
                                 <h6>{{ event.name }}</h6>
                                 <p>{{ event.description }}</p>
                                 <form action="{% url 'export_academy:booking' %}" method="post">


### PR DESCRIPTION
Add duration of webinar to event listing page. 
<img width="1026" alt="Screenshot 2023-03-09 at 11 39 59" src="https://user-images.githubusercontent.com/1638245/224015805-e88b1901-1f02-401d-aa8c-0d097db9703e.png">

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/jira/software/projects/KLS/boards/359?selectedIssue=KLS-270
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
