### PR TITLE
Disallow bot access via robots

### DIFF
--- a/core/templates/robots.txt
+++ b/core/templates/robots.txt
@@ -4,6 +4,7 @@ Disallow: /api/
 Disallow: /activity-stream/
 
 User-agent: MJ12bot
+
 Disallow: /
 
 Sitemap: {{base_url}}/sitemap.xml

--- a/core/templates/robots.txt
+++ b/core/templates/robots.txt
@@ -3,4 +3,7 @@ User-agent: *
 Disallow: /api/
 Disallow: /activity-stream/
 
+User-agent: MJ12bot
+Disallow: /
+
 Sitemap: {{base_url}}/sitemap.xml

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -972,6 +972,10 @@ def test_robots_txt(client, base_url, expected_sitemap_url):
                 b'Disallow: /api/\n',
                 b'Disallow: /activity-stream/\n',
                 b'\n',
+                b'User-agent: MJ12bot\n',
+                b'\n',
+                b'Disallow: /\n',
+                b'\n',
                 f'Sitemap: {expected_sitemap_url}\n'.encode(),
             ]
         )


### PR DESCRIPTION
We are being crawled and attacked via a bot called MJ12bot. Its slowing the international website. Putting this robots.txt fix in to disallow access

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-526
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
