### PR TITLE
Minor fixes for get export help experiment pages

### DIFF
--- a/core/templates/core/get_export_help_experiment_confirmation.html
+++ b/core/templates/core/get_export_help_experiment_confirmation.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="great">
 <section class="great-container">
-    <div class="govuk-!-margin-top-7 three-quarters-width-desktop">
+    <div class="govuk-!-margin-top-7 three-quarters-width-centered-desktop">
         {% include 'components/great/notification-banner.html' with title='Thank you' message="We appreciate your interest and we’ll be in touch once this service is ready to be developed further." %}
         <p class="govuk-!-padding-bottom-6"><a href="/" class="govuk-link">Back to the homepage</a></p>
     </div>

--- a/core/templates/core/get_export_help_experiment_results.html
+++ b/core/templates/core/get_export_help_experiment_results.html
@@ -6,7 +6,7 @@
     <div class="great-bg-white govuk-!-margin-top-7 three-quarters-width-centered-desktop">
         <div class="govuk-!-margin-7">
             <h1 class="govuk-heading-l govuk-!-padding-top-7 govuk-!-margin-bottom-3">We’re improving this website</h1>
-            <p class="govuk-body">We’re working to understand how to make this website better for you. We would love to <a href="https://www.great.gov.uk/search/feedback/" class="govuk-link">hear your feedback</a>.</p>
+            <p class="govuk-body">We’re working to understand how to make this website better for you. We would love to <a href="https://www.great.gov.uk/search/feedback/" class="govuk-link" target="_blank">hear your feedback</a>.</p>
             <p class="govuk-body">For now, here are some links we think you’ll find useful based on the topics you selected.</p>
             {% if other_or_not_sure_chosen %}
                 <h2 class="govuk-heading-m">Suggestions for you:</h2>

--- a/domestic/templates/domestic/includes/experiment-landing-page-hero.html
+++ b/domestic/templates/domestic/includes/experiment-landing-page-hero.html
@@ -1,7 +1,7 @@
 <div class="page-header article-header great-backround-cover-no-repeat" id="hero" style="background-image: url('/static/images/experiment-hero-background.png')">
     <div class="inner-header experiment-landing-page-header">
         <div class="experiment-landing-page-header">
-            <h1 class="great-text-white">Looking for export help</h1>
+            <h1 class="great-text-white">Looking for export help?</h1>
             <p class="great-text-white govuk-!-margin-bottom-6">Find information customised to your needs</p>
             <a href="{% url 'core:get-export-help' %}" class="button white-button-black-text margin-bottom-30">Get help now</a>
         </div>


### PR DESCRIPTION
This PR makes three small fixes to the get export help experiment feature:
- Adds a question mark at the end of the landing page hero heading
- Corrects the container class used on the confirmation page to make it 75% width
- Makes the feedback link on the results page open in a new tab

![Screenshot 2023-08-03 at 11 31 29](https://github.com/uktrade/great-cms/assets/22460823/a8657189-4a34-4dcc-849e-c1d8b8c702ce)

![Screenshot 2023-08-03 at 11 33 42](https://github.com/uktrade/great-cms/assets/22460823/72377894-dbc4-46aa-9335-2032b4c3c22a)


### Workflow

- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Includes screenshot(s) - ideally before and after, but at least after


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
