### PR TITLE
Fix to help save triage data when user signs up

### DIFF
--- a/international_online_offer/forms.py
+++ b/international_online_offer/forms.py
@@ -23,7 +23,7 @@ class IntentForm(forms.Form):
     intent = forms.fields.MultipleChoiceField(
         label='',
         required=True,
-        widget=forms.CheckboxSelectInlineLabelMultiple(attrs={'id': 'intent-select'}),
+        widget=forms.CheckboxSelectInlineLabelMultiple(attrs={'id': 'intent-select'}, use_nice_ids=True),
         choices=choices.INTENT_CHOICES,
     )
     intent_other = forms.CharField(label='', min_length=2, max_length=50, required=False)

--- a/international_online_offer/templates/ioo/edit_your_answers.html
+++ b/international_online_offer/templates/ioo/edit_your_answers.html
@@ -21,9 +21,15 @@
       <p class="govuk-body">Use the options below to change any of the information you've given us about your UK expansion plans.</p>
       <p class="govuk-body">
         <span class="govuk-!-font-weight-bold">For your company:</span> {{ user_data.company_name | default:'-' }}
+        {% if request.user.is_authenticated %}
         <a class="govuk-link" href="{% url 'international_online_offer:profile' %}">
           Change
         </a>
+        {% else %}
+        <a class="govuk-link" href="{% url 'international_online_offer:signup' %}">
+          Sign up
+        </a>
+        {% endif %}
       </p>
     </div>
   </div>

--- a/international_online_offer/templates/ioo/guide.html
+++ b/international_online_offer/templates/ioo/guide.html
@@ -42,7 +42,7 @@
                 {% if user_data.company_location %}
                 <h2 class="govuk-heading-m">{{ user_data.get_company_location_display }}</h2>
                 {% else %}
-                <p class="govuk-body govuk-!-padding-top-2"><a class="govuk-link" href="{% url 'international_online_offer:profile' %}">Add details</a></p>
+                <p class="govuk-body govuk-!-padding-top-2"><a class="govuk-link" href="{% url 'international_online_offer:signup' %}">Sign up</a></p>
                 {% endif %}
             </div>
             <div class="govuk-grid-column-one-quarter">
@@ -50,7 +50,7 @@
                 {% if user_data.company_name %}
                 <h2 class="govuk-heading-m">{{ user_data.company_name }}</h2>
                 {% else %}
-                <p class="govuk-body govuk-!-padding-top-2"><a class="govuk-link" href="{% url 'international_online_offer:profile' %}">Add details</a></p>
+                <p class="govuk-body govuk-!-padding-top-2"><a class="govuk-link" href="{% url 'international_online_offer:signup' %}">Sign up</a></p>
                 {% endif %}
             </div>
             <div class="govuk-grid-column-one-quarter">

--- a/international_online_offer/templates/ioo/triage/intent.html
+++ b/international_online_offer/templates/ioo/triage/intent.html
@@ -42,7 +42,7 @@
   <script type="text/javascript">
     const intentContainer = document.getElementById('id_intent_container');
     const otherInputs = document.getElementById('id_intent_other-container');
-    const otherCheckboxElement = document.getElementById('intent-select_5');
+    const otherCheckboxElement = document.getElementById('intent-select-other');
     GOVUK.utils.toggleRadioOtherOnClick(otherCheckboxElement, otherInputs);
     GOVUK.utils.toggleFieldsetClassOnClick(
         [intentContainer],

--- a/international_online_offer/views.py
+++ b/international_online_offer/views.py
@@ -321,37 +321,31 @@ class IOOProfile(FormView):
         )
 
     def get_initial(self):
-        email = self.request.session.get('email')
-        agree_terms = self.request.session.get('agree_terms')
+        init_user_form_data = {
+            'company_name': '',
+            'company_location': '',
+            'full_name': '',
+            'role': '',
+            'email': self.request.user.email,
+            'telephone_number': '',
+            'agree_terms': True,
+            'agree_info_email': '',
+            'agree_info_telephone': '',
+        }
         if self.request.user.is_authenticated:
             user_data = get_user_data(self.request.user.hashed_uuid)
-            email = self.request.user.email
-            # agreed terms if signed up already
-            agree_terms = True
             if user_data:
-                return {
-                    'company_name': user_data.company_name,
-                    'company_location': user_data.company_location,
-                    'full_name': user_data.full_name,
-                    'role': user_data.role,
-                    'email': email,
-                    'telephone_number': user_data.telephone_number,
-                    'agree_terms': agree_terms,
-                    'agree_info_email': user_data.agree_info_email,
-                    'agree_info_telephone': user_data.agree_info_telephone,
-                }
+                init_user_form_data['email'] = user_data.email
+                init_user_form_data['company_name'] = user_data.company_name
+                init_user_form_data['company_location'] = user_data.company_location
+                init_user_form_data['full_name'] = user_data.full_name
+                init_user_form_data['role'] = user_data.role
+                init_user_form_data['telephone_number'] = user_data.telephone_number
+                init_user_form_data['agree_terms'] = user_data.agree_terms
+                init_user_form_data['agree_info_email'] = user_data.agree_info_email
+                init_user_form_data['agree_info_telephone'] = user_data.agree_info_telephone
 
