### PR TITLE
Kls 759 change contact form settings for west midlands and east midlands office finder

### DIFF
--- a/contact/templates/domestic/contact/includes/office-contact-cta.html
+++ b/contact/templates/domestic/contact/includes/office-contact-cta.html
@@ -1,5 +1,6 @@
-{% if office.name|lower == 'scottish enterprise' %}
+{% if office.name|lower in 'scottish enterprise, dit east midlands, dit west midlands' %}
     <a href="{{ office.website }}" target="_BLANK" class="{{ link_class }}">Contact {{ office.name }} office</a>
 {% else %}
+    {{ office.name }}
     <a href="{% url 'contact:office-finder-contact' postcode=form.cleaned_data.postcode %}" class="{{ link_class }}">Contact {{ office.name }} office</a>
 {% endif %}

--- a/contact/templates/domestic/contact/includes/office-contact-cta.html
+++ b/contact/templates/domestic/contact/includes/office-contact-cta.html
@@ -1,6 +1,5 @@
 {% if office.name|lower in 'scottish enterprise, dit east midlands, dit west midlands' %}
     <a href="{{ office.website }}" target="_BLANK" class="{{ link_class }}">Contact {{ office.name }} office</a>
 {% else %}
-    {{ office.name }}
     <a href="{% url 'contact:office-finder-contact' postcode=form.cleaned_data.postcode %}" class="{{ link_class }}">Contact {{ office.name }} office</a>
 {% endif %}


### PR DESCRIPTION
This ticket adds a region office divert for East and West Midlands to the Contact Us form. 

TO TEST: Simply search for a postcode for both East and West Midlands int he /contact-us/office-finder section of great-cms. Ensure the the link for the region office goes to: https://www.gov.uk/ask-export-support-team

### Workflow

- [X ] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-724
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Reviewing help

- [X ] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
