### PR TITLE
Resolve EA user registration from unique link for sign up/in

### DIFF
--- a/export_academy/helpers.py
+++ b/export_academy/helpers.py
@@ -1,4 +1,3 @@
-import base64
 import hashlib
 from functools import wraps
 
@@ -8,6 +7,8 @@ from django.contrib.auth.views import redirect_to_login
 from django.db.models import Q
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
+from django.utils.encoding import force_str
+from django.utils.http import urlsafe_base64_decode
 
 from core.urls import SIGNUP_URL
 from export_academy.models import Event, Registration
@@ -192,7 +193,7 @@ def get_sectors_list(sector: str, second_sector: str, third_sector: str) -> str:
 
 
 def get_registration_from_unique_link(idb64, token):
-    external_id = base64.b64decode(idb64).decode('utf-8')
+    external_id = force_str(urlsafe_base64_decode(idb64))
     try:
         registration = Registration.objects.get(external_id=external_id)
         email_hash = hashlib.sha256(registration.email.encode('UTF-8'))
@@ -200,5 +201,5 @@ def get_registration_from_unique_link(idb64, token):
             return registration
         else:
             return None
-    except Exception:
+    except Registration.DoesNotExist:
         return None

--- a/export_academy/helpers.py
+++ b/export_academy/helpers.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 from functools import wraps
 
 from django.conf import settings
@@ -187,3 +189,16 @@ def get_sectors_list(sector: str, second_sector: str, third_sector: str) -> str:
     if third_sector:
         sector_list.append(third_sector.capitalize())
     return ', '.join(sector_list)
+
+
+def get_registration_from_unique_link(idb64, token):
+    external_id = base64.b64decode(idb64).decode('utf-8')
+    try:
+        registration = Registration.objects.get(external_id=external_id)
+        email_hash = hashlib.sha256(registration.email.encode('UTF-8'))
+        if email_hash.hexdigest() == token:
+            return registration
+        else:
+            return None
+    except Exception:
+        return None

--- a/export_academy/mixins.py
+++ b/export_academy/mixins.py
@@ -5,7 +5,7 @@ from directory_forms_api_client.forms import GovNotifyEmailActionMixin
 from django.urls import reverse
 
 from config import settings
-from export_academy import forms
+from export_academy import forms, helpers
 from export_academy.models import Registration
 from sso_profile.enrolment.constants import RESEND_VERIFICATION
 
@@ -88,31 +88,26 @@ class VerificationLinksMixin:
 
 
 class HandleNewAndExistingUsersMixin:
-    def user_ea_registered(self):
-        # TODO update to handle unique token.
-        registration_id = self.request.GET.get('registration-id')
-        if registration_id:
-            try:
-                if Registration.objects.get(pk=registration_id):
-                    return True
-            except Exception:
-                return False
-        return False
+    def get_ea_user(self):
+        idb64 = self.request.GET.get('idb64')
+        token = self.request.GET.get('token')
+        if token and idb64:
+            return helpers.get_registration_from_unique_link(idb64, token)
+        return None
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['existing_ea_user'] = self.user_ea_registered()
+        context['existing_ea_user'] = self.get_ea_user() is not None
         return context
 
     def get_form_class(self):
-        if self.user_ea_registered():
+        if self.get_ea_user():
             return forms.ChoosePasswordForm
         else:
             return forms.SignUpForm
 
     def get_initial(self):
         initial = super().get_initial()
-        if self.user_ea_registered():
-            user = Registration.objects.get(pk=self.request.GET.get('registration-id'))
-            initial['email'] = user.email
+        if self.get_ea_user():
+            initial['email'] = self.get_ea_user().email
         return initial

--- a/export_academy/templates/export_academy/accounts/includes/existing_user_body_text.html
+++ b/export_academy/templates/export_academy/accounts/includes/existing_user_body_text.html
@@ -1,3 +1,9 @@
 <p>We’ve upgraded the UK Export Academy website and it has now joined all our other services on great.gov.uk.</p>
-<p>Please create a great.gov.uk password to continue to access your bookings.</p>
+<p>
+    {% if is_signin %}
+    You can now access your events with your great.gov.uk username and password.
+    {% else %}
+    Please create a great.gov.uk password to continue to access your bookings.
+    {% endif %}
+</p>
 <p>If you have any questions or feedback please <a class="govuk-link" href={% url 'contact:contact-us-feedback' %}>get in touch</a>.</p>

--- a/export_academy/templates/export_academy/accounts/signin.html
+++ b/export_academy/templates/export_academy/accounts/signin.html
@@ -25,8 +25,8 @@
 {% endblock %}
 {% block left_panel_content %}
 {% if existing_ea_user %}
-    {% include 'export_academy/accounts/includes/existing_user_body_text.html' %}
+    {% include 'export_academy/accounts/includes/existing_user_body_text.html' with is_signin=True %}
 {% else %}
-    {% include 'export_academy/accounts/includes/new_user_body_text.html' with is_signin=True%}
+    {% include 'export_academy/accounts/includes/new_user_body_text.html' with is_signin=True %}
 {% endif %}
 {% endblock %}

--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -392,7 +392,7 @@ class JoinBookingView(RedirectView):
 
 class SignUpView(HandleNewAndExistingUsersMixin, VerificationLinksMixin, sso_mixins.SignUpMixin, FormView):
     def get_template_names(self):
-        if self.user_ea_registered():
+        if self.get_ea_user():
             return ['export_academy/accounts/create_password.html']
         else:
             return ['export_academy/accounts/signup.html']
