### PR TITLE
Activity Stream endpoint for UKEA's registrations

### DIFF
--- a/activitystream/serializers.py
+++ b/activitystream/serializers.py
@@ -5,7 +5,7 @@ from taggit.serializers import TagListSerializerField
 from wagtail.rich_text import RichText, get_text_for_indexing
 
 from domestic.models import ArticlePage
-from export_academy.models import Booking, Event
+from export_academy.models import Booking, Event, Registration
 from international_online_offer.models import TriageData, UserData
 
 logger = logging.getLogger(__name__)
@@ -123,6 +123,38 @@ class ExportAcademyEventSerializer(serializers.ModelSerializer):
         Prefix field names to match activity stream format
         """
         prefix = 'dit:exportAcademy:event'
+        type = 'Update'
+        return {
+            'id': f'{prefix}:{instance.id}:{type}',
+            'type': f'{type}',
+            'published': instance.modified.isoformat(),
+            'object': {
+                'id': f'{prefix}:{instance.id}',
+                'type': prefix,
+                'created': instance.created.isoformat(),
+                'modified': instance.modified.isoformat(),
+                **{f'{k}': v for k, v in super().to_representation(instance).items()},
+            },
+        }
+
+
+class ExportAcademyRegistrationSerializer(serializers.ModelSerializer):
+    """
+    UKEA's Registration serializer for Activity Stream.
+    """
+
+    firstName = serializers.CharField(source='first_name')  # noqa: N815
+    lastName = serializers.CharField(source='last_name')  # noqa: N815
+
+    class Meta:
+        model = Registration
+        fields = ['email', 'firstName', 'lastName', 'data']
+
+    def to_representation(self, instance):
+        """
+        Prefix field names to match activity stream format
+        """
+        prefix = 'dit:exportAcademy:registration'
         type = 'Update'
         return {
             'id': f'{prefix}:{instance.id}:{type}',

--- a/activitystream/urls.py
+++ b/activitystream/urls.py
@@ -27,6 +27,11 @@ urlpatterns = [
         name='ukea-events',
     ),
     path(
+        'ukea-registrations/',
+        skip_ga360(activitystream.views.ExportAcademyRegistrationActivityStreamView.as_view()),
+        name='ukea-registrations',
+    ),
+    path(
         'ukea-bookings/',
         skip_ga360(activitystream.views.ExportAcademyBookingActivityStreamView.as_view()),
         name='ukea-bookings',

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -120,3 +120,4 @@ domestic/locale/pt/LC_MESSAGES/django.mo
 domestic/locale/zh/LC_MESSAGES/django.po
 domestic/locale/zh/LC_MESSAGES/django.mo
 tests/unit/activitystream/test_serializers.py
+activitystream/serializers.py

--- a/tests/unit/activitystream/test_serializers.py
+++ b/tests/unit/activitystream/test_serializers.py
@@ -10,11 +10,16 @@ from activitystream.serializers import (
     CountryGuidePageSerializer,
     ExportAcademyBookingSerializer,
     ExportAcademyEventSerializer,
+    ExportAcademyRegistrationSerializer,
 )
 from domestic.models import ArticlePage
 from international_online_offer.models import TriageData, UserData
 from tests.unit.domestic.factories import ArticlePageFactory, CountryGuidePageFactory
-from tests.unit.export_academy.factories import BookingFactory, EventFactory
+from tests.unit.export_academy.factories import (
+    BookingFactory,
+    EventFactory,
+    RegistrationFactory,
+)
 
 
 @pytest.mark.django_db
@@ -284,6 +289,30 @@ def test_ukea_event_serializer():
             'startDate': instance.start_date.isoformat(),
             'timezone': instance.timezone,
             'types': [type.name for type in instance.types.all()],
+        },
+    }
+
+
+@pytest.mark.django_db
+def test_ukea_registration_serializer():
+    instance = RegistrationFactory()
+
+    serializer = ExportAcademyRegistrationSerializer()
+
+    output = serializer.to_representation(instance)
+    assert output == {
+        'id': f'dit:exportAcademy:registration:{instance.id}:Update',
+        'type': 'Update',
+        'published': instance.modified.isoformat(),
+        'object': {
+            'id': f'dit:exportAcademy:registration:{instance.id}',
+            'type': 'dit:exportAcademy:registration',
+            'created': instance.created.isoformat(),
+            'modified': instance.modified.isoformat(),
+            'email': instance.email,
+            'firstName': instance.first_name,
+            'lastName': instance.last_name,
+            'data': instance.data,
         },
     }
 

--- a/tests/unit/activitystream/test_views.py
+++ b/tests/unit/activitystream/test_views.py
@@ -13,7 +13,11 @@ from rest_framework.test import APIClient
 
 from tests.unit.core.factories import IndustryTagFactory
 from tests.unit.domestic.factories import ArticlePageFactory, CountryGuidePageFactory
-from tests.unit.export_academy.factories import BookingFactory, EventFactory
+from tests.unit.export_academy.factories import (
+    BookingFactory,
+    EventFactory,
+    RegistrationFactory,
+)
 
 URL = 'http://testserver' + reverse('activitystream:cms-content')
 URL_INCORRECT_DOMAIN = 'http://incorrect' + reverse('activitystream:cms-content')
@@ -413,10 +417,7 @@ def test_search_test_api_view__disabled(client):
 
 @pytest.mark.parametrize(
     'resource,factory,expected_count',
-    (
-        ('events', EventFactory, 0),
-        ('bookings', BookingFactory, 0),
-    ),
+    (('events', EventFactory, 0), ('bookings', BookingFactory, 0), ('registrations', RegistrationFactory, 0)),
 )
 @pytest.mark.django_db
 def test_activity_stream_ukea_views(api_client, resource, factory, expected_count):


### PR DESCRIPTION
CONTEXT: This changeset adds an endpoint for Activity Stream to consume UKEA's registrations.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-754
- [x] Jira ticket has the correct status
- [x] A clear/description pull request messaged added

### Merging

- [x] This PR can be merged by reviewers