### PR TITLE
Wagtail transfer configuration updated

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -791,6 +791,8 @@ WAGTAILTRANSFER_UPDATE_RELATED_MODELS = [
     'core.ContentModule',
     'core.Tour',
     'core.TourStep',
+    'core.Microsite',
+    'core.MicrositePage',
     'domestic.DomesticHomePage',
     'domestic.DomesticDashboard',
     'domestic.StructuralPage',
@@ -818,10 +820,13 @@ WAGTAILTRANSFER_FOLLOWED_REVERSE_RELATIONS = [
     ('core.greatmedia', 'tagged_items', True),
 ]
 
+WAGTAILTRANSFER_NO_FOLLOW_MODELS = ['wagtailcore.page']
+
 WAGTAILTRANSFER_LOOKUP_FIELDS = {
     'taggit.tag': ['slug'],
     'core.personalisationhscodetag': ['slug'],
     'core.personalisationcountrytag': ['slug'],
+    'auth.user': ['username'],
 }
 
 # dit_helpdesk

--- a/config/utils.py
+++ b/config/utils.py
@@ -54,12 +54,24 @@ def get_wagtail_transfer_configuration() -> dict:
                     'BASE_URL': staging_base_url,
                     'SECRET_KEY': staging_secret,
                 },
+                PRODUCTION: {
+                    'BASE_URL': prod_base_url,
+                    'SECRET_KEY': prod_secret,
+                },
             },
             STAGING: {
                 PRODUCTION: {
                     'BASE_URL': prod_base_url,
                     'SECRET_KEY': prod_secret,
-                }
+                },
+                UAT: {
+                    'BASE_URL': uat_base_url,
+                    'SECRET_KEY': uat_secret,
+                },
+                DEV: {
+                    'BASE_URL': dev_base_url,
+                    'SECRET_KEY': dev_secret,
+                },
             },
             UAT: {
                 PRODUCTION: {
@@ -95,9 +107,13 @@ def get_wagtail_transfer_configuration() -> dict:
         uat_secret = env.str('WAGTAILTRANSFER_SECRET_KEY_UAT')
         staging_base_url = env.str('WAGTAILTRANSFER_BASE_URL_STAGING')
         staging_secret = env.str('WAGTAILTRANSFER_SECRET_KEY_STAGING')
+        prod_base_url = env.str('WAGTAILTRANSFER_BASE_URL_PRODUCTION')
+        prod_secret = env.str('WAGTAILTRANSFER_SECRET_KEY_PRODUCTION')
         config.update(
             _get_config(
                 active_environment,
+                prod_base_url=prod_base_url,
+                prod_secret=prod_secret,
                 uat_base_url=uat_base_url,
                 uat_secret=uat_secret,
                 staging_base_url=staging_base_url,
@@ -108,11 +124,19 @@ def get_wagtail_transfer_configuration() -> dict:
         # Staging needs to know about production, to import FROM it
         prod_base_url = env.str('WAGTAILTRANSFER_BASE_URL_PRODUCTION')
         prod_secret = env.str('WAGTAILTRANSFER_SECRET_KEY_PRODUCTION')
+        dev_base_url = env.str('WAGTAILTRANSFER_BASE_URL_DEV')
+        dev_secret = env.str('WAGTAILTRANSFER_SECRET_KEY_DEV')
+        uat_base_url = env.str('WAGTAILTRANSFER_BASE_URL_UAT')
+        uat_secret = env.str('WAGTAILTRANSFER_SECRET_KEY_UAT')
         config.update(
             _get_config(
                 active_environment,
                 prod_base_url=prod_base_url,
                 prod_secret=prod_secret,
+                uat_base_url=uat_base_url,
+                uat_secret=uat_secret,
+                dev_base_url=dev_base_url,
+                dev_secret=dev_secret,
             )
         )
     elif active_environment == UAT:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -470,7 +470,7 @@ pluggy==1.0.0
     #   pytest
 polib==1.2.0
     # via wagtail-localize
-pre-commit==3.3.2
+pre-commit==3.3.3
     # via -r requirements_test.in
 pre-commit-hooks==3.3.0
     # via -r requirements_test.in

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -38,12 +38,24 @@ from config.utils import get_wagtail_transfer_configuration
                     'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_PRODUCTION',
                     'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_PRODUCTION',
                 },
+                'uat': {
+                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_UAT',
+                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_UAT',
+                },
+                'dev': {
+                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_DEV',
+                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_DEV',
+                },
             },
         ),
         (
             'dev',  # can pull from UAT or staging
             False,
             {
+                'production': {
+                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_PRODUCTION',
+                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_PRODUCTION',
+                },
                 'uat': {
                     'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_UAT',
                     'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_UAT',
@@ -88,6 +100,14 @@ from config.utils import get_wagtail_transfer_configuration
                 'production': {
                     'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_PRODUCTION',
                     'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_PRODUCTION',
+                },
+                'uat': {
+                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_UAT',
+                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_UAT',
+                },
+                'dev': {
+                    'BASE_URL': 'value_of_WAGTAILTRANSFER_BASE_URL_DEV',
+                    'SECRET_KEY': 'value_of_WAGTAILTRANSFER_SECRET_KEY_DEV',
                 },
             },
         ),


### PR DESCRIPTION
This PR updates the configuration of wagtail transfer to include our new page models, resolve circular dependancies on page modals and prevent the duplicate key error on username. I have also expanded the list of environments from which staging can pull in pages. It should now be possible for the content designer to move and view a page in any environment.

To test locally:
- set WAGTAIL_TRANSFER_LOCAL_DEV to true in secrets-do-not-commit
- create a new database called greatcms_transfer_target
- with this new database referenced in secrets-do-not-commit run migrations
- update the make webserver command to use port 8030 and spin it up
- revert the previous to changes and spin up greatcms on port 8020

You should now have two instances running locally that you can use wagtail transfer between

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-732
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
