### PR TITLE
Check that user has completed triage on guide

### DIFF
--- a/international_online_offer/core/helpers.py
+++ b/international_online_offer/core/helpers.py
@@ -181,3 +181,14 @@ def can_show_rent_component(tags):
             return True
 
     return False
+
+
+def is_triage_complete(triage_data):
+    if triage_data:
+        if triage_data.sector:
+            if triage_data.intent or triage_data.intent_other:
+                if triage_data.location or triage_data.location_none:
+                    if triage_data.hiring:
+                        if triage_data.spend or triage_data.spend_other:
+                            return True
+    return False

--- a/international_online_offer/core/helpers.py
+++ b/international_online_offer/core/helpers.py
@@ -184,11 +184,11 @@ def can_show_rent_component(tags):
 
 
 def is_triage_complete(triage_data):
-    if triage_data:
-        if triage_data.sector:
-            if triage_data.intent or triage_data.intent_other:
-                if triage_data.location or triage_data.location_none:
-                    if triage_data.hiring:
-                        if triage_data.spend or triage_data.spend_other:
-                            return True
-    return False
+    return bool(
+        triage_data
+        and triage_data.sector
+        and (triage_data.intent or triage_data.intent_other)
+        and (triage_data.location or triage_data.location_none)
+        and triage_data.hiring
+        and (triage_data.spend or triage_data.spend_other)
+    )

--- a/international_online_offer/forms.py
+++ b/international_online_offer/forms.py
@@ -61,6 +61,9 @@ class IntentForm(forms.Form):
     def clean(self):
         cleaned_data = super().clean()
         intent = cleaned_data.get('intent')
+        if intents.OTHER not in intent:
+            cleaned_data['intent_other'] = ''
+
         intent_other = cleaned_data.get('intent_other')
         if intent and any(intents.OTHER in s for s in intent) and not intent_other:
             self.add_error('intent_other', 'Please enter more information here')
@@ -132,6 +135,8 @@ class SpendForm(forms.Form):
     def clean(self):
         cleaned_data = super().clean()
         spend = cleaned_data.get('spend')
+        if spend != spends.SPECIFIC_AMOUNT:
+            cleaned_data['spend_other'] = ''
         spend_other = cleaned_data.get('spend_other')
         if spend == spends.SPECIFIC_AMOUNT and not spend_other:
             self.add_error('spend_other', 'You must enter a value in pounds')

--- a/international_online_offer/forms.py
+++ b/international_online_offer/forms.py
@@ -63,7 +63,6 @@ class IntentForm(forms.Form):
         intent = cleaned_data.get('intent')
         if intents.OTHER not in intent:
             cleaned_data['intent_other'] = ''
-
         intent_other = cleaned_data.get('intent_other')
         if intent and any(intents.OTHER in s for s in intent) and not intent_other:
             self.add_error('intent_other', 'Please enter more information here')

--- a/international_online_offer/models.py
+++ b/international_online_offer/models.py
@@ -392,6 +392,16 @@ class TriageData(models.Model):
     spend_other = models.CharField(max_length=255, null=True)
     is_high_value = models.BooleanField(default=False)
 
+    @property
+    def is_complete(self):
+        if self.sector:
+            if self.intent or self.intent_other:
+                if self.location or self.location_none:
+                    if self.hiring:
+                        if self.spend or self.spend_other:
+                            return True
+        return False
+
 
 class UserData(models.Model):
     hashed_uuid = models.CharField(max_length=200)

--- a/international_online_offer/models.py
+++ b/international_online_offer/models.py
@@ -76,12 +76,13 @@ class IOOGuidePage(BaseContentPage):
         triage_data = get_triage_data_from_db_or_session(request)
 
         is_triage_complete = False
-        if triage_data.sector:
-            if triage_data.intent or triage_data.intent_other:
-                if triage_data.location or triage_data.location_none:
-                    if triage_data.hiring:
-                        if triage_data.spend or triage_data.spend_other:
-                            is_triage_complete = True
+        if triage_data:
+            if triage_data.sector:
+                if triage_data.intent or triage_data.intent_other:
+                    if triage_data.location or triage_data.location_none:
+                        if triage_data.hiring:
+                            if triage_data.spend or triage_data.spend_other:
+                                is_triage_complete = True
 
         # Get trade association and shows page (should only be one)
         trade_page = IOOTradePage.objects.live().filter().first()

--- a/international_online_offer/models.py
+++ b/international_online_offer/models.py
@@ -75,14 +75,7 @@ class IOOGuidePage(BaseContentPage):
         )
         triage_data = get_triage_data_from_db_or_session(request)
 
-        is_triage_complete = False
-        if triage_data:
-            if triage_data.sector:
-                if triage_data.intent or triage_data.intent_other:
-                    if triage_data.location or triage_data.location_none:
-                        if triage_data.hiring:
-                            if triage_data.spend or triage_data.spend_other:
-                                is_triage_complete = True
+        is_triage_complete = helpers.is_triage_complete(triage_data)
 
         # Get trade association and shows page (should only be one)
         trade_page = IOOTradePage.objects.live().filter().first()

--- a/international_online_offer/models.py
+++ b/international_online_offer/models.py
@@ -75,6 +75,14 @@ class IOOGuidePage(BaseContentPage):
         )
         triage_data = get_triage_data_from_db_or_session(request)
 
+        is_triage_complete = False
+        if triage_data.sector:
+            if triage_data.intent or triage_data.intent_other:
+                if triage_data.location or triage_data.location_none:
+                    if triage_data.hiring:
+                        if triage_data.spend or triage_data.spend_other:
+                            is_triage_complete = True
+
         # Get trade association and shows page (should only be one)
         trade_page = IOOTradePage.objects.live().filter().first()
 
