### PR TITLE
HOTFIX - don't get display name for filter if page filter

### DIFF
--- a/export_academy/templatetags/event_list_buttons.py
+++ b/export_academy/templatetags/event_list_buttons.py
@@ -70,7 +70,7 @@ def get_applied_filters(filter_form):
     """
     applied_filters = []
     for filter_type, filter_choices in filter_form.data.lists():
-        if filter_type != 'booking_period':
+        if filter_type != 'booking_period' and filter_type != 'page':
             applied_filters += _get_display_text_for_filter_choices(filter_choices, filter_form, filter_type)
     return applied_filters
 


### PR DESCRIPTION
This PR fixes a bug where in `_get_display_name_for_filters` it tries to find the display name from the filter form for all filters applied (apart from booking_period). Because the page filter doesn't come from the filter form, it throws a key error for the page filter when it looks for it in the form fields.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-786
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
