### PR TITLE
Patch/wagtail transfer circular dependencies

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -833,13 +833,14 @@ WAGTAILTRANSFER_FOLLOWED_REVERSE_RELATIONS = [
     ('core.greatmedia', 'tagged_items', True),
 ]
 
-WAGTAILTRANSFER_NO_FOLLOW_MODELS = ['wagtailcore.page']
+WAGTAILTRANSFER_NO_FOLLOW_MODELS = ['wagtailcore.page', 'core.MicrositePage', 'auth.permission', 'wagtailcore.revision']
 
 WAGTAILTRANSFER_LOOKUP_FIELDS = {
     'taggit.tag': ['slug'],
     'core.personalisationhscodetag': ['slug'],
     'core.personalisationcountrytag': ['slug'],
     'auth.user': ['username'],
+    'auth.permission': ['content_type_id', 'id'],
 }
 
 # dit_helpdesk

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ celery[redis]==5.2.7
     # via
     #   -r requirements.in
     #   django-celery-beat
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   elastic-apm
     #   elasticsearch
@@ -59,9 +59,9 @@ certifi==2023.5.7
     #   sentry-sdk
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.6
     # via
     #   celery
     #   click-didyoumean
@@ -76,7 +76,7 @@ click-repl==0.3.0
     # via celery
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements.in
     #   pyhanko
@@ -207,7 +207,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements.in
     #   wagtail-factories
-faker==18.11.1
+faker==19.2.0
     # via factory-boy
 geoip2==2.9.0
     # via -r requirements.in
@@ -246,7 +246,7 @@ kombu==5.3.1
     # via celery
 l18n==2021.3
     # via wagtail
-lxml==4.9.2
+lxml==4.9.3
     # via
     #   -r requirements.in
     #   pyquery
@@ -257,7 +257,7 @@ markdown2==2.4.0
     #   readtime
 markupsafe==2.1.3
     # via jinja2
-maxminddb==2.3.0
+maxminddb==2.4.0
     # via geoip2
 mohawk==1.1.0
     # via sigauth
@@ -286,7 +286,7 @@ pillow==9.5.0
     #   xhtml2pdf
 polib==1.2.0
     # via wagtail-localize
-prompt-toolkit==3.0.38
+prompt-toolkit==3.0.39
     # via click-repl
 psycopg2==2.9.6
     # via -r requirements.in
@@ -300,7 +300,7 @@ pyhanko-certvalidator==0.23.0
     # via
     #   pyhanko
     #   xhtml2pdf
-pypdf==3.11.0
+pypdf==3.13.0
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode
@@ -310,7 +310,7 @@ pyrsistent==0.19.3
     # via jsonschema
 python-bidi==0.4.2
     # via xhtml2pdf
-python-crontab==2.7.1
+python-crontab==3.0.0
     # via django-celery-beat
 python-dateutil==2.8.2
     # via
@@ -332,7 +332,7 @@ pytz==2023.3
     #   djangorestframework
     #   icalendar
     #   l18n
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   drf-spectacular
     #   pyhanko
@@ -406,7 +406,7 @@ tinycss2==1.2.1
     # via
     #   cssselect2
     #   svglib
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via
     #   asgiref
     #   kombu

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -20,7 +20,7 @@ beautifulsoup4
 freezegun==1.1.0
 pytest-xdist
 webdriver-manager
-browserstack-sdk
+browserstack-sdk==1.12.0
 #pytest-selenium
 
 # Code quality

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -29,12 +29,10 @@ asn1crypto==1.5.1
     #   oscrypto
     #   pyhanko
     #   pyhanko-certvalidator
-astroid==2.15.5
+astroid==2.15.6
     # via pylint
 asttokens==2.2.1
     # via stack-data
-async-generator==1.10
-    # via trio
 async-timeout==4.0.2
     # via redis
 attrs==23.1.0
@@ -58,7 +56,7 @@ beautifulsoup4==4.11.2
     #   wagtail
 billiard==3.6.4.0
     # via celery
-black==23.3.0
+black==23.7.0
     # via
     #   -r requirements_test.in
     #   blacken-docs
@@ -78,7 +76,7 @@ brotli==1.0.9
     # via geventhttpclient
 browserstack-local==1.2.5
     # via browserstack-sdk
-browserstack-sdk==1.10.4
+browserstack-sdk==1.12.0
     # via -r requirements_test.in
 build==0.10.0
     # via pip-tools
@@ -86,7 +84,7 @@ celery[redis]==5.2.7
     # via
     #   -r requirements.in
     #   django-celery-beat
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   elastic-apm
     #   elasticsearch
@@ -98,9 +96,9 @@ cffi==1.15.1
     # via cryptography
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.6
     # via
     #   black
     #   celery
@@ -116,7 +114,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-configargparse==1.5.3
+configargparse==1.7
     # via locust
 coverage[toml]==7.2.7
     # via
@@ -124,7 +122,7 @@ coverage[toml]==7.2.7
     #   pytest-cov
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements.in
     #   pyhanko
@@ -141,7 +139,7 @@ decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-dill==0.3.6
+dill==0.3.7
     # via pylint
 directory-api-client==26.3.0
     # via -r requirements.in
@@ -168,7 +166,7 @@ directory-sso-api-client==7.2.1
     # via -r requirements.in
 directory-validators==9.3.0
     # via -r requirements.in
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
 django==4.1.9
     # via
