### PR TITLE
KLS-1079 - Update logic for content on EA landing page hero

### DIFF
--- a/export_academy/templates/export_academy/landing_page.html
+++ b/export_academy/templates/export_academy/landing_page.html
@@ -18,12 +18,11 @@
                     <p>{{ page.hero_text | richtext | add_govuk_classes }}</p>
                     {% feature_ea_release_two_enabled as ea_release_two_enabled %}
                     {% if ea_release_two_enabled %}
-                        {% is_logged_in as ea_user_logged_in %}
-                        {% if ea_user_logged_in %}
-                            {% include_block page.hero_cta_logged_in %}
-                        {% else %}
+                        {% if user.is_anonymous %}
                             {% include_block page.hero_cta %}
                             <p>{{ page.hero_text_below_cta_logged_out | richtext | add_govuk_classes }}</p>
+                        {% else %}
+                            {% include_block page.hero_cta_logged_in %}
                         {% endif %}
                     {% else %}
                         {% include_block page.hero_cta %}


### PR DESCRIPTION
This PR updates the logic in the export academy landing page hero so that the logged in content appears when a user is logged in, not just when they're registered with EA.

![Screenshot 2023-08-21 at 11 16 13](https://github.com/uktrade/great-cms/assets/22460823/b6f3f351-6915-4c39-afe7-679eaf4c5866)

To test
- Delete your local registration instance if you already have one - `make manage shell_plus` + `Registration.objects.get(email='<your-email>').delete()`
- Go to http://greatcms.trade.great:8020/export-academy/
- When signed OUT you should see the sign up button and text, when signed in you should see the 'View all events' button

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1079
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
