### PR TITLE
DPE-163: fourth step

### DIFF
--- a/contact/forms.py
+++ b/contact/forms.py
@@ -273,6 +273,36 @@ class DomesticExportSupportStep3Form(forms.Form):
     )
 
 
+class DomesticExportSupportStep4Form(forms.Form):
+    product_or_service_1 = forms.CharField(
+        label='Product or service',
+        widget=django_widgets.TextInput(attrs={'class': 'govuk-input govuk-!-width-one-half great-text-input'}),
+        error_messages={
+            'required': 'Enter a product or service',
+        },
+    )
+    product_or_service_2 = forms.CharField(
+        label='Second product or service',
+        widget=django_widgets.TextInput(attrs={'class': 'govuk-input govuk-!-width-one-half great-text-input'}),
+        required=False,
+    )
+    product_or_service_3 = forms.CharField(
+        label='Third product or service',
+        widget=django_widgets.TextInput(attrs={'class': 'govuk-input govuk-!-width-one-half great-text-input'}),
+        required=False,
+    )
+    product_or_service_4 = forms.CharField(
+        label='Fourth product or service',
+        widget=django_widgets.TextInput(attrs={'class': 'govuk-input govuk-!-width-one-half great-text-input'}),
+        required=False,
+    )
+    product_or_service_5 = forms.CharField(
+        label='Fifth product or service',
+        widget=django_widgets.TextInput(attrs={'class': 'govuk-input govuk-!-width-one-half great-text-input'}),
+        required=False,
+    )
+
+
 class ExportSupportForm(GovNotifyEmailActionMixin, forms.Form):
     EMPLOYEES_NUMBER_CHOICES = (
         ('1-9', '1 to 9'),

--- a/contact/templates/domestic/contact/export-support/step-2.html
+++ b/contact/templates/domestic/contact/export-support/step-2.html
@@ -53,7 +53,7 @@
         </div>
     {% elif field.name == 'sector_primary_other' %}
         <div class="govuk-form-group govuk-!-margin-bottom-7" data-other-field>
-            {% include 'domestic/contact/includes/govuk-form-field.html' with field=field inputWrapperClass='great-text-select--arrow' %}
+            {% include 'domestic/contact/includes/govuk-form-field.html' with field=field %}
         </div>
     {% else %}
     <div class="govuk-form-group govuk-!-margin-bottom-7 {% if field.errors %}govuk-form-group--error{% endif %}">

--- a/contact/templates/domestic/contact/export-support/step-4.html
+++ b/contact/templates/domestic/contact/export-support/step-4.html
@@ -1,9 +1,51 @@
 {% extends 'domestic/contact/export-support/base.html' %}
 
+{% block body_js %}
+<script type="text/javascript">
+  const add_another_product_or_service_button = document.getElementById('add_another_product_or_service');
+
+  document.querySelectorAll('[data-hidden]').forEach(el => el.style.display = 'none');
+
+  let hiddenFields = document.querySelectorAll('[data-hidden]');
+
+  if (hiddenFields && hiddenFields.length === 0) {
+    add_another_product_or_service_button.style.display = 'none'
+  }
+
+  $(add_another_product_or_service_button).on("click", (e) => {
+    e.preventDefault();
+
+    hiddenFields = document.querySelectorAll('[data-hidden]');
+
+    if (hiddenFields && hiddenFields.length >= 1) {
+        hiddenFields.forEach((el, index) =>  {
+            if (index === 0) {
+                el.removeAttribute('data-hidden');
+                el.style.removeProperty('display');
+            }
+        })
+
+        if (hiddenFields.length === 1) {
+            add_another_product_or_service_button.style.display = 'none';
+        }
+    }
+  });
+</script>
+{% endblock %}
+
 {% block form_fields %}
     {% for field in form.visible_fields %}
-    <div class="govuk-form-group govuk-!-margin-bottom-7 {% if field.errors %}govuk-form-group--error{% endif %}">
-        {% include 'domestic/contact/includes/govuk-form-field.html' with field=field %}
+    {% if field.name == 'product_or_service_1' %}
+        <div class="govuk-form-group govuk-!-margin-bottom-7 {% if field.errors %}govuk-form-group--error{% endif %}">
+            {% include 'domestic/contact/includes/govuk-form-field.html' with field=field %}
+        </div>
+    {% else %}
+    <div class="govuk-form-group govuk-!-margin-bottom-7 {% if field.errors %}govuk-form-group--error{% endif %}" {% if not field.value %}data-hidden{% endif %}>
+        {% include 'domestic/contact/includes/govuk-form-field.html' with field=field  %}
     </div>
+    {% endif %}
     {% endfor %}
+    <div class="govuk-!-margin-bottom-7">
+        <a href="" class="govuk-link" role="button" id="add_another_product_or_service">Add another product or service</a>
+    </div>
 {% endblock %}

--- a/contact/templates/domestic/contact/export-support/step-5.html
+++ b/contact/templates/domestic/contact/export-support/step-5.html
@@ -1,0 +1,9 @@
+{% extends 'domestic/contact/export-support/base.html' %}
+
+{% block form_fields %}
+    {% for field in form.visible_fields %}
+    <div class="govuk-form-group govuk-!-margin-bottom-7 {% if field.errors %}govuk-form-group--error{% endif %}">
+        {% include 'domestic/contact/includes/govuk-form-field.html' with field=field %}
+    </div>
+    {% endfor %}
+{% endblock %}

--- a/contact/urls.py
+++ b/contact/urls.py
@@ -12,6 +12,7 @@ from contact.views import (
     DomesticExportSupportFormStep2CView,
     DomesticExportSupportFormStep3View,
     DomesticExportSupportFormStep4View,
+    DomesticExportSupportFormStep5View,
     DomesticFormView,
     DomesticSuccessView,
     EcommerceSupportFormPageView,
@@ -296,5 +297,10 @@ if settings.FEATURE_DIGITAL_POINT_OF_ENTRY:
             'contact/domestic/export-support/step4/',
             skip_ga360(DomesticExportSupportFormStep4View.as_view()),
             name='export-support-step-4',
+        ),
+        path(
+            'contact/domestic/export-support/step5/',
+            skip_ga360(DomesticExportSupportFormStep5View.as_view()),
+            name='export-support-step-5',
         ),
     ]

