### PR TITLE
Showing rent or salary component on tagged pages

### DIFF
--- a/international_online_offer/core/helpers.py
+++ b/international_online_offer/core/helpers.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from directory_constants import sectors as directory_constants_sectors
 from international_online_offer.core import (
     choices,
+    intents,
     professions,
     regions,
     sectors as sectors,
@@ -164,3 +165,19 @@ def get_sector_professions_by_level(sector):
         if profession_by_sector_and_level['sector'] == sector:
             return profession_by_sector_and_level
     return None
+
+
+def can_show_salary_component(tags):
+    for tag in tags:
+        if tag.name == intents.FIND_PEOPLE_WITH_SPECIALIST_SKILLS:
+            return True
+
+    return False
+
+
+def can_show_rent_component(tags):
+    for tag in tags:
+        if tag.name == intents.SET_UP_NEW_PREMISES or tag.name == intents.SET_UP_A_NEW_DISTRIBUTION_CENTRE:
+            return True
+
+    return False

--- a/international_online_offer/models.py
+++ b/international_online_offer/models.py
@@ -206,6 +206,11 @@ class IOOArticlePage(BaseContentPage):
         context = super().get_context(request, *args, **kwargs)
         if helpers.is_authenticated(request):
             triage_data = get_triage_data(request.user.hashed_uuid)
+
+            tags = self.tags.all()
+            show_salary_component = helpers.can_show_salary_component(tags)
+            show_rent_component = helpers.can_show_rent_component(tags)
+
             if triage_data:
                 location = request.GET.get(
                     'location', triage_data.location if triage_data.location else choices.regions.LONDON
@@ -214,15 +219,17 @@ class IOOArticlePage(BaseContentPage):
                 sector_display = triage_data.get_sector_display()
 
                 entry_salary = SalaryData.objects.filter(
-                    region=region, vertical__icontains=sector_display, professional_level__icontains='Entry-level'
+                    region__iexact=region,
+                    vertical__icontains=sector_display,
+                    professional_level__icontains='Entry-level',
                 ).aggregate(Avg('median_salary'))
                 mid_salary = SalaryData.objects.filter(
-                    region=region,
+                    region__iexact=region,
                     vertical__icontains=sector_display,
                     professional_level__icontains='Middle/Senior Management',
                 ).aggregate(Avg('median_salary'))
                 executive_salary = SalaryData.objects.filter(
-                    region=region,
+                    region__iexact=region,
                     vertical__icontains=sector_display,
                     professional_level__icontains='Director/Executive',
                 ).aggregate(Avg('median_salary'))
@@ -269,6 +276,8 @@ class IOOArticlePage(BaseContentPage):
                     high_street_retail=high_street_retail,
                     work_office=work_office,
                     professions_by_sector=professions_by_sector,
+                    show_salary_component=show_salary_component,
+                    show_rent_component=show_rent_component,
                 )
         site_section_url = ''
         if self.url:

--- a/international_online_offer/templates/eyb/article.html
+++ b/international_online_offer/templates/eyb/article.html
@@ -49,11 +49,11 @@
   </div>
 </div>
 
-{% if 'find-expert-talent' in request.path%}
+{% if 'find-expert-talent' in request.path or show_salary_component %}
   {% include './includes/salary.html' with salary_location_form=location_form entry_salary=entry_salary mid_salary=mid_salary executive_salary=executive_salary professions_by_sector=professions_by_sector %}
 {% endif %}
 
-{% if 'find-the-right-location-and-premises' in request.path %}
+{% if 'find-the-right-location-and-premises' in request.path or show_rent_component %}
   {% include './includes/rent.html' with rent_location_form=location_form large_warehouse_rent=large_warehouse_rent small_warehouse_rent=small_warehouse_rent shopping_centre=shopping_centre high_street_retail=high_street_retail work_office=work_office %}
 {% endif %}
 

--- a/tests/unit/international_online_offer/test_helpers.py
+++ b/tests/unit/international_online_offer/test_helpers.py
@@ -34,6 +34,23 @@ def test_find_articles_based_on_tags():
     assert helpers.filter_intent_articles_specific_to_sector([], sectors.TECHNOLOGY_AND_SMART_CITIES) == []
 
 
+def test_can_show_salary_rent_component():
+    class MockTag:
+        def __init__(self, name):
+            self.name = name
+
+    tag = MockTag(sectors.TECHNOLOGY_AND_SMART_CITIES)
+    tag2 = MockTag(intents.SET_UP_A_NEW_DISTRIBUTION_CENTRE)
+    tag3 = MockTag(intents.SET_UP_NEW_PREMISES)
+    tag4 = MockTag(intents.FIND_PEOPLE_WITH_SPECIALIST_SKILLS)
+
+    assert helpers.can_show_salary_component([tag]) is False
+    assert helpers.can_show_salary_component([tag, tag4]) is True
+    assert helpers.can_show_rent_component([tag]) is False
+    assert helpers.can_show_rent_component([tag, tag2]) is True
+    assert helpers.can_show_rent_component([tag, tag3]) is True
+
+
 def test_get_trade_assoication_sectors_from_sector():
     assert helpers.get_trade_assoication_sectors_from_sector(directory_constants_sectors.AEROSPACE) == []
     assert helpers.get_trade_assoication_sectors_from_sector(directory_constants_sectors.FOOD_AND_DRINK) == [


### PR DESCRIPTION
Content want the salary and rent components to show on article pages that have been tagged with the relevant tag. 

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-671
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Housekeeping

N/A

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
