### PR TITLE
Update event filter to grab the next event

### DIFF
--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -865,9 +865,12 @@ class EventVideoOnDemandView(DetailView):
         raise Http404
 
     def _get_event_and_video(self):
+        # event is set to the next live occurence of the current event
         event = models.Event.objects.filter(
-            slug__contains=self.event_slug, past_event_recorded_date__date=self.recorded_datetime
-        ).first()
+            slug__contains=self.event_slug,
+            past_event_recorded_date__date=self.recorded_datetime,
+            start_date__gte=datetime.now(),
+        ).last()
         video = getattr(event, 'past_event_video_recording', None)
         return event, video
 


### PR DESCRIPTION
Fixes issue where the next live event section of the past recording page displays the furthest away event rather than the next event.

To test make sure you have multiple events, each with a past recording that falls on the same date. When the past recording is opened the next event should be linked, not the last.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1772
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
