### PR TITLE
Add class to signed out users

### DIFF
--- a/core/templatetags/content_tags.py
+++ b/core/templatetags/content_tags.py
@@ -449,7 +449,9 @@ def render_automated_list_page_card_content(page, request, module_completion_dat
     else:
         html_content = format_html(
             f"""
+            <div class="learn-card-description">
             { page.heading}
+            </div>
         """
         )
     return html_content


### PR DESCRIPTION
A fix to add the. missed out class to signed out version of the LTE landing page descriptions on card.