### PR TITLE
Set draftail toolbar to sticky by default

### DIFF
--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -17,6 +17,7 @@ from django.template.loader import render_to_string
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from great_components.helpers import add_next
 from wagtail.admin.views.pages.bulk_actions.page_bulk_action import PageBulkAction
@@ -505,3 +506,16 @@ def convert_related_links(page):
         {'id': page.related_page_five_id, 'title': page.related_page_five_title, 'link': page.related_page_five_title},
     ]
     return [get_related_link_conversion(item) for item in related_links if item['id'] is not None or item['link'] != '']
+
+
+@hooks.register('insert_editor_js')
+def toolbar_sticky_by_default():
+    return mark_safe(
+        """
+        <script>
+            if (window.localStorage.getItem("wagtail:draftail-toolbar")==null) {
+                window.localStorage.setItem("wagtail:draftail-toolbar", "sticky");
+            };
+        </script>
+        """
+    )

--- a/tests/unit/core/test_wagtail_hooks.py
+++ b/tests/unit/core/test_wagtail_hooks.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.db.models import FileField
 from django.test import TestCase, override_settings
+from django.utils.safestring import mark_safe
 from wagtail.core.rich_text import RichText
 from wagtail.tests.utils import WagtailPageTests
 
@@ -29,6 +30,7 @@ from core.wagtail_hooks import (
     editor_css,
     get_microsite_page_body,
     register_s3_media_file_adapter,
+    toolbar_sticky_by_default,
 )
 from tests.helpers import make_test_video
 from tests.unit.core import factories
@@ -1197,3 +1199,18 @@ class MigrateArticeToMicrositeTestCase(WagtailPageTests, TestCase):
 
     def test_migrate_article_page(self):
         self.assertEqual(MigratePage.execute_action([self.article1]), (1, 1))
+
+
+class WagtailInsertEditorJsTestCase(TestCase):
+    def test_toolbar_sticky_by_default(self):
+        return_value = toolbar_sticky_by_default()
+        expected_value = mark_safe(
+            """
+        <script>
+            if (window.localStorage.getItem("wagtail:draftail-toolbar")==null) {
+                window.localStorage.setItem("wagtail:draftail-toolbar", "sticky");
+            };
+        </script>
+        """
+        )
+        assert return_value == expected_value


### PR DESCRIPTION
Adds a wagtail hook that checks whether the draftail-toolbar is null, and if it is, sets it's value to sticky.

To test: Load up any page in wagtail that has a rich text field after clearing your browsing data, check that the toolbar is pinned.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-842
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
