### PR TITLE
Added redirect when user signs up to personalised guide tab

### DIFF
--- a/international_online_offer/views.py
+++ b/international_online_offer/views.py
@@ -344,7 +344,7 @@ class ProfileView(GA360Mixin, FormView):
 
     def get_success_url(self) -> str:
         if self.request.GET.get('signup'):
-            return '/international/expand-your-business-in-the-uk/guide/?signup=true'
+            return '/international/expand-your-business-in-the-uk/guide/?signup=true#personalised-guide'
         return '/international/expand-your-business-in-the-uk/guide/'
 
     def __init__(self):


### PR DESCRIPTION
Requirement to send newly signed up users to the second tab on the guide page of EYB which shows the personalised content mentioned in the sign up benefits mentioned across the service. 

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-781
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data

### Housekeeping

N/A

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
