### PR TITLE
Update breadcrumbs env. type

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -839,7 +839,7 @@ TRAVEL_ADVICE_FOREIGN = env.str('TRAVEL_ADVICE_FOREIGN', 'https://www.gov.uk/for
 # V1 to V2 migration settings
 # (These will be short-lived as we gradually cut over from V1 to V2 for all traffic)
 
-BREADCRUMBS_ROOT_URL = env.bool('BREADCRUMBS_ROOT_URL', 'https://great.gov.uk/')
+BREADCRUMBS_ROOT_URL = env.str('BREADCRUMBS_ROOT_URL', 'https://great.gov.uk/')
 
 
 # Setting up the the datascience s3 bucket to read files


### PR DESCRIPTION
This PR updates the type of the breadcrumb URL environment variable to a string so the URL can be used in code.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
