### PR TITLE
Feature/kls 976 add help menu item

### DIFF
--- a/activitystream/serializers.py
+++ b/activitystream/serializers.py
@@ -58,7 +58,7 @@ class ArticlePageSerializer(serializers.Serializer):
                 continue
 
             block_value = streamchild.value
-            if type(block_value) == RichText:
+            if type(block_value) is RichText:
                 searchable_items.append(get_text_for_indexing(block_value.__html__()))
 
             if streamchild.block_type == 'pull_quote':

--- a/core/constants.py
+++ b/core/constants.py
@@ -79,3 +79,7 @@ CONSENT_CHOICES = (
 USER_DATA_NAMES = {'ComparisonMarkets': 16384, 'UserProducts': 16384, 'UserMarkets': 16384, 'ActiveProduct': 256}
 
 COUNTRY_FACTSHEET_CTA_TITLE = 'View latest trade statistics'
+
+MENU_ITEM_ADD_AN_EVENT_LINK = (
+    'https://workspace.trade.gov.uk/working-at-dbt/how-do-i/editing-greatgovuk-campaign-sites-getting-started/'
+)

--- a/core/constants.py
+++ b/core/constants.py
@@ -80,6 +80,6 @@ USER_DATA_NAMES = {'ComparisonMarkets': 16384, 'UserProducts': 16384, 'UserMarke
 
 COUNTRY_FACTSHEET_CTA_TITLE = 'View latest trade statistics'
 
-MENU_ITEM_ADD_AN_EVENT_LINK = (
+MENU_ITEM_ADD_CAMPAIGN_SITE_LINK = (
     'https://workspace.trade.gov.uk/working-at-dbt/how-do-i/editing-greatgovuk-campaign-sites-getting-started/'
 )

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -523,10 +523,10 @@ def toolbar_sticky_by_default():
 
 
 @hooks.register('register_help_menu_item')
-def register_ourhelp_link_menu_item():
+def register_campaign_site_help_menu_item():
     return DismissibleMenuItem(
         _('Campaign Site, getting started'),
-        constants.MENU_ITEM_ADD_AN_EVENT_LINK,
+        constants.MENU_ITEM_ADD_CAMPAIGN_SITE_LINK,
         icon_name='help',
         order=900,
         attrs={'target': '_blank', 'rel': 'noreferrer'},

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -20,6 +20,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from great_components.helpers import add_next
+from wagtail.admin.menu import DismissibleMenuItem
 from wagtail.admin.views.pages.bulk_actions.page_bulk_action import PageBulkAction
 from wagtail.core import hooks
 from wagtail.core.models import Page
@@ -518,4 +519,16 @@ def toolbar_sticky_by_default():
             };
         </script>
         """
+    )
+
+
+@hooks.register('register_help_menu_item')
+def register_ourhelp_link_menu_item():
+    return DismissibleMenuItem(
+        _('Campaign Site, getting started'),
+        constants.MENU_ITEM_ADD_AN_EVENT_LINK,
+        icon_name='help',
+        order=900,
+        attrs={'target': '_blank', 'rel': 'noreferrer'},
+        name='campaign-site',
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ click-repl==0.3.0
     # via celery
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.2
+cryptography==41.0.3
     # via
     #   -r requirements.in
     #   pyhanko

--- a/requirements.txt
+++ b/requirements.txt
@@ -294,13 +294,13 @@ pycparser==2.21
     # via cffi
 pygments==2.15.1
     # via sphinx
-pyhanko==0.19.0
+pyhanko==0.20.0
     # via xhtml2pdf
 pyhanko-certvalidator==0.23.0
     # via
     #   pyhanko
     #   xhtml2pdf
-pypdf==3.13.0
+pypdf==3.14.0
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -279,7 +279,7 @@ faker==19.2.0
     # via factory-boy
 filelock==3.12.2
     # via virtualenv
-flake8==6.0.0
+flake8==6.1.0
     # via
     #   -r requirements_test.in
     #   flake8-debugger
@@ -363,7 +363,7 @@ isort==5.12.0
     #   pylint
 itsdangerous==2.1.2
     # via flask
-jedi==0.18.2
+jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via
@@ -442,7 +442,7 @@ packaging==23.1
     #   webdriver-manager
 parso==0.8.3
     # via jedi
-pathspec==0.11.1
+pathspec==0.11.2
     # via black
 pep8-naming==0.13.3
     # via -r requirements_test.in
@@ -460,7 +460,7 @@ pillow==9.5.0
     #   xhtml2pdf
 pip-tools==7.1.0
     # via -r requirements_test.in
-platformdirs==3.9.1
+platformdirs==3.10.0
     # via
     #   black
     #   pylint
@@ -490,26 +490,26 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via
     #   flake8
     #   flake8-debugger
     #   flake8-print
 pycparser==2.21
     # via cffi
-pyflakes==3.0.1
+pyflakes==3.1.0
     # via flake8
 pygments==2.15.1
     # via
     #   ipython
     #   sphinx
-pyhanko==0.19.0
+pyhanko==0.20.0
     # via xhtml2pdf
 pyhanko-certvalidator==0.23.0
     # via
     #   pyhanko
     #   xhtml2pdf
-pylint==2.17.4
+pylint==2.17.5
     # via
     #   pylint-django
     #   pylint-plugin-utils
@@ -517,7 +517,7 @@ pylint-django==2.5.3
     # via -r requirements_test.in
 pylint-plugin-utils==0.8.2
     # via pylint-django
-pypdf==3.13.0
+pypdf==3.14.0
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode
@@ -631,7 +631,7 @@ ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 s3transfer==0.6.1
     # via boto3
-selenium==4.10.0
+selenium==4.11.2
     # via -r requirements_test.in
 sentry-sdk==1.14.0
     # via -r requirements.in
@@ -699,7 +699,7 @@ tomli==2.0.1
     #   pylint
     #   pyproject-hooks
     #   pytest
-tomlkit==0.11.8
+tomlkit==0.12.1
     # via pylint
 traitlets==5.9.0
     # via
@@ -783,7 +783,7 @@ wagtailmedia==0.14.0
     # via -r requirements.in
 wcwidth==0.2.6
     # via prompt-toolkit
-webdriver-manager==3.9.1
+webdriver-manager==4.0.0
     # via -r requirements_test.in
 webencodings==0.5.1
     # via

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -122,7 +122,7 @@ coverage[toml]==7.2.7
     #   pytest-cov
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.2
+cryptography==41.0.3
     # via
     #   -r requirements.in
     #   pyhanko
@@ -642,6 +642,7 @@ sigauth==5.2.0
 six==1.16.0
     # via
     #   airtable-python-wrapper
+    #   asttokens
     #   elasticsearch-dsl
     #   geventhttpclient
     #   html5lib

--- a/tests/unit/core/test_wagtail_hooks.py
+++ b/tests/unit/core/test_wagtail_hooks.py
@@ -1221,19 +1221,11 @@ class WagtailInsertEditorJsTestCase(TestCase):
 
 def test_register_campaign_site_help_menu_item():
     actual = register_campaign_site_help_menu_item()
-    expected = DismissibleMenuItem(
-        _('Campaign Site, getting started'),  # noqa: F821
-        MENU_ITEM_ADD_CAMPAIGN_SITE_LINK,
-        icon_name='help',
-        order=900,
-        attrs={'target': '_blank', 'rel': 'noreferrer'},
-        name='campaign-site',
-    )
 
     assert isinstance(actual, DismissibleMenuItem)
-    assert actual.label == expected.label
-    assert actual.url == expected.url
-    assert actual.icon_name == expected.icon_name
-    assert actual.order == expected.order
-    assert actual.attrs == expected.attrs
-    assert actual.name == expected.name
+    assert actual.label == 'Campaign Site, getting started'
+    assert actual.url == MENU_ITEM_ADD_CAMPAIGN_SITE_LINK
+    assert actual.icon_name == 'help'
+    assert actual.order == 900
+    assert actual.attrs == {'target': '_blank', 'rel': 'noreferrer', 'data-wagtail-dismissible-id': 'campaign-site'}
+    assert actual.name == 'campaign-site'

--- a/tests/unit/core/test_wagtail_hooks.py
+++ b/tests/unit/core/test_wagtail_hooks.py
@@ -9,10 +9,12 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from django.db.models import FileField
 from django.test import TestCase, override_settings
 from django.utils.safestring import mark_safe
+from wagtail.admin.menu import DismissibleMenuItem
 from wagtail.core.rich_text import RichText
 from wagtail.tests.utils import WagtailPageTests
 
 from core import cms_slugs, wagtail_hooks
+from core.constants import MENU_ITEM_ADD_CAMPAIGN_SITE_LINK
 from core.models import DetailPage, MicrositePage
 from core.wagtail_hooks import (
     FileTransferError,
@@ -29,6 +31,7 @@ from core.wagtail_hooks import (
     convert_video,
     editor_css,
     get_microsite_page_body,
+    register_campaign_site_help_menu_item,
     register_s3_media_file_adapter,
     toolbar_sticky_by_default,
 )
@@ -1214,3 +1217,23 @@ class WagtailInsertEditorJsTestCase(TestCase):
         """
         )
         assert return_value == expected_value
+
+
+def test_register_campaign_site_help_menu_item():
+    actual = register_campaign_site_help_menu_item()
+    expected = DismissibleMenuItem(
+        _('Campaign Site, getting started'),  # noqa: F821
+        MENU_ITEM_ADD_CAMPAIGN_SITE_LINK,
+        icon_name='help',
+        order=900,
+        attrs={'target': '_blank', 'rel': 'noreferrer'},
+        name='campaign-site',
+    )
+
+    assert isinstance(actual, DismissibleMenuItem)
+    assert actual.label == expected.label
+    assert actual.url == expected.url
+    assert actual.icon_name == expected.icon_name
+    assert actual.order == expected.order
+    assert actual.attrs == expected.attrs
+    assert actual.name == expected.name


### PR DESCRIPTION
Add menu item 'Campaign Sites" to Help Menu at the top of the menu
Link navigates to 
https://workspace.trade.gov.uk/working-at-dbt/how-do-i/editing-greatgovuk-campaign-sites-getting-started/
in new tab

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-976
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.



### Housekeeping

- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
