### PR TITLE
Refactor filter summary and improve tests

### DIFF
--- a/export_academy/templatetags/event_list_buttons.py
+++ b/export_academy/templatetags/event_list_buttons.py
@@ -68,9 +68,10 @@ def get_applied_filters(filter_form):
     """Get selected filters from form data, get their display text
     from the field choices and add them to applied_filters.
     """
+    filters_to_display = [filter for filter in filter_form.fields.keys() if filter != 'booking_period']
     applied_filters = []
     for filter_type, filter_choices in filter_form.data.lists():
-        if filter_type != 'booking_period' and filter_type != 'page':
+        if filter_type in filters_to_display:
             applied_filters += _get_display_text_for_filter_choices(filter_choices, filter_form, filter_type)
     return applied_filters
 

--- a/tests/unit/export_academy/test_views.py
+++ b/tests/unit/export_academy/test_views.py
@@ -41,6 +41,21 @@ def test_export_academy_event_list_page_logged_out(client, export_academy_landin
     assert response.status_code == 200
 
 
+@pytest.mark.parametrize('page_query, num_events_on_page', (('', 10), ('?page=1', 10), ('?page=2', 5)))
+@pytest.mark.django_db
+def test_export_academy_event_list_pagination(
+    client, page_query, num_events_on_page, export_academy_landing_page, test_event_list_hero
+):
+    now = timezone.now()
+    factories.EventFactory.create_batch(
+        15, start_date=now + timedelta(hours=6), end_date=now + timedelta(hours=7), completed=None
+    )
+    url = f"{reverse('export_academy:upcoming-events')}{page_query}"
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.context['page_obj']) == num_events_on_page
+
+
 @pytest.mark.django_db
 def test_export_academy_event_list_page_context(client, user, export_academy_landing_page, test_event_list_hero):
     event = factories.EventFactory()


### PR DESCRIPTION
This PR refactors the way display names for applied filters are computed. It now loops over the fields from the filter form, rather than the query parameters, so as to avoid including any non-filter parameters such as `page` or `next`.

It also adds a test for pagination on the events list page which would catch issues such as #2261 in the future.

**To test**
- Go to /export-academy/events
- Select filters down the left (not including booking period) and click apply filter
- These should appear in a summary 
- Assuming you have more than 10 events locally, going to `?page=2` should successfully render the second page of results

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-786
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
