### PR TITLE
Microsite block spacing v2

### DIFF
--- a/core/templates/microsites/blocks/columns.html
+++ b/core/templates/microsites/blocks/columns.html
@@ -6,9 +6,9 @@
 {% load get_template_translation_enabled from content_tags %}
 {% get_template_translation_enabled as TRANSLATE_TEXT %}
 
-<div class="govuk-grid-row govuk-!-margin-top-3">
+<div class="govuk-grid-row govuk-!-margin-bottom-6">
 {% for item in value %}
-<div class="microsite-column govuk-grid-column-one-{% if value|length == 3 %}third{% else %}half{% endif %} govuk-!-margin-bottom-3">
+<div class="microsite-column govuk-grid-column-one-{% if value|length == 3 %}third{% else %}half{% endif %}">
     {%if item.value.image%}
         <div class="govuk-!-margin-bottom-6 great-scaled-full-img">
             {% image item.value.image width-700 %}

--- a/core/templates/microsites/blocks/columns.html
+++ b/core/templates/microsites/blocks/columns.html
@@ -18,7 +18,7 @@
         {{ item.value.text }}
     {% endfilter %}
     {%if item.value.button_url%}
-        <a href="{{ item.value.button_url|persist_language:request.GET }}" class="govuk-button">
+        <a href="{{ item.value.button_url|persist_language:request.GET }}" class="govuk-button govuk-!-margin-bottom-0">
             {% comment %} I'm assuming this will change but including for completeness {% endcomment %}
             {% if TRANSLATE_TEXT %}
                 {% translate item.value.button_label %}

--- a/core/templates/microsites/blocks/cta.html
+++ b/core/templates/microsites/blocks/cta.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 {% load persist_language from component_tags %}
-<div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+<div class="govuk-grid-row govuk-!-margin-bottom-6">
     <div class="govuk-grid-column-full">
         <section class="govuk-!-padding-6 great-bg-light-blue">
             <h3 class="govuk-heading-m great-font-size-28">{% if value.title %}{{ value.title }}{% else %}{{ title }}{% endif %}</h3>

--- a/core/templates/microsites/blocks/image.html
+++ b/core/templates/microsites/blocks/image.html
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-        <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-3 great-ratio-16-9">
+        <div class="govuk-!-margin-bottom-6 great-ratio-16-9">
             {% image value width-1200 %}
         </div>
     </div>

--- a/core/templates/microsites/blocks/image_full_width.html
+++ b/core/templates/microsites/blocks/image_full_width.html
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-3 great-media-container">
+        <div class="govuk-!-margin-bottom-6 great-media-container">
             {% image value original width="" height="" %}
         </div>
     </div>

--- a/core/templates/microsites/blocks/link.html
+++ b/core/templates/microsites/blocks/link.html
@@ -2,7 +2,7 @@
 {% load wagtailimages_tags %}
 {% load add_govuk_classes get_link_blocks get_text_blocks from content_tags %}
 
-<div class="govuk-!-padding-top-6 great-full-width-bar great-bg-lighter-grey govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+<div class="govuk-!-padding-top-6 great-full-width-bar great-bg-lighter-grey govuk-!-margin-bottom-6">
     {% with firstTextBlock=value|get_text_blocks|first %}
         {% if firstTextBlock %}
             <div class="govuk-grid-row">

--- a/core/templates/microsites/blocks/streamfield.html
+++ b/core/templates/microsites/blocks/streamfield.html
@@ -9,7 +9,7 @@
     {% if block.block_type == 'form' %}
      {% filter add_govuk_classes %}
         {% if form %}
-            <div class="form-container {{form_class}} govuk-!-static-padding-0 govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+            <div class="form-container {{form_class}} govuk-!-static-padding-0 govuk-!-margin-bottom-6">
                 {% if form_success %}
                     <div class="success-message-container">
                         <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css"

--- a/core/templates/microsites/blocks/text.html
+++ b/core/templates/microsites/blocks/text.html
@@ -1,6 +1,6 @@
 {% load add_govuk_classes from content_tags %}
 
-<div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+<div class="govuk-grid-row govuk-!-margin-bottom-6">
     <div class="govuk-grid-column-three-quarters richtext">
         {% filter add_govuk_classes %}
             {{ value }}


### PR DESCRIPTION
This ticket makes some amendments to the spacing within Microsites components, in order to fix the CSS 'margin collapse' bug that was occurring. 

TO TEST: Has already been reviewed by Chris Tucker; but what is required is to look at a microsites page and ensure all components have a bottom margin of 30px (screenshots to illustrate this are on the ticket). 

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Reviewing help

- [X] Explains how to test locally, including how to set up appropriate data
- [X] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
