### PR TITLE
KLS-931 Add additional text to export academy signin/signup forms

### DIFF
--- a/export_academy/templates/export_academy/accounts/signin.html
+++ b/export_academy/templates/export_academy/accounts/signin.html
@@ -4,6 +4,7 @@
     {% if existing_ea_user %}
         {% include 'export_academy/accounts/includes/existing_user_form_fields.html' %}
     {% else %}
+        <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">Don't have an account? <a class="govuk-link" href="{% url 'export_academy:signup' %}">Sign up</a>
         {% csrf_token %}
         {% for field in form.visible_fields %}
             <div class="govuk-form-group {% if field.errors %}govuk-form-group--error govuk-!-margin-top-6{% endif %}">

--- a/export_academy/templates/export_academy/accounts/signup.html
+++ b/export_academy/templates/export_academy/accounts/signup.html
@@ -3,6 +3,7 @@
 
 {% block form %}
     <h3 class="govuk-!-margin-top-3 govuk-!-margin-bottom-6">Sign up</h3>
+    <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">Already have an account? <a class="govuk-link" href="{% url 'export_academy:signin' %}">Sign in</a>
     {% csrf_token %}
     {% for field in form.visible_fields %}
     <div class="govuk-form-group {% if field.errors %}govuk-form-group--error govuk-!-margin-top-6{% endif %}">


### PR DESCRIPTION
This PR adds additional help text to the export academy sign in and sign up forms, so that users can still see the options to sign in if on the signup page and vice-versa on all screen sizes.

This text will not be visible when migrated users access this page via a unique link.

**To test**
- Go to /export-academy/signup or /export-academy/signin

**Sign up page**
![Screenshot 2023-07-21 at 13 56 38](https://github.com/uktrade/great-cms/assets/22460823/8ee27753-fda7-4ef4-aec8-29273ea7e3d6)

**Sign in page**
![Screenshot 2023-07-21 at 13 56 52](https://github.com/uktrade/great-cms/assets/22460823/6eeb075d-1215-4159-a5d9-292cf581b2a9)

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-931
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
