### PR TITLE
Set use domestic header to true for article pages converted to microsites

### DIFF
--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -378,6 +378,7 @@ def migrate_article_page_to_microsite(page):
         cta_link_label=page.cta_link_label,
         cta_link=page.cta_link,
         related_links=json.dumps(convert_related_links(page)),
+        use_domestic_header_logo=True,
     )
     page.delete()
     microsite_page.slug = slug


### PR DESCRIPTION

Ticket: https://uktrade.atlassian.net/jira/software/projects/KLS/boards/359?assignee=63343adf88ed2ebef97c64ac&selectedIssue=KLS-768

Migrated page at bottom
![image](https://github.com/uktrade/great-cms/assets/56481191/6668ba4f-8bd5-4158-b2a7-293c48a4764f)
settings use domestic logo is now ticket by default after migrating to microsute page
![image](https://github.com/uktrade/great-cms/assets/56481191/01070f64-3ace-46eb-af45-09b0e6638f0b)


(Please add a sentence or two explaining the context of this PR. Reviewers can go to the ticket for detail.)
CONTEXT: This changeset adds/removes/updates [summary of feature/area/code] so that [summary of benefit].

_Tick or delete as appropriate:_

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
