### PR TITLE
Add search words beverage to food drink parent

### DIFF
--- a/core/static/javascript/international-online-offer.js
+++ b/core/static/javascript/international-online-offer.js
@@ -53,7 +53,7 @@ function customIOOSectorSuggest (query, populateResults) {
     },
     {
       "en":"Food and Drink",
-      "tags":["casual dining","dining","alcoholic drinks","bakery products","brewing","dairy products","food and drink manufacturing","free from","allergen free food","frozen and chilled foods","fruit and vegetables","meat products","non-alcoholic drinks","cordial","juice drinks","organic food","pet food","ready meals","secondary food processing","bread","baking"]
+      "tags":["casual dining","dining","alcoholic drinks","bakery products","brewing","dairy products","food and drink manufacturing","free from","allergen free food","frozen and chilled foods","fruit and vegetables","meat products","non-alcoholic drinks","cordial","juice drinks","organic food","pet food","ready meals","secondary food processing","bread","baking","food and beverage","food & beverage","beverage"]
     },
     {
       "en":"Technology and Smart Cities",


### PR DESCRIPTION
UR showed that users searching for food & beverage and beverage weren't able to select food and drink as a parent category. Adding in additional tags to enable this.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-520
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
