### PR TITLE
Fix template auto-reloading

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 
 import directory_healthcheck.backends
 import environ
@@ -13,8 +14,8 @@ from sentry_sdk.integrations.django import DjangoIntegration
 import healthcheck.backends
 from .utils import get_wagtail_transfer_configuration
 
-ROOT_DIR = environ.Path(__file__) - 2
-CORE_APP_DIR = ROOT_DIR.path('core')
+ROOT_DIR = Path(__file__).resolve().parents[1]
+CORE_APP_DIR = ROOT_DIR / 'core'
 
 env = environ.Env()
 
@@ -116,11 +117,11 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
-            CORE_APP_DIR.path('templates'),
-            ROOT_DIR.path('templates'),  # For overriding templates in dependencies, such as great-components
-            ROOT_DIR.path('sso_profile', 'templates'),
-            ROOT_DIR.path('sso_profile', 'common', 'templates'),
-            ROOT_DIR.path('sso_profile', 'enrolment', 'templates'),
+            CORE_APP_DIR / 'templates',
+            ROOT_DIR / 'templates',  # For overriding templates in dependencies, such as great-components
+            ROOT_DIR / 'sso_profile' / 'templates',
+            ROOT_DIR / 'sso_profile' / 'common' / 'templates',
+            ROOT_DIR / 'sso_profile' / 'enrolment' / 'templates',
         ],
         'APP_DIRS': True,
         'OPTIONS': {
@@ -239,21 +240,21 @@ STATICFILES_FINDERS = [
 ]
 
 STATICFILES_DIRS = [
-    str(ROOT_DIR('core/static')),
-    str(ROOT_DIR('core/components/static')),
-    str(ROOT_DIR('domestic/static')),
-    str(ROOT_DIR('react-components/dist')),
-    str(ROOT_DIR('sso_profile/common/static')),
-    str(ROOT_DIR('sso_profile/static')),
+    str(ROOT_DIR / 'core' / 'static'),
+    str(ROOT_DIR / 'core' / 'components/static'),
+    str(ROOT_DIR / 'domestic' / 'static'),
+    str(ROOT_DIR / 'react-components' / 'dist'),
+    str(ROOT_DIR / 'sso_profile' / 'common' / 'static'),
+    str(ROOT_DIR / 'sso_profile' / 'static'),
 ]
 
 STATICFILES_STORAGE = env.str('STATICFILES_STORAGE', 'whitenoise.storage.CompressedStaticFilesStorage')
 DEFAULT_FILE_STORAGE = env.str('DEFAULT_FILE_STORAGE', 'storages.backends.s3boto3.S3Boto3Storage')
 
-STATIC_ROOT = str(ROOT_DIR('staticfiles'))
+STATIC_ROOT = str(ROOT_DIR / 'staticfiles')
 STATIC_URL = '/static/'
 
-MEDIA_ROOT = str(ROOT_DIR('media'))
+MEDIA_ROOT = str(ROOT_DIR / 'media')
 MEDIA_URL = '/media/'  # NB: this is overriden later, if/when AWS is set up
 PDF_STATIC_URL = ''  # NB: overriiden by AWS public s3 if setup
 

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -282,7 +282,7 @@ def ccce_import_schedule(hs_code, origin_country='CA', destination_country='GB')
 @functools.lru_cache(maxsize=None)
 def get_popular_export_destinations(sector_label):
     export_destinations = Counter()
-    with open(settings.ROOT_DIR + 'core/fixtures/countries-sectors-export.csv', 'r') as f:
+    with open(settings.ROOT_DIR / 'core/fixtures/countries-sectors-export.csv', 'r') as f:
         for row in csv.DictReader(StringIO(f.read()), delimiter=','):
             row_sector_label = row['sector'].split(' :')[0]  # row has multi level delimited by ' :'. Get top level.
             if is_fuzzy_match(label_a=row_sector_label, label_b=sector_label):

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ django==4.1.9
 django-environ==0.4.*
 django-redis==5.2.*
 django_storages[boto3]==1.13.2
-django-extensions==3.2.1
+django-extensions==3.2.3
 django-ipware==2.1.*
 djangorestframework==3.14.*
 django-formtools==2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ anyascii==0.3.2
     # via wagtail
 arabic-reshaper==3.0.0
     # via xhtml2pdf
-asgiref==3.7.1
+asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via
@@ -74,7 +74,7 @@ click-repl==0.2.0
     # via celery
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements.in
     #   pyhanko
@@ -147,7 +147,7 @@ django-decorator-include==3.0
     # via -r requirements.in
 django-environ==0.4.5
     # via -r requirements.in
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements.in
 django-filter==22.1
     # via wagtail
@@ -200,7 +200,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements.in
     #   wagtail-factories
-faker==18.9.0
+faker==18.10.1
     # via factory-boy
 geoip2==2.9.0
     # via -r requirements.in
@@ -214,7 +214,7 @@ html5lib==1.1
     # via
     #   wagtail
     #   xhtml2pdf
-icalendar==5.0.5
+icalendar==5.0.7
     # via -r requirements.in
 idna==3.4
     # via requests
@@ -232,7 +232,7 @@ jsonschema==3.2.0
     # via
     #   directory-components
     #   great-components
-kombu==5.2.4
+kombu==5.3.0
     # via celery
 l18n==2021.3
     # via wagtail
@@ -245,7 +245,7 @@ markdown2==2.4.0
     # via
     #   -r requirements.in
     #   readtime
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 maxminddb==2.3.0
     # via geoip2
@@ -290,7 +290,7 @@ pyhanko-certvalidator==0.22.0
     # via
     #   pyhanko
     #   xhtml2pdf
-pypdf==3.9.0
+pypdf==3.9.1
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode
@@ -332,7 +332,7 @@ redis==4.5.5
     # via
     #   celery
     #   django-redis
-regex==2023.5.5
+regex==2023.6.3
     # via dateparser
 reportlab==3.6.13
     # via
@@ -395,9 +395,10 @@ tinycss2==1.2.1
     # via
     #   cssselect2
     #   svglib
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   asgiref
+    #   kombu
     #   pypdf
     #   qrcode
     #   wagtail-localize

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -22,7 +22,7 @@ appnope==0.1.3
     # via ipython
 arabic-reshaper==3.0.0
     # via xhtml2pdf
-asgiref==3.7.1
+asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via
@@ -74,9 +74,9 @@ botocore==1.27.96
     #   s3transfer
 brotli==1.0.9
     # via geventhttpclient
-browserstack-local==1.2.4
+browserstack-local==1.2.5
     # via browserstack-sdk
-browserstack-sdk==1.8.1
+browserstack-sdk==1.10.0
     # via -r requirements_test.in
 build==0.10.0
     # via pip-tools
@@ -116,13 +116,13 @@ click-repl==0.2.0
     # via celery
 configargparse==1.5.3
     # via locust
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   pytest-codecov
     #   pytest-cov
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements.in
     #   pyhanko
@@ -208,7 +208,7 @@ django-decorator-include==3.0
     # via -r requirements.in
 django-environ==0.4.5
     # via -r requirements.in
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements.in
 django-filter==22.1
     # via wagtail
@@ -270,7 +270,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements.in
     #   wagtail-factories
-faker==18.9.0
+faker==18.10.1
     # via factory-boy
 filelock==3.12.0
     # via virtualenv
@@ -330,7 +330,7 @@ html5lib==1.1
     # via
     #   wagtail
     #   xhtml2pdf
-icalendar==5.0.5
+icalendar==5.0.7
     # via -r requirements.in
 identify==2.5.24
     # via pre-commit
@@ -346,7 +346,7 @@ iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via -r requirements_test.in
-ipython==8.13.2
+ipython==8.14.0
     # via ipdb
 iso3166==1.0.1
     # via -r requirements.in
@@ -370,7 +370,7 @@ jsonschema==3.2.0
     # via
     #   directory-components
     #   great-components
-kombu==5.2.4
+kombu==5.3.0
     # via celery
 l18n==2021.3
     # via wagtail
@@ -387,7 +387,7 @@ markdown2==2.4.0
     # via
     #   -r requirements.in
     #   readtime
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
@@ -509,7 +509,7 @@ pylint-django==2.5.3
     # via -r requirements_test.in
 pylint-plugin-utils==0.8.2
     # via pylint-django
-pypdf==3.9.0
+pypdf==3.9.1
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode
@@ -574,7 +574,7 @@ pyyaml==6.0
     #   browserstack-sdk
     #   pre-commit
     #   pyhanko
-pyzmq==25.0.2
+pyzmq==25.1.0
     # via locust
 qrcode==7.4.2
     # via pyhanko
@@ -584,7 +584,7 @@ redis==4.5.5
     # via
     #   celery
     #   django-redis
-regex==2023.5.5
+regex==2023.6.3
     # via dateparser
 reportlab==3.6.13
     # via
@@ -608,7 +608,7 @@ requests==2.31.0
     #   sphinx
     #   wagtail
     #   webdriver-manager
-requests-mock==1.10.0
+requests-mock==1.11.0
     # via -r requirements_test.in
 requests-oauthlib==1.3.1
     # via django-staff-sso-client
@@ -616,13 +616,13 @@ requests-toolbelt==1.0.0
     # via browserstack-sdk
 roundrobin==0.0.4
     # via locust
-ruamel-yaml==0.17.28
+ruamel-yaml==0.17.31
     # via pre-commit-hooks
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 s3transfer==0.6.1
     # via boto3
-selenium==4.9.1
+selenium==4.10.0
     # via -r requirements_test.in
 sentry-sdk==1.14.0
     # via -r requirements.in
@@ -703,14 +703,15 @@ trio==0.22.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.10.2
+trio-websocket==0.10.3
     # via selenium
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   asgiref
     #   astroid
     #   black
     #   ipython
+    #   kombu
     #   locust
     #   pylint
     #   pypdf
@@ -781,7 +782,7 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
-werkzeug==2.3.4
+werkzeug==2.3.5
     # via
     #   -r requirements_test.in
     #   flask


### PR DESCRIPTION
This PR fixes an issue which, since upgrading to django 4.1.9, meant that we had lost auto-reloading after changing an html template. The issue was caused by the `runserver_plus` command coming from `django-extensions` package, and fixed in version 3.2.3.

The newer version now calls the `django.template.autoreload.get_template_directories` method, which in turn calls [django.utils._os.to_path](https://github.com/django/django/blob/main/django/utils/_os.py#L56). This method relies on paths being either in string format or an instance of `pathlib.Path`. Because we create our `ROOT_DIR` path in settings.py using `environ.path` - this was causing `get_template_directories()` to give an error.

So this PR also updates our directory paths in settings.py to use `pathlib.Path`. This now looks to be the standard recommended in the [django docs here](https://docs.djangoproject.com/en/4.1/howto/overriding-templates/#overriding-from-the-project-s-templates-directory).

To test
- Install requirements - `make manage install_requirements`
- Run `make webserver`
- Go to any page in your browser
- Update the template for that page
- You should immediately see changes in your browser after refreshing the page

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-757
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Housekeeping

- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
