### PR TITLE
Fix logged out listing test

### DIFF
--- a/tests/unit/export_academy/test_views.py
+++ b/tests/unit/export_academy/test_views.py
@@ -1,9 +1,11 @@
+from datetime import timedelta
 from unittest import mock
 
 import pytest
 from directory_forms_api_client import actions
 from django.test import override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 from config import settings
 from core.models import HeroSnippet
@@ -27,8 +29,12 @@ def test_export_academy_landing_page(client, export_academy_landing_page, export
 
 
 @pytest.mark.django_db
-def test_export_academy_event_list_page(client, export_academy_landing_page, test_event_list_hero):
-    # Listing page needs a hero snippet instance to work
+# Listing page needs a hero snippet instance to work
+def test_export_academy_event_list_page_logged_out(client, export_academy_landing_page, test_event_list_hero):
+    now = timezone.now()
+    factories.EventFactory.create_batch(
+        5, start_date=now + timedelta(hours=6), end_date=now + timedelta(hours=7), completed=None
+    )
     url = reverse('export_academy:upcoming-events')
     response = client.get(url)
     assert response.status_code == 200


### PR DESCRIPTION
This PR fixes an issue with the test for the logged out event listing view. Previously no events were in the test database, meaning that an error in the template for rendering an event was not caught, as there were no events to render.

This change creates events in the database before calling the URL, meaning it should catch similar errors in the future.

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-639
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