@@ -407,11 +407,11 @@ class SignUpView(HandleNewAndExistingUsersMixin, VerificationLinksMixin, sso_mix
             email=email,
             verification_code=verification_code,
             form_url=self.request.path,
-            verification_link=self.get_verification_link(uidb64, token, user_registered=self.user_ea_registered()),
+            verification_link=self.get_verification_link(uidb64, token, user_registered=self.get_ea_user()),
             resend_verification_link=self.get_resend_verification_link(),
         )
         return HttpResponseRedirect(
-            self.get_redirect_url(user_registered=self.user_ea_registered(), uidb64=uidb64, token=token)
+            self.get_redirect_url(user_registered=self.get_ea_user(), uidb64=uidb64, token=token)
         )
 
     def get_redirect_url(self, uidb64=None, token=None, user_registered=False):
@@ -426,7 +426,7 @@ class SignUpView(HandleNewAndExistingUsersMixin, VerificationLinksMixin, sso_mix
 
     def handle_already_registered(self, email):
         sso_helpers.notify_already_registered(email=email, form_url=self.request.path, login_url=self.get_login_url())
-        return HttpResponseRedirect(self.get_redirect_url(user_registered=self.user_ea_registered()))
+        return HttpResponseRedirect(self.get_redirect_url(user_registered=self.get_ea_user()))
 
     def do_sign_up_flow(self, request):
         form = self.get_form()
@@ -450,10 +450,8 @@ class SignUpView(HandleNewAndExistingUsersMixin, VerificationLinksMixin, sso_mix
                 return self.handle_signup_success(
                     response,
                     form,
-                    self.get_redirect_url(user_registered=self.user_ea_registered(), uidb64=uidb64, token=token),
-                    verification_link=self.get_verification_link(
-                        uidb64, token, user_registered=self.user_ea_registered()
-                    ),
+                    self.get_redirect_url(user_registered=self.get_ea_user(), uidb64=uidb64, token=token),
+                    verification_link=self.get_verification_link(uidb64, token, user_registered=self.get_ea_user()),
                 )
 
         # Ensure email address is always added to initial data

--- a/tests/unit/export_academy/test_helpers.py
+++ b/tests/unit/export_academy/test_helpers.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 from datetime import timedelta
 
 import pytest
@@ -7,7 +9,7 @@ from django.utils import timezone
 from wagtail_factories import DocumentFactory
 
 from config import settings
-from export_academy import helpers
+from export_academy import helpers, models
 from tests.unit.export_academy import factories
 
 
@@ -235,3 +237,25 @@ def test_get_3_sectors_list():
     third_sector = 'third sector'
     sectors = helpers.get_sectors_list(primary_sector, second_sector, third_sector)
     assert sectors == 'Primary sector, Second sector, Third sector'
+
+
+@pytest.mark.django_db
+def test_get_registration_from_unique_link_success(test_registration):
+    idb64 = base64.b64encode(bytes(test_registration.external_id, 'utf-8'))
+    token = hashlib.sha256(test_registration.email.encode('UTF-8')).hexdigest()
+    assert helpers.get_registration_from_unique_link(token=token, idb64=idb64) == test_registration
+
+
+@pytest.mark.parametrize(
+    'external_id,email',
+    (
+        ('None', 'test@example.com'),
+        ('123456789', 'another@email.com'),
+        ('987654321', 'test@example.com'),
+    ),
+)
+@pytest.mark.django_db
+def test_get_registration_from_unique_link_failure(test_registration, external_id, email):
+    idb64 = base64.b64encode(bytes(external_id, 'utf-8'))
+    token = hashlib.sha256(email.encode('UTF-8')).hexdigest()
+    assert helpers.get_registration_from_unique_link(token=token, idb64=idb64) is None


### PR DESCRIPTION
This PR updates the sign in and sign up flows for users already registered to the Export Academy to fetch the user's registration object (and pre-populate their email address in the template) using a combination of `idb64` and `token` query parameters.

The idb64 value represents a user's aventri registration id, base 64 encoded.
The token represents a hashed version of the same user's email address.

To get the correct registration object:
- the aventri id (ie `Registration.external_id`) is decoded
- the user with that external_id is found
- the email address related to that registration object is hashed
- this hashed email is compared to the token in the query params
- if these values match, the user's email address is pe-populated in the sign in/up form

**To test locally**
- make sure you have directory-forms-api, directory-sso and directory-sso-proxy running
- ensure you have a registration in your local db with an external_id
- In a django shell run the following code:
```
import base64
import hashlib

me = Registration.objects.get(email='your_email')
token = hashlib.sha256(me.email.encode('UTF-8')).hexdigest()
idb64 = base64.b64encode(bytes(me.external_id, 'utf-8')).decode("utf-8")
``` 
- To sign in, go to http://greatcms.trade.great:8020/export-academy/signin?idb64=idb64&token=token, replacing the idb64 and token values with the ones you've just created in the shell
- To sign up, go to http://greatcms.trade.great:8020/export-academy/signup?idb64=idb64&token=token. You'll likely get redirected to the verification code page and get an email that says you're already registered 

**Sign in**
![Screenshot 2023-06-29 at 16 13 35](https://github.com/uktrade/great-cms/assets/22460823/0b7b5286-f3f7-47ab-9b8a-4f0a34577d31)

**Sign up**
![Screenshot 2023-06-29 at 16 15 18](https://github.com/uktrade/great-cms/assets/22460823/b0c00839-fb29-4fc7-948f-a327d29fcfef)


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-802
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
