### PR TITLE
Hotfix - add logic to only get booking data if user logged in

### DIFF
--- a/export_academy/templates/export_academy/includes/event_name_duration.html
+++ b/export_academy/templates/export_academy/includes/event_name_duration.html
@@ -1,5 +1,5 @@
 {% load event_list_buttons %}
 
 <h4 class="event-title">{{ event.name }}</h4>
-{% user_is_booked_on_event request.user event as event_is_booked %}
+{% if not user.is_anonymous %} {% user_is_booked_on_event request.user event as event_is_booked %}{% endif %}
 <p class="great-font-size-18 great-text-light-grey {% if event_is_booked %}govuk-!-margin-bottom-2{% endif %}">Duration: {{ event.start_date|timesince:event.end_date }}</p>


### PR DESCRIPTION
This PR is a hotfix for a bug on the event listing page which causes the page to break if the user is logged out.
The change only calls `user_is_booked_on_event` if the user is not anonymous. 

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

### Housekeeping

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