@@ -264,12 +262,12 @@ elasticsearch-dsl==7.4.1
     # via -r requirements.in
 et-xmlfile==1.1.0
     # via openpyxl
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via
     #   pytest
     #   trio
     #   trio-websocket
-execnet==1.9.0
+execnet==2.0.2
     # via pytest-xdist
 executing==1.2.0
     # via stack-data
@@ -277,7 +275,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements.in
     #   wagtail-factories
-faker==18.11.1
+faker==19.2.0
     # via factory-boy
 filelock==3.12.2
     # via virtualenv
@@ -313,7 +311,7 @@ freezegun==1.1.0
     # via -r requirements_test.in
 geoip2==2.9.0
     # via -r requirements.in
-gevent==22.10.2
+gevent==23.7.0
     # via
     #   geventhttpclient
     #   locust
@@ -321,7 +319,7 @@ geventhttpclient==2.0.9
     # via locust
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.32
     # via -r requirements_test.in
 great-components==2.3.0
     # via -r requirements.in
@@ -339,7 +337,7 @@ html5lib==1.1
     #   xhtml2pdf
 icalendar==5.0.7
     # via -r requirements.in
-identify==2.5.24
+identify==2.5.26
     # via pre-commit
 idna==3.4
     # via
@@ -347,7 +345,7 @@ idna==3.4
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.7.0
+importlib-metadata==6.8.0
     # via flask
 inflection==0.5.1
     # via drf-spectacular
@@ -388,7 +386,7 @@ lazy-object-proxy==1.9.0
     # via astroid
 locust==2.15.1
     # via -r requirements_test.in
-lxml==4.9.2
+lxml==4.9.3
     # via
     #   -r requirements.in
     #   pyquery
@@ -403,7 +401,7 @@ markupsafe==2.1.3
     #   werkzeug
 matplotlib-inline==0.1.6
     # via ipython
-maxminddb==2.3.0
+maxminddb==2.4.0
     # via geoip2
 mccabe==0.7.0
     # via
@@ -460,9 +458,9 @@ pillow==9.5.0
     #   reportlab
     #   wagtail
     #   xhtml2pdf
-pip-tools==6.13.0
+pip-tools==7.1.0
     # via -r requirements_test.in
-platformdirs==3.8.0
+platformdirs==3.9.1
     # via
     #   black
     #   pylint
@@ -477,7 +475,7 @@ pre-commit==3.3.3
     # via -r requirements_test.in
 pre-commit-hooks==3.3.0
     # via -r requirements_test.in
-prompt-toolkit==3.0.38
+prompt-toolkit==3.0.39
     # via
     #   click-repl
     #   ipython
@@ -519,7 +517,7 @@ pylint-django==2.5.3
     # via -r requirements_test.in
 pylint-plugin-utils==0.8.2
     # via pylint-django
-pypdf==3.11.0
+pypdf==3.13.0
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode
@@ -554,7 +552,7 @@ pytest-xdist==3.3.1
     # via -r requirements_test.in
 python-bidi==0.4.2
     # via xhtml2pdf
-python-crontab==2.7.1
+python-crontab==3.0.0
     # via django-celery-beat
 python-dateutil==2.8.2
     # via
@@ -579,7 +577,7 @@ pytz==2023.3
     #   djangorestframework
     #   icalendar
     #   l18n
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   browserstack-sdk
     #   drf-spectacular
@@ -644,6 +642,7 @@ sigauth==5.2.0
 six==1.16.0
     # via
     #   airtable-python-wrapper
+    #   asttokens
     #   elasticsearch-dsl
     #   geventhttpclient
     #   html5lib
@@ -697,24 +696,23 @@ tomli==2.0.1
     #   build
     #   coverage
     #   ipdb
+    #   pip-tools
     #   pylint
     #   pyproject-hooks
     #   pytest
 tomlkit==0.11.8
     # via pylint
-tqdm==4.65.0
-    # via webdriver-manager
 traitlets==5.9.0
     # via
     #   ipython
     #   matplotlib-inline
-trio==0.22.0
+trio==0.22.2
     # via
     #   selenium
     #   trio-websocket
 trio-websocket==0.10.3
     # via selenium
-typing-extensions==4.6.3
+typing-extensions==4.7.1
     # via
     #   asgiref
     #   astroid
@@ -753,7 +751,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.23.1
+virtualenv==20.24.1
     # via pre-commit
 w3lib==1.22.0
     # via directory-client-core
@@ -786,7 +784,7 @@ wagtailmedia==0.14.0
     # via -r requirements.in
 wcwidth==0.2.6
     # via prompt-toolkit
-webdriver-manager==3.8.6
+webdriver-manager==3.9.1
     # via -r requirements_test.in
 webencodings==0.5.1
     # via
@@ -798,7 +796,7 @@ werkzeug==2.3.6
     #   -r requirements_test.in
     #   flask
     #   locust
-wheel==0.40.0
+wheel==0.41.0
     # via pip-tools
 whitenoise==6.5.0
     # via -r requirements.in
@@ -810,7 +808,7 @@ wsproto==1.2.0
     # via trio-websocket
 xhtml2pdf==0.2.11
     # via -r requirements.in
-zipp==3.15.0
+zipp==3.16.2
     # via importlib-metadata
 zope-event==5.0
     # via gevent


### PR DESCRIPTION
Updates the wagtail transfer config to fix Circular Dependancy errors when transferring pages that contain links to their children within rich text fields.

To test locally follow this documentation: https://uktrade.atlassian.net/wiki/spaces/ED/pages/3541434450/Using+Wagtail+Transfer

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-837
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
