### PR TITLE
Eam 104 refine

### DIFF
--- a/export_academy/helpers.py
+++ b/export_academy/helpers.py
@@ -29,19 +29,23 @@ def get_buttons_for_event(user, event):
                     {'url': event.link, 'label': 'Join', 'classname': 'text', 'title': 'Join'},
                 ]
         else:
-            result['form_event_booking_buttons'] += [
-                {
-                    'label': 'Book',
-                    'classname': 'link',
-                    'value': 'Confirmed',
-                    'type': 'submit',
-                },
-            ]
+            result['form_event_booking_buttons'] += get_event_booking_button()
     else:
-        # logged out event buttons
-        pass
+        # logged out buttons
+        result['form_event_booking_buttons'] += get_event_booking_button()
 
     return result
+
+
+def get_event_booking_button():
+    return [
+        {
+            'label': 'Book',
+            'classname': 'link',
+            'value': 'Confirmed',
+            'type': 'submit',
+        },
+    ]
 
 
 def get_event_completed_buttons(event):

--- a/tests/unit/export_academy/test_helpers.py
+++ b/tests/unit/export_academy/test_helpers.py
@@ -11,9 +11,26 @@ from tests.unit.export_academy import factories
 
 
 @pytest.mark.django_db
-def test_book_button_returned_for_upcoming_event(user):
+def test_book_button_returned_for_upcoming_event_registered_user(user):
     now = datetime.now(tz=timezone.utc)
     factories.RegistrationFactory(email=user.email)
+    event = factories.EventFactory(start_date=now + timedelta(hours=6), end_date=now + timedelta(hours=7))
+
+    buttons = get_buttons_for_event(user, event)
+
+    assert buttons['form_event_booking_buttons'] == [
+        {
+            'label': 'Book',
+            'classname': 'link',
+            'value': 'Confirmed',
+            'type': 'submit',
+        },
+    ]
+
+
+@pytest.mark.django_db
+def test_book_button_returned_for_upcoming_event_not_registered_user(user):
+    now = datetime.now(tz=timezone.utc)
     event = factories.EventFactory(start_date=now + timedelta(hours=6), end_date=now + timedelta(hours=7))
 
     buttons = get_buttons_for_event(user, event)

--- a/tests/unit/export_academy/test_helpers.py
+++ b/tests/unit/export_academy/test_helpers.py
@@ -82,6 +82,23 @@ def test_join_button_returned_for_booked_in_progress_event(user):
 
 
 @pytest.mark.django_db
+def test_join_button_returned_for_booked_in_upcoming_event(user):
+    now = datetime.now(tz=timezone.utc)
+    event = factories.EventFactory(
+        start_date=now + timedelta(days=1),
+        end_date=now + timedelta(days=1, hours=1),
+    )
+    registration = factories.RegistrationFactory(email=user.email, first_name=user.first_name)
+    factories.BookingFactory(event=event, registration=registration, status='Confirmed')
+
+    buttons = get_buttons_for_event(user, event)
+
+    assert buttons['event_action_buttons'] == [
+        {'url': event.link, 'label': 'Join', 'classname': 'text', 'title': 'Join'}
+    ]
+
+
+@pytest.mark.django_db
 def test_view_buttons_returned_for_booked_past_event(user):
     now = datetime.now(tz=timezone.utc)
     event = factories.EventFactory(


### PR DESCRIPTION
This PR ensures that the 'Book' button is shown for users who are not logged into export academy and additionally displays the 'Join' button upon booking.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/jira/software/projects/KLS/boards/359?selectedIssue=KLS-360
- [x] Jira ticket has the correct status.
- [x] [Changelog](CHANGELOG.md) entry added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
