### PR TITLE
Fix font size of signup/in link text

### DIFF
--- a/export_academy/templates/export_academy/accounts/includes/existing_user_body_text.html
+++ b/export_academy/templates/export_academy/accounts/includes/existing_user_body_text.html
@@ -6,4 +6,4 @@
     Please create a great.gov.uk password to continue to access your bookings.
     {% endif %}
 </p>
-<p>If you have any questions or feedback please <a class="govuk-link" href={% url 'contact:contact-us-feedback' %}>get in touch</a>.</p>
+<p>If you have any questions or feedback please <a class="govuk-link govuk-!-font-size-24" href={% url 'contact:contact-us-feedback' %}>get in touch</a>.</p>

--- a/export_academy/templates/export_academy/accounts/includes/new_user_body_text.html
+++ b/export_academy/templates/export_academy/accounts/includes/new_user_body_text.html
@@ -4,19 +4,19 @@
         <li>
             <i class="fas fa-check-circle" aria-hidden="true"></i>
             {% if is_signin %}
-                <span>Sign in to great.gov.uk, or if you don't have an account already, <a class="govuk-link" href={% url 'export_academy:signup' %}>sign up</a></span>
+                <span>Sign in to great.gov.uk, or if you don't have an account already, <a class="govuk-link govuk-!-font-size-24" href={% url 'export_academy:signup' %}>sign up</a></span>
             {% else %}
-                <span>Sign up to great.gov.uk, or if you have an account already, <a class="govuk-link" href={% url 'export_academy:signin' %}>sign in</a></span>
+                <span>Sign up to great.gov.uk, or if you have an account already, <a class="govuk-link govuk-!-font-size-24" href={% url 'export_academy:signin' %}>sign in</a></span>
             {% endif %}
         </li>
         <li>
             <i class="fas fa-check-circle" aria-hidden="true"></i>
-            <span>Book an event. You can <a class="govuk-link" href={% url 'export_academy:upcoming-events' %}>see what’s currently on offer here</a></span>
+            <span>Book an event. You can <a class="govuk-link govuk-!-font-size-24" href={% url 'export_academy:upcoming-events' %}>see what’s currently on offer here</a></span>
         </li>
         <li>
             <i class="fas fa-check-circle" aria-hidden="true"></i>
             <span>Answer a few questions about your business. That’s it. You only need to do this once, just sign in with your great.gov.uk password every time you visit.</span>
         </li>
     </ul>
-    <p>If you have any questions or feedback please <a class="govuk-link" href={% url 'contact:contact-us-feedback' %}>get in touch</a>.</p>
+    <p>If you have any questions or feedback please <a class="govuk-link govuk-!-font-size-24" href={% url 'contact:contact-us-feedback' %}>get in touch</a>.</p>
 </div>


### PR DESCRIPTION
This PR makes sure that the link text on the sign in and sign up pages for export academy are font 24.

![Screenshot 2023-07-06 at 12 37 29](https://github.com/uktrade/great-cms/assets/22460823/0569f0a0-ddff-41bc-ba57-78082465ce11)

![Screenshot 2023-07-06 at 12 37 37](https://github.com/uktrade/great-cms/assets/22460823/f2a084f0-0d6a-4baa-9fa3-d01cfa20a49f)

To test
- Go to http://greatcms.trade.great:8020/export-academy/signup

### Workflow

- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
