### PR TITLE
Add event registration confirmation page

### DIFF
--- a/export_academy/models.py
+++ b/export_academy/models.py
@@ -159,6 +159,10 @@ class Booking(TimeStampedModel):
     registration = models.ForeignKey(Registration, on_delete=models.CASCADE)
     status = models.CharField(choices=STATUSES, default=CONFIRMED, max_length=15)
 
+    @property
+    def is_cancelled(self):
+        return self.status == self.CANCELLED
+
 
 class ExportAcademyHomePage(ExportAcademyPagePanels, BaseContentPage):
     template = 'export_academy/landing_page.html'

--- a/export_academy/templates/export_academy/booking_success.html
+++ b/export_academy/templates/export_academy/booking_success.html
@@ -21,7 +21,7 @@
             <div class="ea-listing-page">{% include 'components/hero.html' with image=hero.image hero_title=hero.title hero_text=hero.text hide_image_for_mobile=True %}</div>
         {% endwith %}
     {% endblock %}
-    {% breadcrumbs 'Events' %}
+        {% breadcrumbs current_page_breadcrumb %}
         <a href="/">great.gov.uk</a>
         <a href="{% pageurl landing_page %}">UK Export Academy</a>
     {% endbreadcrumbs %}
@@ -34,7 +34,7 @@
                         data-module="govuk-notification-banner">
                         <div class="govuk-notification-banner__header">
                             <h2 class="great-text-white">
-                                {% if booking.status == 'Confirmed' %}Booking{% else %}Cancellation{% endif %} confirmed
+                                {% if just_registered %}Registration{% elif booking.status == 'Confirmed' %}Booking{% else %}Cancellation{% endif %} confirmed
                             </h2>
                         </div>
                         <div class="govuk-notification-banner__content">
@@ -51,6 +51,13 @@
                             {% endif %}
                         </div>
                     </div>
+                    {% if just_registered %}
+                        <h4 class="govuk-!-margin-bottom-3">What happens next</h4>
+                        <p class="great-font-size-mobile-18">
+                            You are now able to book a place on any of our Export Academy events,
+                            watch recordings of past events you’ve booked and cancel any events you can no longer attend.
+                        </p>
+                    {% endif %}
                     <a href="{% url 'export_academy:upcoming-events' %}" class="link block margin-top-30 margin-bottom-60">See all events</a>
                 </div>
             </div>

