### PR TITLE
Add middleware to limit data accessed on the domain and CSP

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -110,6 +110,7 @@ MIDDLEWARE = [
     'core.middleware.UserSpecificRedirectMiddleware',
     'core.middleware.StoreUserExpertiseMiddleware',
     'core.middleware.CheckGATags',
+    'core.middleware.HHTPHeaderDisallowEmbeddingMiddleware',
     # 'directory_sso_api_client.middleware.AuthenticationMiddleware',
     'great_components.middleware.NoCacheMiddlware',
     'csp.middleware.CSPMiddleware',

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -272,3 +272,10 @@ ga_schema = {
         'user_id',
     ],
 }
+
+
+class HHTPHeaderDisallowEmbeddingMiddleware(MiddlewareMixin):
+    def __call__(self, request):
+        response = super().__call__(request)
+        response['X-Permitted-Cross-Domain-Policies'] = 'none'
+        return response

--- a/tests/unit/core/test_middleware.py
+++ b/tests/unit/core/test_middleware.py
@@ -330,3 +330,11 @@ def test_redirect_edge_cases(client):
     # Navigate to it
     response = client.get('/redirectme/')
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_http_headers_disallow_embedding(domestic_site, client):
+    response = client.get(domestic_site.root_page.url)
+
+    assert response.status_code == 200
+    assert 'X-Permitted-Cross-Domain-Policies' in response.headers


### PR DESCRIPTION
CONTEXT: This changeset brings missing application security headers into the global responses:

- `X-Permitted-Cross-Domain-Policies` via a custom middleware class

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1237
- [x] Jira ticket has the correct status
- [x] A clear/description pull request messaged added

### Housekeeping

- [x] Added all new environment variables to Vault
- [x] Python requirements have been re-compiled

### Merging

- [x] This PR can be merged by reviewers

