### PR TITLE
Update session backend to use redis cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.0
+  browser-tools: circleci/browser-tools@1.4.2
   node: circleci/node@5.0.2
 
 ###############################################################################
@@ -24,7 +24,6 @@ postgres: &postgres
 postgres_url: &postgres_url
   DATABASE_URL: postgresql://debug:debug@localhost/greatcms
 
-
 ###############################################################################
 # Steps
 ###############################################################################
@@ -36,7 +35,8 @@ install_postgresql_client: &install_postgresql_client
       sudo apt-get update
       sudo apt-get install postgresql-client
 
-create_virtualenv_and_install_dependencies: &create_virtualenv_and_install_dependencies
+create_virtualenv_and_install_dependencies:
+  &create_virtualenv_and_install_dependencies
   run:
     name: Create virtualenv and install dependencies
     command: |
@@ -61,20 +61,17 @@ setup_db: &setup_db
       make ARGUMENTS=migrate manage
       make ARGUMENTS=bootstrap_great manage
 
-
 ###############################################################################
 # Jobs
 ###############################################################################
 
 jobs:
-
   test:
     working_directory: ~/greatcms
     docker:
       - <<: *python_node_browsers
       - <<: *postgres
-    environment:
-      *postgres_url
+    environment: *postgres_url
     steps:
       - checkout
       - *install_postgresql_client
@@ -85,7 +82,7 @@ jobs:
       - save_cache:
           key: v1-deps-{{ checksum "requirements_test.txt" }}
           paths:
-            - "venv"
+            - 'venv'
       - run:
           name: Run Unit tests
           command: |
@@ -99,8 +96,7 @@ jobs:
     docker:
       - <<: *python_node_browsers
       - <<: *postgres
-    environment:
-      *postgres_url
+    environment: *postgres_url
     steps:
       - checkout
       - *install_postgresql_client
@@ -121,7 +117,7 @@ jobs:
       - save_cache:
           key: v1-deps-{{ checksum "requirements_test.txt" }}
           paths:
-            - "venv"
+            - 'venv'
       - run:
           name: Run Browser tests
           command: |
@@ -181,7 +177,7 @@ jobs:
       - save_cache:
           key: v1-deps-{{ checksum "package-lock.json" }}
           paths:
-            - "node_modules"
+            - 'node_modules'
       - run:
           name: Run Javascript tests
           command: npm test -- --maxWorkers=1

--- a/config/settings.py
+++ b/config/settings.py
@@ -382,7 +382,8 @@ SECURE_HSTS_SECONDS = env.int('SECURE_HSTS_SECONDS', 16070400)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_SSL_REDIRECT = env.bool('SECURE_SSL_REDIRECT', True)
 
-SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+
 SESSION_COOKIE_SECURE = env.bool('SESSION_COOKIE_SECURE', True)
 SESSION_COOKIE_HTTPONLY = True
 # must be None to allow copy upstream to work

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -126,3 +126,4 @@ tests/unit/international_online_offer/test_helpers.py
 tests/unit/international_online_offer/test_views.py
 export_academy/forms.py
 design-system/package-lock.json
+tests/unit/sso/test_backends.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=config.settings
+DJANGO_SETTINGS_MODULE=tests.test_settings
 junit_family=xunit2
 addopts = -p no:warnings --ignore=node_modules --ignore=config/celery.py --capture=no --nomigrations --reuse-db -W ignore::DeprecationWarning -vv
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from config.celery import app as celery_app
+
+__all__ = ['celery_app']

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,3 @@
+from config.settings import *  # noqa F401, F403
+
+SESSION_ENGINE = 'django.contrib.sessions.backends.db'

--- a/tests/unit/sso/test_backends.py
+++ b/tests/unit/sso/test_backends.py
@@ -17,6 +17,7 @@ def sso_request(rf, settings, client):
     return request
 
 
+@pytest.mark.django_db
 @mock.patch.object(sso_api_client.user, 'get_session_user', wraps=sso_api_client.user.get_session_user)
 def test_auth_ok(mock_get_session_user, sso_request, requests_mock, settings):
     settings.AUTHENTICATION_BACKENDS = ['sso.backends.BusinessSSOUserBackend']

--- a/tests/unit/sso_profile/enrolment/test_views.py
+++ b/tests/unit/sso_profile/enrolment/test_views.py
@@ -375,8 +375,7 @@ def test_200_feature_on(url, client):
 @pytest.fixture
 def session_client_company_factory(client, settings):
     def session_client(company_choice):
-        session = signed_cookies.SessionStore()
-        session.save()
+        session = client.session
         session[constants.SESSION_KEY_COMPANY_CHOICE] = company_choice
         session.save()
         client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key


### PR DESCRIPTION
This PR updates the session engine to use redis cache as its backend, rather than the current signed_cookies backend. This will fix an issue where wagtail page previews (the data for which is stored in django's session) break due to the size of the session cookie being too large.

To avoid having to mock redis for every test that accesses the session (180), this PR also sets the default database session backend to be used by tests.

This change will not affect user's logged in sessions as this is handled by a separate cookie - not django's session cookie.

**To test locally**
- Log into wagtail locally
- You should see a `sessionid` cookie in your browser whose key will match a key in your local redis instance.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-837
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [ ] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
