### PR TITLE
Event registration naming & booking query fixes

### DIFF
--- a/export_academy/helpers.py
+++ b/export_academy/helpers.py
@@ -154,7 +154,7 @@ def check_registration(function):
                 return function(request, *args, **kwargs)
             else:
                 event_id = request.POST['event_id']
-                return redirect(reverse_lazy('export_academy:registration', kwargs=dict(booking_id=event_id)))
+                return redirect(reverse_lazy('export_academy:registration', kwargs=dict(event_id=event_id)))
         else:
             return redirect_to_login(referer, SIGNUP_URL, REDIRECT_FIELD_NAME)
 

--- a/export_academy/mixins.py
+++ b/export_academy/mixins.py
@@ -45,8 +45,8 @@ class RegistrationMixin:
 
     def get_initial(self):
         initial = super().get_initial()
-        if self.kwargs.get('booking_id'):
-            self.request.session['booking_id'] = str(self.kwargs.get('booking_id'))
+        if self.kwargs.get('event_id'):
+            self.request.session['event_id'] = str(self.kwargs.get('event_id'))
         data = self.request.session.get('form_data')
         if data is not None:
             self.initial_data = initial = pickle.loads(bytes.fromhex(data))[0]

--- a/export_academy/urls.py
+++ b/export_academy/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name='upcoming-events',
     ),
     path(
-        'registration/<uuid:booking_id>',
+        'registration/<uuid:event_id>',
         login_required(views.RegistrationPersonalDetails.as_view(), login_url=SIGNUP_URL),
         {
             'slug': snippet_slugs.EA_REGISTRATION_PAGE_HERO,

--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -328,5 +328,7 @@ class RegistrationConfirmChoices(core_mixins.GetSnippetContentMixin, BookingMixi
         )
 
     def get_success_url(self):
-        booking_id = getattr(Booking.objects.get(event_id=self.request.session.get('event_id')), 'id')
-        return reverse_lazy('export_academy:registration-success', kwargs={'booking_id': booking_id})
+        booking = Booking.objects.get(
+            event_id=self.request.session.get('event_id'), registration_id=self.request.user.email
+        )
+        return reverse_lazy('export_academy:registration-success', kwargs={'booking_id': booking.id})

--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -304,8 +304,8 @@ class RegistrationConfirmChoices(core_mixins.GetSnippetContentMixin, BookingMixi
 
         self.model(**reg_data).save()
 
-    def confirm_booking(self, booking_id):
-        booking_data = dict(event_id=booking_id, status=models.Booking.CONFIRMED)
+    def confirm_booking(self, event_id):
+        booking_data = dict(event_id=event_id, status=models.Booking.CONFIRMED)
         booking_object = self.register_booking(booking_data)
         self.success_url = reverse_lazy('export_academy:registration-success', kwargs={'booking_id': booking_object.id})
         self.send_email_confirmation(booking_object, booking_data)
@@ -313,8 +313,8 @@ class RegistrationConfirmChoices(core_mixins.GetSnippetContentMixin, BookingMixi
     def form_valid(self, form):
         self.submit_registration()
         self.send_gov_notify(self.initial_data)
-        booking_id = self.request.session.get('booking_id')
-        self.confirm_booking(booking_id)
+        event_id = self.request.session.get('event_id')
+        self.confirm_booking(event_id)
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
@@ -328,5 +328,5 @@ class RegistrationConfirmChoices(core_mixins.GetSnippetContentMixin, BookingMixi
         )
 
     def get_success_url(self):
-        booking_id = getattr(Booking.objects.get(event_id=self.request.session.get('booking_id')), 'id')
+        booking_id = getattr(Booking.objects.get(event_id=self.request.session.get('event_id')), 'id')
         return reverse_lazy('export_academy:registration-success', kwargs={'booking_id': booking_id})

--- a/tests/unit/export_academy/test_views.py
+++ b/tests/unit/export_academy/test_views.py
@@ -77,7 +77,7 @@ def test_export_academy_registration_page(
     event = factories.EventFactory()
     client.force_login(user)
 
-    url = reverse('export_academy:registration', kwargs=dict(booking_id=event.id))
+    url = reverse('export_academy:registration', kwargs=dict(event_id=event.id))
     response = client.get(url)
 
     assert response.status_code == 200
@@ -86,7 +86,7 @@ def test_export_academy_registration_page(
 @pytest.mark.django_db
 def test_export_academy_registration_page_redirect(client):
     event = factories.EventFactory()
-    url = reverse('export_academy:registration', kwargs=dict(booking_id=event.id))
+    url = reverse('export_academy:registration', kwargs=dict(event_id=event.id))
     response = client.get(url)
 
     assert response.status_code == 302
@@ -106,10 +106,12 @@ def test_registration_success_view(
 ):
     client.force_login(user)
     event = factories.EventFactory()
+    registration = factories.RegistrationFactory(email=user.email)
+    factories.BookingFactory(event=event, registration=registration)
     url = reverse('export_academy:registration-confirm')
 
     client.post(
-        reverse('export_academy:registration', kwargs={'booking_id': event.id}),
+        reverse('export_academy:registration', kwargs={'event_id': event.id}),
         valid_registration_form_data,
     )
 
@@ -262,11 +264,11 @@ def test_export_academy_registration_success(
     url = reverse('export_academy:registration-confirm')
 
     client.post(
-        reverse('export_academy:registration', kwargs={'booking_id': event.id}),
+        reverse('export_academy:registration', kwargs={'event_id': event.id}),
         valid_registration_form_data,
     )
 
-    assert client.session['booking_id'] == event.id
+    assert client.session['event_id'] == event.id
 
     response = client.post(
         url,
@@ -312,7 +314,7 @@ def test_export_academy_booking_redirect(client, user):
     response = client.post(url, form_data)
 
     assert response.status_code == 302
-    assert response.url == reverse('export_academy:registration', kwargs=dict(booking_id=event.id))
+    assert response.url == reverse('export_academy:registration', kwargs=dict(event_id=event.id))
 
 
 @mock.patch.object(actions, 'GovNotifyEmailAction')

--- a/tests/unit/export_academy/test_views.py
+++ b/tests/unit/export_academy/test_views.py
@@ -261,6 +261,8 @@ def test_export_academy_registration_success(
     event = factories.EventFactory()
     registration = factories.RegistrationFactory(email=user.email)
     booking = factories.BookingFactory(event=event, registration=registration, status=Booking.CANCELLED)
+    # creates bookings for the same event to ensure correct booking is fetched
+    factories.BookingFactory.create_batch(3, event=event)
     url = reverse('export_academy:registration-confirm')
 
     client.post(


### PR DESCRIPTION
This PR makes two fixes to the export academy registration flow:
1) Updates the URL parameter representing an event id to be `event_id` rather than `booking_id`
2) Updates the query to get the user's `booking_id` in the redirection to the registration success page to ensure it gets the booking object related to the current user

### Workflow

- [x] A clear/description pull request messaged added.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
