### PR TITLE
KLS-1142 - disable attendance tab on wagtail events

### DIFF
--- a/export_academy/cms_panels.py
+++ b/export_academy/cms_panels.py
@@ -99,11 +99,12 @@ class EventPanel:
         FieldPanel('closed', heading='closed for bookings'),
     ]
 
-    attendance_panel = [BookingsInlinePanel('bookings', panels=[FieldPanel('status')], label='Bookings')]
+    # temporarily disabling the 'Attendance' tab. See KLS-1142 for further details.
+    # attendance_panel = [BookingsInlinePanel('bookings', panels=[FieldPanel('status')], label='Bookings')]
 
     edit_handler = TabbedInterface(
         [
             ObjectList(event_panel, heading='Event'),
-            ObjectList(attendance_panel, heading='Attendance'),
+            # ObjectList(attendance_panel, heading='Attendance'),
         ]
     )


### PR DESCRIPTION
Editing an event with > c. 330 attendees causes a 400 error because the maximum number of form fields is sent. This change disables the attendance tab temporarily so that events can be modified.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/jira/software/projects/KLS/boards/359?selectedIssue=KLS-1142
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

1. Visit the events page in Wagtail admin
2. Click edit on an event
3. The 'Attendance' tab should not be displayed

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
