### PR TITLE
Backport hotfix - Disallow crawling from specified bot in robots.txt

### DIFF
--- a/core/templates/robots.txt
+++ b/core/templates/robots.txt
@@ -9,4 +9,7 @@ Disallow: /
 User-agent: PetalBot
 Disallow: /
 
+User-agent: Bytespider
+Disallow: /
+
 Sitemap: {{base_url}}/sitemap.xml

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -978,6 +978,9 @@ def test_robots_txt(client, base_url, expected_sitemap_url):
                 b'User-agent: PetalBot\n',
                 b'Disallow: /\n',
                 b'\n',
+                b'User-agent: Bytespider\n',
+                b'Disallow: /\n',
+                b'\n',
                 f'Sitemap: {expected_sitemap_url}\n'.encode(),
             ]
         )


### PR DESCRIPTION
This PR backports a hotfix which was applied to the master branch - see PR here #2206 .