--- a/contact/views.py
+++ b/contact/views.py
@@ -202,7 +202,7 @@ class DomesticExportSupportFormStep1View(contact_mixins.ExportSupportFormMixin, 
             **kwargs,
             heading_text='Contact us',
             button_text='Continue',
-            step_text='Step 1 of 7',
+            step_text='Step 1 of 6',
         )
 
     def get_success_url(self):
@@ -230,7 +230,7 @@ class DomesticExportSupportFormStep2AView(contact_mixins.ExportSupportFormMixin,
             **kwargs,
             heading_text='About your business',
             button_text='Continue',
-            step_text='Step 2 of 7',
+            step_text='Step 2 of 6',
             back_link=reverse_lazy('contact:export-support'),
         )
 
@@ -249,7 +249,7 @@ class DomesticExportSupportFormStep2BView(contact_mixins.ExportSupportFormMixin,
             **kwargs,
             heading_text='About your business',
             button_text='Continue',
-            step_text='Step 2 of 7',
+            step_text='Step 2 of 6',
             back_link=reverse_lazy('contact:export-support'),
         )
 
@@ -268,7 +268,7 @@ class DomesticExportSupportFormStep2CView(contact_mixins.ExportSupportFormMixin,
             **kwargs,
             heading_text='About your business',
             button_text='Continue',
-            step_text='Step 2 of 7',
+            step_text='Step 2 of 6',
             back_link=reverse_lazy('contact:export-support'),
         )
 
@@ -293,15 +293,40 @@ class DomesticExportSupportFormStep3View(contact_mixins.ExportSupportFormMixin, 
             heading_text='About you',
             strapline_text='This information will allow us to contact you about your enquiry.',
             button_text='Continue',
-            step_text='Step 3 of 7',
+            step_text='Step 3 of 6',
             form_data=form_data,
             back_link=reverse_lazy('contact:export-support-step-2a'),
         )
 
+    def form_valid(self, form):
+        self.save_data(form)
+        return super().form_valid(form)
+
 
 class DomesticExportSupportFormStep4View(contact_mixins.ExportSupportFormMixin, FormView):
-    form_class = contact_forms.DomesticExportSupportStep3Form
+    form_class = contact_forms.DomesticExportSupportStep4Form
     template_name = 'domestic/contact/export-support/step-4.html'
+    success_url = reverse_lazy('contact:export-support-step-5')
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(
+            **kwargs,
+            heading_text='About your product or service',
+            strapline_text="""This information will help us provide support for your specific product or service.
+             Try to keep your descriptions short (2-3 words) and use the link to add up to 5 products or services.""",
+            button_text='Continue',
+            step_text='Step 4 of 6',
+            back_link=reverse_lazy('contact:export-support-step-3'),
+        )
+
+    def form_valid(self, form):
+        self.save_data(form)
+        return super().form_valid(form)
+
+
+class DomesticExportSupportFormStep5View(contact_mixins.ExportSupportFormMixin, FormView):
+    form_class = contact_forms.DomesticExportSupportStep4Form
+    template_name = 'domestic/contact/export-support/step-5.html'
 
 
 class InternationalFormView(

--- a/tests/unit/contact/test_forms.py
+++ b/tests/unit/contact/test_forms.py
@@ -830,6 +830,24 @@ def test_selling_online_overseas_contact_details_form__editable_fields():
                 'email': 'Enter an email address in the correct format, like name@example.com',
             },
         ),
+        (
+            forms.DomesticExportSupportStep4Form,
+            {
+                'product_or_service_1': 'Test product 1',
+            },
+            True,
+            {},
+        ),
+        (
+            forms.DomesticExportSupportStep4Form,
+            {
+                'product_or_service_1': '',
+            },
+            False,
+            {
+                'product_or_service_1': 'Enter a product or service',
+            },
+        ),
     ),
 )
 @pytest.mark.django_db

--- a/tests/unit/contact/test_views.py
+++ b/tests/unit/contact/test_views.py
@@ -1516,6 +1516,16 @@ def test_privacy_url_passed_to_fta_form_view(client, mock_free_trade_agreements)
                 'email': 'Enter an email address in the correct format, like name@example.com',
             },
         ),
+        (
+            reverse('contact:export-support-step-4'),
+            {
+                'product_or_service_1': 'Test product 1',
+            },
+            reverse('contact:export-support-step-5'),
+            {
+                'product_or_service_1': 'Enter a product or service',
+            },
+        ),
     ),
 )
 @pytest.mark.django_db


### PR DESCRIPTION
Adds the fourth form the new "Digital point of Entry" contact support form.

![Screenshot 2023-06-14 at 11 00 49](https://github.com/uktrade/great-cms/assets/66948936/21f0355f-8b34-4bb3-9c2e-7d19b12cfc0a)

To test locally go to "http://greatcms.trade.great:8020/contact/domestic/export-support/"

Fill in the first, second and third steps of form and then click "Continue" button. You will be redirected to the fourth step.

On successful submit the form redirects to an empty page where the fifth step form will be located in a future ticket.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
