### PR TITLE
Change booking query to exclude any with status 'Cancelled'

### DIFF
--- a/export_academy/models.py
+++ b/export_academy/models.py
@@ -22,7 +22,7 @@ from export_academy.forms import EventAdminModelForm
 
 
 def send_notifications_for_all_bookings(event, template_id, additional_notify_data=None):
-    bookings = Booking.objects.filter(event_id=event.id)
+    bookings = Booking.objects.exclude(status="Cancelled").filter(event_id=event.id)
     for booking in bookings:
         email = booking.registration.email
 

--- a/export_academy/models.py
+++ b/export_academy/models.py
@@ -22,7 +22,7 @@ from export_academy.forms import EventAdminModelForm
 
 
 def send_notifications_for_all_bookings(event, template_id, additional_notify_data=None):
-    bookings = Booking.objects.exclude(status="Cancelled").filter(event_id=event.id)
+    bookings = Booking.objects.exclude(status='Cancelled').filter(event_id=event.id)
     for booking in bookings:
         email = booking.registration.email
 


### PR DESCRIPTION
This PR is to apply a simple fix to stop emails from being sent to users that have booked onto an event and subsequently cancelled. Prior to this change, reminder and follow-up emails were sent regardless of booking status.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1031
- [x] Jira ticket has the correct status.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