-        return {
-            'company_name': self.request.session.get('company_name'),
-            'company_location': self.request.session.get('company_location'),
-            'full_name': self.request.session.get('full_name'),
-            'role': self.request.session.get('role'),
-            'email': email,
-            'telephone_number': self.request.session.get('telephone_number'),
-            'agree_terms': agree_terms,
-            'agree_info_email': self.request.session.get('agree_info_email'),
-            'agree_info_telephone': self.request.session.get('agree_info_telephone'),
-        }
+        return init_user_form_data
 
     def form_valid(self, form):
         if self.request.user.is_authenticated:
@@ -359,16 +353,28 @@ class IOOProfile(FormView):
                 hashed_uuid=self.request.user.hashed_uuid,
                 defaults=form.cleaned_data,
             )
-        else:
-            self.request.session['company_name'] = form.cleaned_data['company_name']
-            self.request.session['company_location'] = form.cleaned_data['company_location']
-            self.request.session['full_name'] = form.cleaned_data['full_name']
-            self.request.session['role'] = form.cleaned_data['role']
-            self.request.session['email'] = form.cleaned_data['email']
-            self.request.session['telephone_number'] = form.cleaned_data['telephone_number']
-            self.request.session['agree_terms'] = form.cleaned_data['agree_terms']
-            self.request.session['agree_info_email'] = form.cleaned_data['agree_info_email']
-            self.request.session['agree_info_telephone'] = form.cleaned_data['agree_info_telephone']
+
+            session_data_triage_object = {}
+            for key in [
+                'sector',
+                'intent',
+                'intent_other',
+                'location',
+                'location_none',
+                'hiring',
+                'spend',
+                'spend_other',
+                'is_high_value',
+            ]:
+                if self.request.session.get(key):
+                    session_data_triage_object[key] = self.request.session.get(key)
+                    del self.request.session[key]
+
+            TriageData.objects.update_or_create(
+                hashed_uuid=self.request.user.hashed_uuid,
+                defaults=session_data_triage_object,
+            )
+
         return super().form_valid(form)
 
 

--- a/tests/unit/international_online_offer/test_views.py
+++ b/tests/unit/international_online_offer/test_views.py
@@ -7,7 +7,7 @@ from django.urls import reverse, reverse_lazy
 from directory_constants import sectors as directory_constants_sectors
 from directory_sso_api_client import sso_api_client
 from international_online_offer.core import helpers, hirings, intents, regions, spends
-from international_online_offer.models import TriageData
+from international_online_offer.models import TriageData, UserData
 from sso import helpers as sso_helpers
 from tests.helpers import create_response
 
@@ -318,6 +318,28 @@ def test_ioo_profile(client, user, settings):
     settings.FEATURE_INTERNATIONAL_ONLINE_OFFER = True
     url = reverse('international_online_offer:profile')
     user.email = 'test@test.com'
+    client.force_login(user)
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_ioo_profile_initial(client, user, settings):
+    settings.FEATURE_INTERNATIONAL_ONLINE_OFFER = True
+    UserData.objects.create(
+        hashed_uuid='123',
+        company_name='DBT',
+        company_location='France',
+        full_name='Joe Bloggs',
+        role='Director',
+        email='test@test.com',
+        telephone_number='07923456787',
+        agree_terms=True,
+        agree_info_email=False,
+        agree_info_telephone=False,
+    )
+    url = reverse('international_online_offer:spend')
+    user.hashed_uuid = '123'
     client.force_login(user)
     response = client.get(url)
     assert response.status_code == 200

--- a/tests/unit/international_online_offer/test_views.py
+++ b/tests/unit/international_online_offer/test_views.py
@@ -314,9 +314,11 @@ def test_triage_spend_session(client, settings):
 
 
 @pytest.mark.django_db
-def test_ioo_profile(client, settings):
+def test_ioo_profile(client, user, settings):
     settings.FEATURE_INTERNATIONAL_ONLINE_OFFER = True
     url = reverse('international_online_offer:profile')
+    user.email = 'test@test.com'
+    client.force_login(user)
     response = client.get(url)
     assert response.status_code == 200
 


### PR DESCRIPTION
We had a bug where users triage session data was being lost when signing up. Although this should only happen if the session cookie is wiped there is now a fix in place which force saves the session data on signup and deletes the session data as its no longer required. 

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-556
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Housekeeping

- [x] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
