### PR TITLE
KLS-859 - Put event booking period filter behind feature flag

### DIFF
--- a/export_academy/templatetags/event_list_buttons.py
+++ b/export_academy/templatetags/event_list_buttons.py
@@ -44,10 +44,9 @@ def set_all_events(value):
 
 @register.filter
 def get_filters(list_of_filters, user):
-    if user.is_authenticated:
+    if user.is_authenticated and settings.FEATURE_EXPORT_ACADEMY_RELEASE_2:
         return list_of_filters
-    else:
-        return [field for field in list_of_filters if field.name != 'booking_period']
+    return [field for field in list_of_filters if field.name != 'booking_period']
 
 
 @register.simple_tag


### PR DESCRIPTION
This PR puts the booking period filter on the events list page behind the export academy release 2 feature flag.

**To test**
- Log in locally
- go to /export-academy/events
- The booking period filter (all, current bookings, past bookings) should not be visible

### Workflow

- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
