### PR TITLE
added include_block to pass request and richtext filter to cta teaser

### DIFF
--- a/core/templates/microsites/blocks/columns.html
+++ b/core/templates/microsites/blocks/columns.html
@@ -18,7 +18,7 @@
         {{ item.value.text }}
     {% endfilter %}
     {%if item.value.button_url%}
-        <a href="{{ item.value.button_url }}" class="govuk-button">
+        <a href="{{ item.value.button_url|persist_language:request.GET }}" class="govuk-button">
             {% comment %} I'm assuming this will change but including for completeness {% endcomment %}
             {% if TRANSLATE_TEXT %}
                 {% translate item.value.button_label %}

--- a/core/templates/microsites/blocks/cta.html
+++ b/core/templates/microsites/blocks/cta.html
@@ -4,7 +4,7 @@
     <div class="govuk-grid-column-full">
         <section class="govuk-!-padding-6 great-bg-light-blue">
             <h3 class="govuk-heading-m great-font-size-28">{% if value.title %}{{ value.title }}{% else %}{{ title }}{% endif %}</h3>
-            <p class="govuk-body">{% if value.teaser %}{{ value.teaser }}{% else %}{{ teaser }}{% endif %}</p>
+            <p class="govuk-body">{% if value.teaser %}{{ value.teaser|richtext }}{% else %}{{ teaser|richtext }}{% endif %}</p>
             <div>
                 <a href="{% if value.link %}{{ value.link|persist_language:request.GET }}{% else %}{{ link|persist_language:request.GET }}{% endif %}" class="govuk-button govuk-!-margin-bottom-0">
                     {% if value.teaser %}{{ value.link_label }}{% else %}{{ link_label }}{% endif %}

--- a/core/templates/microsites/blocks/streamfield.html
+++ b/core/templates/microsites/blocks/streamfield.html
@@ -2,6 +2,7 @@
 
 {% load add_govuk_classes from content_tags %}
 {% load replace_emphasis_tags from content_tags %}
+{% load wagtailcore_tags %}
 
 {% for block in streamfield_content %}
 
@@ -32,7 +33,7 @@
         {% endfilter %}
     {% else %}
         {% filter replace_emphasis_tags %}
-            {{ block }}
+            {% include_block block %}
         {%endfilter%}
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR is to fix a bug that was introduced when deploying tickets KLS-765 and KLS-730. The tickets enabled the persistence of language across microsite's and to alter the CTA teaser field to provide richtext. 

fixes:

Language persistence: I have changed how blocks are included in the streamfield.html template. We now use Wagtails include_block template tag as it passes the request to the block templates. Therefore we can use the persist_language filter without error.

CTA: I have added the richtext tag to render the html correctly.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-765 and https://uktrade.atlassian.net/browse/KLS-730 and 
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
