### PR TITLE
Add middleware to limit data on the domain and CSP via HTTP headers

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -103,9 +103,11 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'wagtail.contrib.legacy.sitemiddleware.SiteMiddleware',
+    'csp.middleware.CSPMiddleware',
     'core.middleware.UserSpecificRedirectMiddleware',
     'core.middleware.StoreUserExpertiseMiddleware',
     'core.middleware.CheckGATags',
+    'core.middleware.HHTPHeaderDisallowEmbeddingMiddleware',
     # 'directory_sso_api_client.middleware.AuthenticationMiddleware',
     'great_components.middleware.NoCacheMiddlware',
 ]
@@ -994,3 +996,11 @@ SPECTACULAR_SETTINGS = {
 
 # Wagtail Draftail Anchors
 DRAFTAIL_ANCHORS_RENDERER = env.str('DRAFTAIL_ANCHORS_RENDERER', 'wagtail_draftail_anchors.rich_text.render_span')
+
+# django-csp config
+CSP_DEFAULT_SRC = 'self'
+CSP_CHILD_SRC = 'self'
+CSP_OBJECT_SRC = 'none'
+CSP_FRAME_ANCESTORS = 'none'
+CSP_UPGRADE_INSECURE_REQUESTS = True
+CSP_BLOCK_ALL_MIXED_CONTENT = True

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -272,3 +272,10 @@ ga_schema = {
         'user_id',
     ],
 }
+
+
+class HHTPHeaderDisallowEmbeddingMiddleware(MiddlewareMixin):
+    def __call__(self, request):
+        response = super().__call__(request)
+        response['X-Permitted-Cross-Domain-Policies'] = 'none'
+        return response

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -136,3 +136,4 @@ search/views.py
 tests/unit/search/test_views.py
 tests/unit/domestic/views/test_views.py
 sso_profile/templates/personal_profile/personal-profile.html
+core/middleware.py

--- a/requirements.in
+++ b/requirements.in
@@ -78,3 +78,4 @@ drf-spectacular==0.26.2
 Babel==2.12.1
 pandas==1.5.3
 sqlalchemy==1.4.49
+django-csp

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,6 +123,7 @@ django==4.1.10
     #   directory-healthcheck
     #   directory-validators
     #   django-celery-beat
+    #   django-csp
     #   django-decorator-include
     #   django-extensions
     #   django-filter
@@ -146,6 +147,8 @@ django==4.1.10
     #   wagtailmedia
 django-celery-beat==2.5.0
     # via -r requirements.in
+django-csp==3.7
+    # via -r requirements.in
 django-decorator-include==3.0
     # via -r requirements.in
 django-environ==0.4.5
@@ -160,7 +163,7 @@ django-health-check==3.17.0
     # via directory-healthcheck
 django-ipware==2.1.0
     # via -r requirements.in
-django-modelcluster==6.0
+django-modelcluster==6.1
     # via wagtail
 django-permissionedforms==0.1
     # via wagtail
@@ -212,6 +215,8 @@ geoip2==2.9.0
     # via -r requirements.in
 great-components==2.4.0
     # via -r requirements.in
+greenlet==3.0.0
+    # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements.in
 hashids==0.8.4
@@ -303,7 +308,7 @@ pyhanko-certvalidator==0.24.1
     # via
     #   pyhanko
     #   xhtml2pdf
-pypdf==3.16.2
+pypdf==3.16.3
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode
@@ -421,7 +426,7 @@ typing-extensions==4.8.0
     #   wagtail-localize
 tzdata==2023.3
     # via django-celery-beat
-tzlocal==5.0.1
+tzlocal==5.1
     # via
     #   dateparser
     #   pyhanko

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -62,7 +62,7 @@ black==23.9.1
     #   blacken-docs
 blacken-docs==1.6.0
     # via -r requirements_test.in
-blinker==1.6.2
+blinker==1.6.3
     # via flask
 boto3==1.24.96
     # via
@@ -184,6 +184,7 @@ django==4.1.10
     #   directory-healthcheck
     #   directory-validators
     #   django-celery-beat
+    #   django-csp
     #   django-debug-toolbar
     #   django-decorator-include
     #   django-extensions
@@ -208,6 +209,8 @@ django==4.1.10
     #   wagtailmedia
 django-celery-beat==2.5.0
     # via -r requirements.in
+django-csp==3.7
+    # via -r requirements.in
 django-debug-toolbar==3.2.4
     # via -r requirements_test.in
 django-decorator-include==3.0
@@ -224,7 +227,7 @@ django-health-check==3.17.0
     # via directory-healthcheck
 django-ipware==2.1.0
     # via -r requirements.in
-django-modelcluster==6.0
+django-modelcluster==6.1
     # via wagtail
 django-permissionedforms==0.1
     # via wagtail
@@ -335,7 +338,9 @@ gitpython==3.1.37
 great-components==2.4.0
     # via -r requirements.in
 greenlet==3.0.0
-    # via gevent
+    # via
+    #   gevent
+    #   sqlalchemy
 gunicorn==20.1.0
     # via -r requirements.in
 h11==0.14.0
@@ -546,7 +551,7 @@ pylint-django==2.5.3
     # via -r requirements_test.in
 pylint-plugin-utils==0.8.2
     # via pylint-django
-pypdf==3.16.2
+pypdf==3.16.3
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode
@@ -658,7 +663,7 @@ requests-toolbelt==1.0.0
     # via browserstack-sdk
 roundrobin==0.0.4
     # via locust
-ruamel-yaml==0.17.33
+ruamel-yaml==0.17.35
     # via pre-commit-hooks
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
@@ -742,7 +747,7 @@ tomlkit==0.12.1
     # via pylint
 tqdm==4.66.1
     # via djlint
-traitlets==5.11.1
+traitlets==5.11.2
     # via
     #   ipython
     #   matplotlib-inline
@@ -766,7 +771,7 @@ typing-extensions==4.8.0
     #   wagtail-localize
 tzdata==2023.3
     # via django-celery-beat
-tzlocal==5.0.1
+tzlocal==5.1
     # via
     #   dateparser
     #   pyhanko
@@ -854,7 +859,7 @@ zipp==3.17.0
     # via importlib-metadata
 zope-event==5.0
     # via gevent
-zope-interface==6.0
+zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tests/unit/core/test_middleware.py
+++ b/tests/unit/core/test_middleware.py
@@ -330,3 +330,11 @@ def test_redirect_edge_cases(client):
     # Navigate to it
     response = client.get('/redirectme/')
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_http_headers_disallow_embedding(domestic_site, client):
+    response = client.get(domestic_site.root_page.url)
+
+    assert response.status_code == 200
+    assert 'X-Permitted-Cross-Domain-Policies' in response.headers


### PR DESCRIPTION
CONTEXT: This changeset brings missing application security headers into the global responses as per list:

- `Content-Security-Policy` via the [django-csp](https://github.com/mozilla/django-csp) library
- `X-Permitted-Cross-Domain-Policies` via a custom middleware class

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1237
- [x] Jira ticket has the correct status
- [x] A clear/description pull request messaged added

### Housekeeping

- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers
