### PR TITLE
Remove CodeCov "magna" bot (part 2)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,5 @@
 codecov:
   require_ci_to_pass: yes
-  bot: 'magna-bot'
 
 coverage:
   status:


### PR DESCRIPTION
CONTEXT: This change removes the `magna-bot` CodeCov user.   

**This is a DRAFT PR only - to test the removal of this configuration.**

### Merging

- [ ] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
