### PR TITLE
Remove breadcrumb block causing duplicate

### DIFF
--- a/domestic/templates/domestic/base.html
+++ b/domestic/templates/domestic/base.html
@@ -173,9 +173,6 @@
   {% include 'core/header.html' %}
 {% endblock %}
 
-{% block breadcrumbs %}
-{% endblock %}
-
 {% block body_content_container %}
   <main id="content" tabindex="-1" class="{% block css_layout_class %}{% endblock css_layout_class %}">
     {% block content %}{% endblock %}

--- a/export_academy/templates/export_academy/event_details.html
+++ b/export_academy/templates/export_academy/event_details.html
@@ -10,18 +10,17 @@
 
 {% block head_title %}Events – {{ event.name }}{% endblock %}
 
-{% block breadcrumbs %}
+
+
+{% block content  %}
     <div class="great great-bg-white">
-        <div id="breadcrumbs"
-             class="great-bg-light-blue">
-            {% breadcrumbs event.name %}
-            <a href="/">great.gov.uk</a>
-            <a href="../../">UK Export Academy</a>
-            <a href="../">Events</a>
+    <div id="breadcrumbs" class="great-bg-light-blue">
+        {% breadcrumbs event.name %}
+        <a href="/">great.gov.uk</a>
+        <a href="../../">UK Export Academy</a>
+        <a href="../">Events</a>
         {% endbreadcrumbs %}
     </div>
-    {%endblock%}
-    {% block content  %}
     <section class="great govuk-!-padding-bottom-6 govuk-!-padding-top-9">
         <div class="great-container event-details-header-container">
             <div class="event-details-header-info govuk-grid-column-two-thirds-from-desktop govuk-!-static-padding-0">


### PR DESCRIPTION
This PR removes the breadcrumb block from domestic/base.html and updates the template for the events details page so that the breadcrumbs still show. This resolves the duplicate breadcrumbs elsewhere on the site.

To test check the links in the footers (i.e. terms and conditions) and there should no longer be double breadcrumbs. additionally check the event details page, the breadcrumbs should still be visible.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1196
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
