### PR TITLE
KLS-1603 fix campaign site redirects

### DIFF
--- a/domestic/views/campaign.py
+++ b/domestic/views/campaign.py
@@ -1,6 +1,7 @@
 from babel import Locale as BabelLocale
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.http import Http404
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.translation import get_language
@@ -167,9 +168,11 @@ class CampaignView(BaseNotifyUserFormView):
     def get_context_data(self, **kwargs):
         if not self.form_type:
             kwargs['form'] = None
+        if not self.current_page:
+            raise Http404
         return super().get_context_data(
             **kwargs,
-            page=self.current_page if self.current_page else None,
+            page=self.current_page,
             form_success=self.form_success,
             available_languages=self.available_languages,
             current_language=self.current_language,

--- a/tests/unit/domestic/views/test_views.py
+++ b/tests/unit/domestic/views/test_views.py
@@ -408,16 +408,12 @@ class CampaignViewTestCase(WagtailPageTests, TestCase):
     def test_no_page_slug(self):
         url = reverse_lazy('domestic:campaigns', kwargs={'page_slug': None})
         request = self.client.get(url)
-        view = domestic.views.campaign.CampaignView(request=request)
-        current_page = view.request.context_data['view'].current_page
-        self.assertEqual(current_page, None)
+        self.assertEqual(request.status_code, 404)
 
     def test_page_does_not_exist(self):
         url = reverse_lazy('domestic:campaigns', kwargs={'page_slug': 'page_that_does_not_exist'})
         request = self.client.get(url)
-        view = domestic.views.campaign.CampaignView(request=request)
-        current_page = view.request.context_data['view'].current_page
-        self.assertEqual(current_page, None)
+        self.assertEqual(request.status_code, 404)
 
     def test_get_current_page(self):
         self.listing_page = ArticleListingPageFactory(slug='test-listing', title='test', landing_page_title='test')


### PR DESCRIPTION
This change addresses the the bug in Campaign pages that prevents redirects from working correctly.

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1603
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
