### PR TITLE
KLS-1654 BugFix on Learn to Export Page objectives

### DIFF
--- a/core/templates/core/objectives.html
+++ b/core/templates/core/objectives.html
@@ -1,16 +1,16 @@
 {% load  wagtailcore_tags %}
 {% load add_govuk_classes from content_tags %}
 <div class="objectives">
-    <h2 class="govuk-heading-l">What you’ll learn</h2>
     {% filter add_govuk_classes %}
+        <h2>What you’ll learn</h2>
         {% for block in page.objective %}
-            {{ block.value|richtext }}
+            {% if block.block_type == 'paragraph' %}{{ block.value | richtext }}{% endif %}
         {% endfor %}
+        <ul>
+            {% for block in page.objective %}
+                {% if block.block_type == 'ListItem' %}<li>{{ block.value.item }}</li>{% endif %}
+            {% endfor %}
+        </ul>
     {% endfilter %}
-    <ul class="govuk-list govuk-list--bullet">
-        {% for block in page.objective %}
-            {% if block.block_type == 'ListItem' %}<li>{{ block.value.item }}</li>{% endif %}
-        {% endfor %}
-    </ul>
     <hr class="hr hr--dark govuk-!-margin-bottom-6 govuk-!-margin-top-6" />
 </div>


### PR DESCRIPTION
This PR fixes issue whereby objectives (of type Wagtail StructBlock) were being sent directly to a richtext filter resulting in some LearnToExport pages not loading.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/jira/software/projects/KLS/boards/359?selectedIssue=KLS-1654
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
1. Visit a 'Learn to export' page that has objectives
2. The page does not load with the error message `TypeError: 'richtext' template filter received an invalid value; expected string, got <class 'wagtail.blocks.struct_block.StructValue'>`
3. After PR page displays correctly

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
