### PR TITLE
Clone events on Wagtail admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 * KLS-426 - Add event types to filterset on UKEA's listings page
+* KLS-452 - Event cloning from Wagtail admin
 
 ## [2.28.0](https://github.com/uktrade/great-cms/releases/tag/2.28.0)
 [Full Changelog](https://github.com/uktrade/great-cms/compare/2.27.0...2.28.0)

--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -19,9 +19,9 @@ class EventListView(FilterView, ListView):
         bookings = []
 
         if user.is_authenticated:
-            bookings = models.Booking.objects.filter(registration_id=user.email, status='Confirmed').values_list(
-                'event_id', flat=True
-            )
+            bookings = models.Booking.objects.filter(
+                registration_id=user.email, status='Confirmed'  # type: ignore
+            ).values_list('event_id', flat=True)
 
         ctx.update(bookings=bookings, filter=self.filterset_class(self.request.GET))
 
@@ -54,7 +54,7 @@ class RegistrationFormView(BookingMixin, FormView):
         reg_data = dict(
             first_name=cleaned_data.get('first_name'),
             last_name=cleaned_data.get('last_name'),
-            email=self.request.user.email,
+            email=self.request.user.email,  # type: ignore
             data=cleaned_data,
         )
         self.save_model(reg_data)

--- a/export_academy/wagtail_hooks.py
+++ b/export_academy/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from django.contrib.admin.utils import quote
 from django.urls import re_path
-from django.utils.translation import gettext_lazy, ugettext_lazy
+from django.utils.translation import gettext_lazy
 from wagtail.contrib.modeladmin.helpers import ButtonHelper
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.contrib.modeladmin.views import CreateView, InstanceSpecificView
@@ -13,7 +13,7 @@ class CloneView(CreateView, InstanceSpecificView):
 
 
 class EventAdminButtonHelper(ButtonHelper):
-    """EventAdminButtonHelper lorem ipsum dolor sit amet."""
+    """EventAdminButtonHelper handles special button configuration for Events on Wagtail admin."""
 
     clone_button_classnames = ['button-small', 'button-secondary']
 
@@ -22,9 +22,9 @@ class EventAdminButtonHelper(ButtonHelper):
 
         return {
             'url': self.url_helper.get_action_url('clone', quote(obj.pk)),
-            'label': ugettext_lazy('Clone'),
+            'label': gettext_lazy('Clone'),
             'classname': classname,
-            'title': ugettext_lazy('Clone a new %s') % self.verbose_name,
+            'title': gettext_lazy('Clone a new %s') % self.verbose_name,
         }
 
     def get_buttons_for_obj(self, obj, exclude=None, classnames_add=None, classnames_exclude=None):
@@ -35,8 +35,8 @@ class EventAdminButtonHelper(ButtonHelper):
         return btns
 
 
-class EventsAdmin(ModelAdmin):
-    """EventsAdmin allows to add the Event model to the Wagtail admin."""
+class EventAdmin(ModelAdmin):
+    """EventAdmin allows to add the Event model to the Wagtail admin."""
 
     model = Event
     button_helper_class = EventAdminButtonHelper
@@ -76,4 +76,4 @@ class EventsAdmin(ModelAdmin):
         return urls
 
 
-modeladmin_register(EventsAdmin)
+modeladmin_register(EventAdmin)

--- a/export_academy/wagtail_hooks.py
+++ b/export_academy/wagtail_hooks.py
@@ -1,10 +1,46 @@
+from django.contrib.admin.utils import quote
+from django.urls import re_path
+from django.utils.translation import gettext_lazy, ugettext_lazy
+from wagtail.contrib.modeladmin.helpers import ButtonHelper
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail.contrib.modeladmin.views import CreateView, InstanceSpecificView
 
-from export_academy import models
+from export_academy.models import Event
+
+
+class CloneView(CreateView, InstanceSpecificView):
+    page_title = gettext_lazy('Cloning')
+
+
+class EventAdminButtonHelper(ButtonHelper):
+    """EventAdminButtonHelper lorem ipsum dolor sit amet."""
+
+    clone_button_classnames = ['button-small', 'button-secondary']
+
+    def clone_button(self, obj):
+        classname = self.finalise_classname(classnames_add=self.clone_button_classnames)
+
+        return {
+            'url': self.url_helper.get_action_url('clone', quote(obj.pk)),
+            'label': ugettext_lazy('Clone'),
+            'classname': classname,
+            'title': ugettext_lazy('Clone a new %s') % self.verbose_name,
+        }
+
+    def get_buttons_for_obj(self, obj, exclude=None, classnames_add=None, classnames_exclude=None):
+        btns = super().get_buttons_for_obj(obj, exclude, classnames_add, classnames_exclude)
+        if 'clone' not in (exclude or []):
+            btns.insert(1, self.clone_button(obj))
+
+        return btns
 
 
 class EventsAdmin(ModelAdmin):
-    model = models.Event
+    """EventsAdmin allows to add the Event model to the Wagtail admin."""
+
+    model = Event
+    button_helper_class = EventAdminButtonHelper
+    clone_view_class = CloneView
     base_url_path = 'events'
     menu_label = 'Events'
     menu_icon = 'date'
@@ -20,6 +56,24 @@ class EventsAdmin(ModelAdmin):
         return ', '.join(str(type.name) for type in obj.types.all())
 
     get_types.short_description = 'Type'
+
+    def clone_view(self, request, **kwargs):
+        kwargs.update(**{'model_admin': self})
+        view_class = self.clone_view_class
+
+        return view_class.as_view(**kwargs)(request)
+
+    def get_admin_urls_for_registration(self):
+        urls = super().get_admin_urls_for_registration()
+        urls += (
+            re_path(
+                self.url_helper.get_action_url_pattern('clone'),
+                self.clone_view,
+                name=self.url_helper.get_action_url_name('clone'),
+            ),
+        )
+
+        return urls
 
 
 modeladmin_register(EventsAdmin)

--- a/tests/unit/export_academy/test_wagtail_hooks.py
+++ b/tests/unit/export_academy/test_wagtail_hooks.py
@@ -1,0 +1,59 @@
+from unittest import mock
+
+import pytest
+
+from export_academy.wagtail_hooks import EventAdmin, EventAdminButtonHelper
+from tests.unit.export_academy.factories import EventFactory
+
+
+@pytest.mark.django_db
+def test_event_admin_button_helper(rf, django_user_model):
+    obj = EventFactory()
+
+    user = django_user_model.objects.create_user(username='username', password='password', is_staff=True)
+
+    request = rf.get('/')
+    request.user = user
+
+    mock_view = mock.Mock(name='mock_view')
+    mock_view.model = obj._meta.model  # type: ignore
+    mock_view.url_helper.get_action_url.return_value = '/admin/mock-url/path/'
+
+    helper = EventAdminButtonHelper(request=request, view=mock_view)
+
+    assert helper.clone_button(obj) == {
+        'classname': 'button button-small button-secondary',
+        'label': 'Clone',
+        'title': 'Clone a new event',
+        'url': '/admin/mock-url/path/',
+    }
+
+    assert helper.get_buttons_for_obj(obj) == [
+        {'url': '/admin/mock-url/path/', 'label': 'Inspect', 'classname': 'button', 'title': 'Inspect this event'},
+        {
+            'url': '/admin/mock-url/path/',
+            'label': 'Clone',
+            'classname': 'button button-small button-secondary',
+            'title': 'Clone a new event',
+        },
+        {'url': '/admin/mock-url/path/', 'label': 'Edit', 'classname': 'button', 'title': 'Edit this event'},
+        {'url': '/admin/mock-url/path/', 'label': 'Delete', 'classname': 'button no', 'title': 'Delete this event'},
+    ]
+
+
+@pytest.mark.django_db
+def test_event_admin(rf, django_user_model):
+    admin = EventAdmin()
+    obj = EventFactory()
+    user = django_user_model.objects.create_user(username='username', password='password', is_staff=True)
+
+    obj.types.add('Masterclass')  # type: ignore
+    obj.types.add('Sector')  # type: ignore
+
+    assert admin.get_types(obj) == 'Masterclass, Sector'
+
+    request = rf.get('/')
+    request.user = user
+    view = admin.clone_view(request, instance_pk=obj.pk)  # type: ignore
+
+    assert view.context_data['model_admin'] == admin  # type: ignore


### PR DESCRIPTION
CONTEXT: This changeset brings the ability to clone events from Wagtail admin.

![image](https://user-images.githubusercontent.com/471674/224677426-03d6e56f-cc17-4b77-bd55-09e1781b18e7.png)

![image](https://user-images.githubusercontent.com/471674/224677474-91d26baf-3f39-4685-b673-d57c20fc4ffc.png)

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-452
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [X] Includes screenshot(s)

### Merging

- [X] This PR can be merged by reviewers.
