### PR TITLE
Link "Sign in required" button to login page

### DIFF
--- a/core/templates/components/card.html
+++ b/core/templates/components/card.html
@@ -41,18 +41,18 @@
         {% endif %}
 
         {% if description %}
-    <p>{{ description }}</p>
-  {% endif %}
-  {% if url %}
-  <a class="button primary-button"  href="{{ url }}">
-    View
-  </a>
-  {% endif %}
+          <p>{{ description }}</p>
+        {% endif %}
+        {% if url %}
+          <a class="button primary-button" href="{{ url }}">
+            View
+          </a>
+        {% endif %}
         {% if show_sign_in_required and not request.user.is_authenticated %}
           {% if request.path == '/' %}
-          <div class="sign-in-button-wrapper">
-            <a href="/login/" class="button primary-button govuk-link--no-underline">Sign in required</a>
-          </div>
+            <div class="sign-in-button-wrapper">
+              <a href="/login/"><button class="primary-button small-button">Sign in required</button></a>
+            </div>
           {% endif %}
         {% endif %}
       {% endif %}

--- a/core/templates/components/card.html
+++ b/core/templates/components/card.html
@@ -51,7 +51,7 @@
         {% if show_sign_in_required and not request.user.is_authenticated %}
           {% if request.path == '/' %}
           <div class="sign-in-button-wrapper">
-            <button class="primary-button small-button">Sign in required</button>
+            <a href="/login/" class="button primary-button govuk-link--no-underline">Sign in required</a>
           </div>
           {% endif %}
         {% endif %}

--- a/tests/unit/domestic/test_models.py
+++ b/tests/unit/domestic/test_models.py
@@ -1962,9 +1962,15 @@ def test_great_domestic_homepage_magna_ctas_labels(root_page, client, user):
 
         assert b'<p>Test test</p>' in response.content
         if not user_logged_in:
-            assert b'<button class="primary-button small-button">Sign in required</button>' in response.content
+            assert (
+                b'<a href="/login/" class="button primary-button govuk-link--no-underline">Sign in required</a>'
+                in response.content
+            )
         else:
-            assert b'<button class="primary-button small-button">Sign in required</button>' not in response.content
+            assert (
+                b'<a href="/login/" class="button primary-button govuk-link--no-underline">Sign in required</a>'
+                not in response.content
+            )
 
 
 class StructuralPageTests(WagtailPageTests):

--- a/tests/unit/domestic/test_models.py
+++ b/tests/unit/domestic/test_models.py
@@ -1963,12 +1963,12 @@ def test_great_domestic_homepage_magna_ctas_labels(root_page, client, user):
         assert b'<p>Test test</p>' in response.content
         if not user_logged_in:
             assert (
-                b'<a href="/login/" class="button primary-button govuk-link--no-underline">Sign in required</a>'
+                b'<a href="/login/"><button class="primary-button small-button">Sign in required</button></a>'
                 in response.content
             )
         else:
             assert (
-                b'<a href="/login/" class="button primary-button govuk-link--no-underline">Sign in required</a>'
+                b'<a href="/login/"><button class="primary-button small-button">Sign in required</button></a>'
                 not in response.content
             )
 


### PR DESCRIPTION
This PR links the "Sign in required" buttons on the great dashboard to the login page. To test go to the logged out dashboard and try the "Sign up required" buttons

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/522
- [x] Jira ticket has the correct status.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
