### PR TITLE
Adding in hpo scoring rules for new sectors

### DIFF
--- a/international_online_offer/core/scorecard.py
+++ b/international_online_offer/core/scorecard.py
@@ -87,6 +87,25 @@ def is_hpo(sector, location):
                 regions.SOUTH_EAST,
             ]
         },
+        {
+            directory_constants_sectors.ENERGY: [
+                regions.NORTH_EAST,
+                regions.SCOTLAND,
+                regions.SOUTH_EAST,
+            ]
+        },
+        {
+            directory_constants_sectors.BIOTECHNOLOGY_AND_PHARMACEUTICALS: [
+                regions.NORTH_EAST,
+                regions.SCOTLAND,
+                regions.YORKSHIRE_AND_HUMBER,
+                regions.EAST_MIDLANDS,
+                regions.NORTH_WEST,
+                regions.EASTERN,
+                regions.WALES,
+                regions.NORTHERN_IRELAND,
+            ]
+        },
     ]
 
     for sector_location in hpo_sector_location:


### PR DESCRIPTION
Adding in hpo scoring rules for new sectors: we now support two new sectors in EYB. The mapping for the high potential opportunities has been completed and now if an investor is setting up in any of the new sectors (energy or biotech / pharma) and they are looking at specific locations they will be scored as high value due.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-763
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Housekeeping

N/A

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
