### PR TITLE
Redirect to EA signup from book button

### DIFF
--- a/export_academy/helpers.py
+++ b/export_academy/helpers.py
@@ -10,7 +10,6 @@ from django.urls import reverse_lazy
 from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode
 
-from core.urls import SIGNUP_URL
 from export_academy.models import Event, Registration
 
 
@@ -162,7 +161,7 @@ def check_registration(function):
                 event_id = request.POST['event_id']
                 return redirect(reverse_lazy('export_academy:registration', kwargs=dict(event_id=event_id)))
         else:
-            return redirect_to_login(referer, SIGNUP_URL, REDIRECT_FIELD_NAME)
+            return redirect_to_login(referer, 'export_academy:signup', REDIRECT_FIELD_NAME)
 
     return _wrapped_view_function
 

--- a/tests/unit/export_academy/test_views.py
+++ b/tests/unit/export_academy/test_views.py
@@ -383,7 +383,7 @@ def test_export_academy_booking_redirect_to_login(client, user):
     response = client.post(url, form_data)
 
     assert response.status_code == 302
-    assert response.url.startswith(reverse('core:signup'))
+    assert response.url.startswith(reverse('export_academy:signup'))
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR updates the `check_registration` method to redirect to the export academy sign up page when a logged-out user clicks the 'Book' button on an event. Rather than redirecting to the standard Great sign up page.

**To test**
- When logged out, go to http://greatcms.trade.great:8020/export-academy/events/
- Click the 'Book' button on an event
- You should be redirected to http://greatcms.trade.great:8020/export-academy/signup

### Workflow

- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
