### PR TITLE
Remove CodeCov "magna" bot (part 3)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -20,7 +20,6 @@ coverage:
   ignore:
     - core/management/commands/import_*
 
-
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
CONTEXT: This change removes the `magna-bot` CodeCov user.   

**This is a DRAFT PR only - to test the removal of this configuration.**

### Merging

- [ ] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
