### PR TITLE
KLS-540 - Scroll to top of results when EA filters are refreshed

### DIFF
--- a/domestic/static/javascript/eventFilters.js
+++ b/domestic/static/javascript/eventFilters.js
@@ -12,6 +12,7 @@ var eventFilters = (function () {
     setVars()
     bindEvents()
     setFilters()
+    scrollToTopOfResults()
   }
 
   function setVars() {
@@ -119,6 +120,17 @@ var eventFilters = (function () {
     filters.removeAttribute('role')
     filters.removeAttribute('aria-labelledby')
     mobileFiltersSelected = []
+  }
+
+  function scrollToTopOfResults() {
+    // Scroll so that results are at the top of the screen
+    // when filters are changed
+    const url = new URL(window.location.href)
+    const filtersChanged = document.referrer.includes('/events/')
+    if (url.search.length && filtersChanged) {
+      const breadcumbs = document.getElementById('breadcrumbs')
+      breadcrumbs.scrollIntoView(true)
+    }
   }
 
   return {

--- a/export_academy/templates/export_academy/event_list.html
+++ b/export_academy/templates/export_academy/event_list.html
@@ -13,7 +13,7 @@
             <div class="ea-listing-page">{% include 'components/hero.html' with image=hero.image hero_title=hero.title hero_text=hero.text hide_image_for_mobile=True %}</div>
         {% endwith %}
     {% endblock %}
-    <div class="great-display-from-tablet">
+    <div id="breadcrumbs" class="great-display-from-tablet">
         {% breadcrumbs 'Events' %}
             <a href="/">great.gov.uk</a>
             <a href="{% pageurl landing_page %}">UK Export Academy</a>
@@ -59,7 +59,6 @@
                             <p>There are currently no events available for the filters you have chosen.</p>
                             <p>Remove one or more of your filter choices to broaden your search.</p>
                         {% else %}
-
                             {% for event in page_obj %}
                             <div class="govuk-grid-row event-list-card">
                                 <div class="govuk-!-padding-left-3 govuk-!-padding-right-3 great-display-until-tablet">
@@ -121,9 +120,9 @@
 {{ block.super }}
 <script src="{% static 'javascript/eventFilters.js' %}"></script>
 <script src="{% static 'javascript/showMore.js'%}"></script>
-<script>
-  $(function() {
-    eventFilters.init();
-  });
+<script type="text/javascript">
+    $(function() {
+        eventFilters.init();
+    });
 </script>
 {% endblock %}


### PR DESCRIPTION
This PR adds javascript logic which will scroll the user to the top of the list of results (ie the breadcrumbs component being at the top of the screen) when a user selects a filter.

This scrolling behaviour will occur when:
- There are query parameters are in the url (which happens when filters are applied)
- The referrer url contains `/events/` (to prevent the scrolling happening on book marked or shared links)

**To test**
- Go to `export-academy/events/`
- Select a filter
- When the page reloads, the breadcrumbs element should be at the top of your screen 

![Screenshot 2023-05-09 at 10 13 16](https://user-images.githubusercontent.com/22460823/237050812-070180c6-3645-4a9f-ab7f-5283b9bd95d8.png)

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-540
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
