### PR TITLE
KLS-728: Show events filter to logged in users

### DIFF
--- a/export_academy/templatetags/event_list_buttons.py
+++ b/export_academy/templatetags/event_list_buttons.py
@@ -42,7 +42,7 @@ def set_all_events(value):
 
 @register.filter
 def get_filters(list_of_filters, user):
-    if helpers.is_export_academy_registered(user):
+    if user.is_authenticated:
         return list_of_filters
     else:
         return [field for field in list_of_filters if field.name != 'booking_period']


### PR DESCRIPTION
Show "Events" filters to all logged in users on export academy events page.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