@@ -112,6 +120,7 @@ class IOOGuidePage(BaseContentPage):
             get_to_know_market_articles=list(chain(sector_only_articles, intent_articles_specific_to_sector)),
             support_and_incentives_articles=all_articles_tagged_with_support_and_incentives,
             trade_page=trade_page,
+            is_triage_complete=is_triage_complete,
         )
 
         self.set_ga360_payload(
@@ -391,16 +400,6 @@ class TriageData(models.Model):
     spend = models.CharField(max_length=255, choices=choices.SPEND_CHOICES)
     spend_other = models.CharField(max_length=255, null=True)
     is_high_value = models.BooleanField(default=False)
-
-    @property
-    def is_complete(self):
-        if self.sector:
-            if self.intent or self.intent_other:
-                if self.location or self.location_none:
-                    if self.hiring:
-                        if self.spend or self.spend_other:
-                            return True
-        return False
 
 
 class UserData(models.Model):

--- a/international_online_offer/templates/eyb/guide.html
+++ b/international_online_offer/templates/eyb/guide.html
@@ -33,7 +33,7 @@
         </div>
     </div>
     {% endif %}
-    {% if not triage_data.is_complete %}
+    {% if not is_triage_complete %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             {% include './includes/govuk/notification_banner.html' with banner_title="Important" banner_heading='Complete a 2-minute step by step process to ensure this guide is tailored to your specific needs.' banner_link='international_online_offer:sector' banner_link_text='Start now' %}

--- a/international_online_offer/templates/eyb/guide.html
+++ b/international_online_offer/templates/eyb/guide.html
@@ -19,7 +19,7 @@
 <div class="govuk-width-container">
     {% if not eyb_user %}
         {% if triage_data.is_high_value %}
-        <div class="govuk-grid-row" id="complete_contact_form_message">
+        <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 {% include './includes/govuk/notification_banner.html' with banner_heading='Your business may qualify for 1 to 1 support. One of our specialist advisers will contact you to discuss your expansion plans. Sign up to access this support and your personalised online guide.' banner_link=complete_contact_form_link banner_link_text=complete_contact_form_link_text %}
             </div>
@@ -27,9 +27,16 @@
         {% endif %}
     {% endif %}
     {% if eyb_user and request.GET.signup %}
-    <div class="govuk-grid-row" id="complete_contact_form_message">
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             {% include './includes/govuk/notification_banner.html' with css_class="govuk-notification-banner--success" banner_title="Success" banner_heading='Your account has been created. You can now access your personalised guide tailored to your expansion plans.' %}
+        </div>
+    </div>
+    {% endif %}
+    {% if not triage_data.is_complete %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {% include './includes/govuk/notification_banner.html' with banner_title="Important" banner_heading='Complete a 2-minute step by step process to ensure this guide is tailored to your specific needs.' banner_link='international_online_offer:sector' banner_link_text='Start now' %}
         </div>
     </div>
     {% endif %}

--- a/tests/unit/international_online_offer/test_helpers.py
+++ b/tests/unit/international_online_offer/test_helpers.py
@@ -4,7 +4,15 @@ import pytest
 from directory_forms_api_client import actions
 
 from directory_constants import sectors as directory_constants_sectors
-from international_online_offer.core import helpers, intents, regions, sectors
+from international_online_offer.core import (
+    helpers,
+    hirings,
+    intents,
+    regions,
+    sectors,
+    spends,
+)
+from international_online_offer.models import TriageData
 
 
 def test_find_articles_based_on_tags():
@@ -139,3 +147,15 @@ def test_get_rent_data():
 def test_get_sector_professions_by_level():
     food_drink_profession = helpers.get_sector_professions_by_level(directory_constants_sectors.FOOD_AND_DRINK)
     assert food_drink_profession['entry_level'] == 'bartenders, waiting staff and cooks'
+
+
+@pytest.mark.django_db
+def test_is_triage_complete():
+    mock_triage_data = TriageData()
+    mock_triage_data.sector = directory_constants_sectors.FOOD_AND_DRINK
+    mock_triage_data.intent_other = 'TEST OTHER INTENT'
+    mock_triage_data.location = regions.LONDON
+    mock_triage_data.hiring = hirings.ELEVEN_TO_FIFTY
+    mock_triage_data.spend = spends.FIVE_HUNDRED_THOUSAND_ONE_TO_ONE_MILLION
+    assert helpers.is_triage_complete(None) is False
+    assert helpers.is_triage_complete(mock_triage_data) is True

--- a/tests/unit/international_online_offer/test_views.py
+++ b/tests/unit/international_online_offer/test_views.py
@@ -310,7 +310,7 @@ def test_triage_spend_session(client, settings):
     url = reverse('international_online_offer:spend')
     client.post(url, {'spend': spends.TWO_MILLION_ONE_TO_FIVE_MILLION})
     assert client.session['spend'] == spends.TWO_MILLION_ONE_TO_FIVE_MILLION
-    assert client.session['spend_other'] is None
+    assert client.session['spend_other'] == ''
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Check that user has completed triage on guide and message asking them to complete it. This comes as a change as we've noticed users that signup before going through the triage are coming through to the dashboard and we need this additional IST need this information to help guide them down the line.

The idea was to remove sign in link but this breaks the returning user journey 
The second idea was to change the signup success message to show signed up but not completed triage. These are separate flows and should be considered this way, plus we also need to show the message of triage incomplete if a user has got to the guide page, is logged out and has not yet signed up.

Solution was instead to show this message any time the triage is incomplete.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-710
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Housekeeping

N/A

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
