### PR TITLE
Reintroduce accessibility change to breadcrumbs

### DIFF
--- a/domestic/templates/domestic/base.html
+++ b/domestic/templates/domestic/base.html
@@ -173,7 +173,7 @@
   {% include 'core/header.html' %}
 {% endblock %}
 
-{% block breadcrumbs-ea-detail-page %}
+{% block breadcrumbs-block %}
 {% endblock %}
 
 {% block body_content_container %}

--- a/domestic/templates/domestic/base.html
+++ b/domestic/templates/domestic/base.html
@@ -173,6 +173,9 @@
   {% include 'core/header.html' %}
 {% endblock %}
 
+{% block breadcrumbs-ea-detail-page %}
+{% endblock %}
+
 {% block body_content_container %}
   <main id="content" tabindex="-1" class="{% block css_layout_class %}{% endblock css_layout_class %}">
     {% block content %}{% endblock %}

--- a/export_academy/templates/export_academy/event_details.html
+++ b/export_academy/templates/export_academy/event_details.html
@@ -10,7 +10,7 @@
 
 {% block head_title %}Events – {{ event.name }}{% endblock %}
 
-{% block breadcrumbs-ea-detail-page %}
+{% block breadcrumbs-block %}
     <div class="great great-bg-white">
         <div id="breadcrumbs"
              class="great-bg-light-blue">

--- a/export_academy/templates/export_academy/event_details.html
+++ b/export_academy/templates/export_academy/event_details.html
@@ -10,17 +10,18 @@
 
 {% block head_title %}Events – {{ event.name }}{% endblock %}
 
-
-
-{% block content  %}
+{% block breadcrumbs-ea-detail-page %}
     <div class="great great-bg-white">
-    <div id="breadcrumbs" class="great-bg-light-blue">
-        {% breadcrumbs event.name %}
-        <a href="/">great.gov.uk</a>
-        <a href="../../">UK Export Academy</a>
-        <a href="../">Events</a>
+        <div id="breadcrumbs"
+             class="great-bg-light-blue">
+            {% breadcrumbs event.name %}
+            <a href="/">great.gov.uk</a>
+            <a href="../../">UK Export Academy</a>
+            <a href="../">Events</a>
         {% endbreadcrumbs %}
     </div>
+    {%endblock%}
+    {% block content  %}
     <section class="great govuk-!-padding-bottom-6 govuk-!-padding-top-9">
         <div class="great-container event-details-header-container">
             <div class="event-details-header-info govuk-grid-column-two-thirds-from-desktop govuk-!-static-padding-0">


### PR DESCRIPTION
This PR moves breadcrumbs back out of the content block on the EA details page. This allows the skip to main content link to bypass the breadcrumbs to improve accessibility.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1196
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
