### PR TITLE
Reinstate the event's attendance tab in Wagtail Admin

### DIFF
--- a/export_academy/cms_panels.py
+++ b/export_academy/cms_panels.py
@@ -1,10 +1,16 @@
-from wagtail.admin.panels import (  # InlinePanel,
+from wagtail.admin.panels import (
     FieldPanel,
+    InlinePanel,
     MultiFieldPanel,
     ObjectList,
     TabbedInterface,
 )
 from wagtailmedia.widgets import AdminMediaChooser
+
+
+class BookingsInlinePanel(InlinePanel):
+    class BoundPanel(InlinePanel.BoundPanel):
+        template_name = 'wagtailadmin/export_academy/panels/bookings_inline_panel.html'
 
 
 class ExportAcademyPagePanels:
@@ -93,12 +99,11 @@ class EventPanel:
         FieldPanel('closed', heading='closed for bookings'),
     ]
 
-    # disabling the attendance_panel temporarily to support UKEA V2 release. refer to KLS-989 for further details.
-    # attendance_panel = [InlinePanel('bookings', label='Bookings')]
+    attendance_panel = [BookingsInlinePanel('bookings', panels=[FieldPanel('status')], label='Bookings')]
 
     edit_handler = TabbedInterface(
         [
             ObjectList(event_panel, heading='Event'),
-            # ObjectList(attendance_panel, heading='Attendance'),
+            ObjectList(attendance_panel, heading='Attendance'),
         ]
     )

--- a/export_academy/templates/wagtailadmin/export_academy/panels/bookings_inline_panel.html
+++ b/export_academy/templates/wagtailadmin/export_academy/panels/bookings_inline_panel.html
@@ -1,0 +1,58 @@
+{% load i18n l10n wagtailadmin_tags %}
+
+{{ self.formset.management_form }}
+
+{% if self.formset.non_form_errors %}
+    <div class="error-message">
+        {% for error in self.formset.non_form_errors %}
+            <span>{{ error|escape }}</span>
+        {% endfor %}
+    </div>
+{% endif %}
+
+{% if self.help_text %}
+    {% help_block status="info" %}{{ self.help_text }}{% endhelp_block %}
+{% endif %}
+
+<div id="info" class="help">{{ self.children|length }} {{ self.heading|lower }}</div>
+
+<div id="id_{{ self.formset.prefix }}-FORMS">
+    {% comment %}
+
+    Child elements of this div will become orderable elements. Do not place additional
+    "furniture" elements here unless you intend them to be part of the child ordering.
+
+    {% endcomment %}
+
+    {% for child in self.children %}
+        {% include "wagtailadmin/export_academy/panels/bookings_inline_panel_child.html" %}
+    {% endfor %}
+</div>
+
+<script type="text/django-form-template" id="id_{{ self.formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    {% escapescript %}
+        {% include "wagtailadmin/panels/inline_panel_child.html" with child=self.empty_child %}
+    {% endescapescript %}
+</script>
+
+{# Align with guiding line of the preceding child panel. #}
+<div class="w-mb-4 -w-ml-0.5">
+    {% block add_button %}
+        <button type="button" class="button button-small button-secondary chooser__choose-button" id="id_{{ self.formset.prefix }}-ADD">
+            {% icon name=icon|default:"plus-inverse" %}{% blocktrans trimmed with label=self.label|lower %}Add {{ label }}{% endblocktrans %}
+        </button>
+    {% endblock %}
+</div>
+
+{% block js_init %}
+    <script>
+        (function() {
+            var panel = new InlinePanel({
+                formsetPrefix: "id_{{ self.formset.prefix }}",
+                emptyChildFormPrefix: "{{ self.empty_child.form.prefix }}",
+                canOrder: {% if can_order %}true{% else %}false{% endif %},
+                maxForms: {{ self.formset.max_num|unlocalize }}
+            });
+        })();
+    </script>
+{% endblock %}

--- a/export_academy/templates/wagtailadmin/export_academy/panels/bookings_inline_panel_child.html
+++ b/export_academy/templates/wagtailadmin/export_academy/panels/bookings_inline_panel_child.html
@@ -1,0 +1,28 @@
+{% load i18n wagtailadmin_tags %}
+
+{% fragment as id %}inline_child_{{ child.form.prefix }}{% endfragment %}
+{% fragment as panel_id %}{{ id }}-panel{% endfragment %}
+<div data-inline-panel-child id="{{ id }}" data-contentpath-disabled>
+    {% fragment as header_controls %}
+        {% if can_order %}
+            <button type="button" class="button button--icon text-replace white" data-inline-panel-child-move-up title="{% trans 'Move up' %}">{% icon name="arrow-up" %}</button>
+            <button type="button" class="button button--icon text-replace white" data-inline-panel-child-move-down title="{% trans 'Move down' %}">{% icon name="arrow-down" %}</button>
+        {% endif %}
+        <button type="button" class="button button--icon text-replace white" id="{{ child.form.DELETE.id_for_label }}-button" title="{% trans 'Delete' %}">{% icon name="bin" %}</button>
+    {% endfragment %}
+    {% fragment as heading %}
+        {{ child.instance.registration.email }}
+    {% endfragment %}
+    {% panel id=panel_id heading=heading heading_size="label" heading_level="3" header_controls=header_controls %}
+        {% if child.form.non_field_errors %}
+            <ul>
+                {% for error in child.form.non_field_errors %}
+                    <li class="error-message">
+                        <span>{{ error|escape }}</span>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+        {{ child.render_form_content }}
+    {% endpanel %}
+</div>


### PR DESCRIPTION
CONTEXT: This PR brings back the attendance tab to the event's edit page in Wagtail Admin.

![image](https://github.com/uktrade/great-cms/assets/471674/1d072afc-f0e1-454c-a04b-84e4b81146df)

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1016
- [x] Jira ticket has the correct status
- [x] A clear/description pull request messaged added

### Reviewing help

- [x] Includes screenshots

### Merging

- [x] This PR can be merged by reviewers