--- a/export_academy/urls.py
+++ b/export_academy/urls.py
@@ -115,8 +115,12 @@ urlpatterns = [
     ),
     path('booking/', check_registration(views.BookingUpdateView.as_view()), name='booking'),
     path(
-        'registration/success/<uuid:booking_id>',
-        views.RegistrationSuccessPageView.as_view(template_name='export_academy/registration_form_success.html'),
+        'registration/booking/<uuid:booking_id>/success/',
+        views.SuccessPageView.as_view(template_name='export_academy/booking_success.html'),
+        {
+            'slug': snippet_slugs.EA_REGISTRATION_PAGE_HERO,
+            'snippet_import_path': 'core.models.HeroSnippet',  # see core.mixins.GetSnippetContentMixin
+        },
         name='registration-success',
     ),
     path(

--- a/export_academy/urls.py
+++ b/export_academy/urls.py
@@ -129,6 +129,15 @@ urlpatterns = [
         name='booking-success',
     ),
     path(
+        'booking/<uuid:booking_id>/cancellation/success',
+        views.SuccessPageView.as_view(template_name='export_academy/booking_success.html'),
+        {
+            'slug': snippet_slugs.EXPORT_ACADEMY_LISTING_PAGE_HERO,
+            'snippet_import_path': 'core.models.HeroSnippet',  # see core.mixins.GetSnippetContentMixin
+        },
+        name='cancellation-success',
+    ),
+    path(
         'event/<uuid:pk>/',
         views.EventDetailsView.as_view(),
         name='event-details',

--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -85,12 +85,22 @@ class SuccessPageView(core_mixins.GetSnippetContentMixin, TemplateView):
         user = self.request.user
         return get_buttons_for_event(user, event, on_confirmation=True)
 
+    def user_just_registered(self, booking):
+        return self.request.path == reverse_lazy(
+            'export_academy:registration-success', kwargs={'booking_id': booking.id}
+        )
+
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx['landing_page'] = models.ExportAcademyHomePage.objects.first()
+
         booking = models.Booking.objects.get(id=ctx['booking_id'])
         ctx['booking'] = booking
         ctx['event'] = booking.event
+
+        just_registered = self.user_just_registered(booking)
+        ctx['just_registered'] = just_registered
+        ctx['current_page_breadcrumb'] = 'Registration' if just_registered else 'Events'
         return ctx
 
 

--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -74,12 +74,10 @@ class BookingUpdateView(BookingMixin, UpdateView):
         return booking_object
 
     def get_success_url(self):
-        return reverse_lazy('export_academy:booking-success', kwargs={'booking_id': self.object.id})
-
-
-# TODO remove once registration flow merged
-class RegistrationSuccessPageView(TemplateView):
-    pass
+        success_url = (
+            'export_academy:cancellation-success' if self.object.is_cancelled else 'export_academy:booking-success'
+        )
+        return reverse_lazy(success_url, kwargs={'booking_id': self.object.id})
 
 
 class SuccessPageView(core_mixins.GetSnippetContentMixin, TemplateView):

--- a/tests/unit/export_academy/test_models.py
+++ b/tests/unit/export_academy/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 
-from .factories import EventFactory, RegistrationFactory
+from export_academy.models import Booking
+from .factories import BookingFactory, EventFactory, RegistrationFactory
 
 
 @pytest.mark.parametrize(
@@ -11,3 +12,10 @@ from .factories import EventFactory, RegistrationFactory
 def test_model_to_string(factory, attrs):
     instance = factory()
     assert str(instance) == ':'.join([str(getattr(instance, attr)) for attr in attrs])
+
+
+@pytest.mark.parametrize('status,is_cancelled', ((Booking.CANCELLED, True), (Booking.CONFIRMED, False)))
+@pytest.mark.django_db
+def test_booking_is_cancelled_property(status, is_cancelled):
+    booking = BookingFactory(status=status)
+    assert booking.is_cancelled == is_cancelled

--- a/tests/unit/export_academy/test_views.py
+++ b/tests/unit/export_academy/test_views.py
@@ -107,10 +107,16 @@ def test_export_academy_registration_success_view(client, user):
 
 
 @pytest.mark.parametrize(
-    'booking_status,text', ((Booking.CONFIRMED, 'Booking confirmed'), (Booking.CANCELLED, 'Cancellation confirmed'))
+    'booking_status,success_url,text',
+    (
+        (Booking.CONFIRMED, 'export_academy:booking-success', 'Booking confirmed'),
+        (Booking.CANCELLED, 'export_academy:cancellation-success', 'Cancellation confirmed'),
+    ),
 )
 @pytest.mark.django_db
-def test_booking_success_view(export_academy_landing_page, test_event_list_hero, client, user, booking_status, text):
+def test_booking_success_view(
+    export_academy_landing_page, test_event_list_hero, client, user, booking_status, success_url, text
+):
     client.force_login(user)
     registration = factories.RegistrationFactory(email=user.email)
     event = factories.EventFactory()
@@ -340,7 +346,7 @@ def test_export_academy_booking_cancellation_success(mock_notify_cancellation, c
     assert len(factories.Booking.objects.all()) == 1
     assert factories.Booking.objects.get(pk=booking.id).status == 'Cancelled'
     assert response.status_code == 302
-    assert response.url == reverse('export_academy:booking-success', kwargs={'booking_id': booking.id})
+    assert response.url == reverse('export_academy:cancellation-success', kwargs={'booking_id': booking.id})
     assert mock_notify_cancellation.call_count == 1
     assert mock_notify_cancellation.call_args_list == [
         mock.call(


### PR DESCRIPTION
This PR adds the frontend for the registration success page. It also updates the registration and cancellation success URLs to be clearer.

These are now:
- Registration: `registration/booking/<uuid:booking_id>/success/`
- Cancellation: `booking/<uuid:booking_id>/cancellation/success`

**Screenshot Desktop**
![Screenshot 2023-05-19 at 15 57 31](https://github.com/uktrade/great-cms/assets/22460823/daa73553-f8a9-458d-b3ab-66ee8f1ba866)

**Screenshot mobile**
![Screenshot 2023-05-19 at 15 58 23](https://github.com/uktrade/great-cms/assets/22460823/ece41a8f-0476-4baf-9181-f5584a052946)

**To test**
- Make sure you've removed your local registration instance
- Go to `/export-academy/events` and click book on an event
- Go through the registration form
- At the end you should see the confirmation page

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-645
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
