### PR TITLE
redirect campaign site uk-advanced-manufacturing-plan

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -36,6 +36,8 @@ available_sitemaps = {
     'static': views.StaticViewSitemap,
 }
 
+AMP_URL = f'{settings.BASE_URL}/AMP/'
+
 
 urlpatterns = [
     # WHEN ADDING TO THIS LIST CONSIDER WHETHER YOU SHOULD ALSO ADD THE URL NAME
@@ -158,6 +160,14 @@ urlpatterns = [
         r'^microsites/*(?P<page_slug>[-a-zA-Z0-9_]+)/$',
         skip_ga360(MicrositeView.as_view()),
         name='microsites',
+    ),
+    re_path(
+        r'^campaign-site/uk-advanced-manufacturing-plan/',
+        skip_ga360(
+            views.PermanentQuerystringRedirectView.as_view(
+                url=AMP_URL,
+            )
+        ),
     ),
     re_path(
         r'^campaign-site/.*/(?P<page_slug>[-a-zA-Z0-9_]+)/$',

--- a/core/urls.py
+++ b/core/urls.py
@@ -37,6 +37,7 @@ available_sitemaps = {
 }
 
 AMP_URL = f'{settings.BASE_URL}/AMP/'
+INDIA_URL = f'{settings.BASE_URL}/india/'
 
 
 urlpatterns = [
@@ -166,6 +167,14 @@ urlpatterns = [
         skip_ga360(
             views.PermanentQuerystringRedirectView.as_view(
                 url=AMP_URL,
+            )
+        ),
+    ),
+    re_path(
+        r'^campaign-site/india/',
+        skip_ga360(
+            views.PermanentQuerystringRedirectView.as_view(
+                url=INDIA_URL,
             )
         ),
     ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,8 @@ certifi==2023.11.17
     #   sentry-sdk
 cffi==1.16.0
     # via cryptography
+chardet==5.2.0
+    # via reportlab
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
@@ -94,7 +96,7 @@ directory-api-client==26.4.2
     # via -r requirements.in
 directory-ch-client==3.1.0
     # via -r requirements.in
-directory-client-core==7.2.5
+directory-client-core==7.2.6
     # via
     #   directory-api-client
     #   directory-ch-client
@@ -158,7 +160,7 @@ django-environ==0.4.5
     # via -r requirements.in
 django-extensions==3.2.3
     # via -r requirements.in
-django-filter==23.4
+django-filter==23.5
     # via wagtail
 django-formtools==2.3
     # via -r requirements.in
@@ -322,7 +324,7 @@ pyhanko-certvalidator==0.26.2
     # via
     #   pyhanko
     #   xhtml2pdf
-pypdf==3.17.1
+pypdf==3.17.2
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode
@@ -369,7 +371,7 @@ redis==5.0.1
     #   django-redis
 regex==2023.10.3
     # via dateparser
-reportlab[pycairo]==4.0.7
+reportlab[pycairo]==4.0.8
     # via
     #   reportlab
     #   svglib
@@ -434,7 +436,7 @@ tinycss2==1.2.1
     # via
     #   cssselect2
     #   svglib
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   asgiref
     #   kombu

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -93,6 +93,8 @@ cffi==1.16.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
+chardet==5.2.0
+    # via reportlab
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
@@ -150,7 +152,7 @@ directory-api-client==26.4.2
     # via -r requirements.in
 directory-ch-client==3.1.0
     # via -r requirements.in
-directory-client-core==7.2.5
+directory-client-core==7.2.6
     # via
     #   directory-api-client
     #   directory-ch-client
@@ -219,7 +221,7 @@ django-environ==0.4.5
     # via -r requirements.in
 django-extensions==3.2.3
     # via -r requirements.in
-django-filter==23.4
+django-filter==23.5
     # via wagtail
 django-formtools==2.3
     # via -r requirements.in
@@ -345,7 +347,7 @@ gitpython==3.1.40
     # via -r requirements_test.in
 great-components==2.5.0
     # via -r requirements.in
-greenlet==3.0.1
+greenlet==3.0.2
     # via gevent
 gunicorn==20.1.0
     # via -r requirements.in
@@ -363,7 +365,7 @@ html5lib==1.1
     #   xhtml2pdf
 icalendar==5.0.11
     # via -r requirements.in
-identify==2.5.32
+identify==2.5.33
     # via pre-commit
 idna==3.6
     # via
@@ -499,7 +501,7 @@ pillow-heif==0.14.0
     # via willow
 pip-tools==7.3.0
     # via -r requirements_test.in
-platformdirs==4.0.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
@@ -510,7 +512,7 @@ pluggy==1.3.0
     #   pytest
 polib==1.2.0
     # via wagtail-localize
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements_test.in
 pre-commit-hooks==3.3.0
     # via -r requirements_test.in
@@ -558,7 +560,7 @@ pylint-django==2.5.5
     # via -r requirements_test.in
 pylint-plugin-utils==0.8.2
     # via pylint-django
-pypdf==3.17.1
+pypdf==3.17.2
     # via xhtml2pdf
 pypng==0.20220715.0
     # via qrcode
@@ -626,7 +628,7 @@ pyyaml==6.0.1
     #   drf-spectacular
     #   pre-commit
     #   pyhanko
-pyzmq==25.1.1
+pyzmq==25.1.2
     # via locust
 qrcode==7.4.2
     # via pyhanko
@@ -640,7 +642,7 @@ regex==2023.10.3
     # via
     #   dateparser
     #   djlint
-reportlab[pycairo]==4.0.7
+reportlab[pycairo]==4.0.8
     # via
     #   reportlab
     #   svglib
@@ -679,7 +681,7 @@ ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 s3transfer==0.6.2
     # via boto3
-selenium==4.15.2
+selenium==4.16.0
     # via -r requirements_test.in
 sentry-sdk==1.14.0
     # via -r requirements.in
@@ -767,7 +769,7 @@ trio==0.23.1
     #   trio-websocket
 trio-websocket==0.11.1
     # via selenium
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   asgiref
     #   astroid


### PR DESCRIPTION
Redirect for Campaign site www.great.gov.uk/campaign-site/uk-advanced-manufacturing-plan to

www.great.gov.uk/AMP

Redirect for Campaign site www.great.gov.uk/campaign-site/india to

www.great.gov.uk/india

Nb: Does not work if added to urls_redirect.py

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1679
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Python requirements have been re-compiled.
- [x] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
