### PR TITLE
IOO-673: East location validation error

### DIFF
--- a/international_online_offer/core/choices.py
+++ b/international_online_offer/core/choices.py
@@ -61,7 +61,7 @@ INTENT_CHOICES = (
 
 # Copy of EXPERTISE_REGION_CHOICES in directory constants but using non const keys needed for scorecard service
 REGION_CHOICES = (
-    (regions.EASTERN, 'East of England'),
+    (regions.EASTERN, 'East'),
     (regions.EAST_MIDLANDS, 'East Midlands'),
     (regions.LONDON, 'London'),
     (regions.NORTH_EAST, 'North East'),


### PR DESCRIPTION
Fixes bug in EYB whereby once a user selects "East" as a sector validation was failing.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
