### PR TITLE
Removing session usage for EYB triage and user data

### DIFF
--- a/international_online_offer/templates/eyb/triage/location.html
+++ b/international_online_offer/templates/eyb/triage/location.html
@@ -27,10 +27,10 @@
                     </div>
                     <div id="region-city-information-container"
                          class="govuk-grid-row"
-                         style="{% if not city %} display: none {% endif %}">
+                         style="{% if not city_description %} display: none {% endif %}">
                         <div class="govuk-grid-column-two-thirds">
                             <div class="govuk-inset-text">
-                                <span id="city-text">{{ city }}</span> is in <span id="region-text" class="govuk-!-font-weight-bold">{{ region }}</span>, we will tailor your guide to this region.
+                                <span id="city-text">{{ city_description }}</span> is in <span id="region-text" class="govuk-!-font-weight-bold">{{ region_description }}</span>, we will tailor your guide to this region.
                             </div>
                         </div>
                     </div>

--- a/international_online_offer/templates/eyb/triage/sector.html
+++ b/international_online_offer/templates/eyb/triage/sector.html
@@ -27,10 +27,10 @@
                     </div>
                     <div id="sic-sector-information-container"
                          class="govuk-grid-row"
-                         style="{% if not sector or not sector_sub %} display: none {% endif %}">
+                         style="{% if not sector_description or not sector_sub_description %} display: none {% endif %}">
                         <div class="govuk-grid-column-two-thirds">
                             <div class="govuk-inset-text">
-                                <span id="sic-text">{{ sector_sub }}</span> is in our <span id="sector-text" class="govuk-!-font-weight-bold">{{ sector }}</span> sector, we will tailor your guide to this sector.
+                                <span id="sic-text">{{ sector_sub_description }}</span> is in our <span id="sector-text" class="govuk-!-font-weight-bold">{{ sector_description }}</span> sector, we will tailor your guide to this sector.
                             </div>
                         </div>
                     </div>

--- a/international_online_offer/views.py
+++ b/international_online_offer/views.py
@@ -72,10 +72,12 @@ class SectorView(GA360Mixin, FormView):
         return next_url
 
     def get_context_data(self, **kwargs):
+        sector_description = None
+        sector_sub_description = None
         triage_data = get_triage_data_for_user(self.request)
         if triage_data:
-            sector = triage_data.get_sector_display()
-            sector_sub = triage_data.get_sector_sub_display()
+            sector_description = triage_data.get_sector_display()
+            sector_sub_description = triage_data.get_sector_sub_display()
 
         return super().get_context_data(
             **kwargs,
@@ -85,8 +87,8 @@ class SectorView(GA360Mixin, FormView):
             why_we_ask_this_question_text="""We'll use this information to provide customised content
               relevant to your sector and products or services.""",
             autocomplete_sector_data=region_sector_helpers.get_sectors_and_sic_sectors_file_as_string(),
-            sector_sub=sector_sub,
-            sector=sector,
+            sector_description=sector_description,
+            sector_sub_description=sector_sub_description,
         )
 
     def get_initial(self):
@@ -187,9 +189,11 @@ class LocationView(GA360Mixin, FormView):
 
     def get_context_data(self, **kwargs):
         triage_data = get_triage_data_for_user(self.request)
+        region_description = None
+        city_description = None
         if triage_data:
-            region = triage_data.get_location_display()
-            city = triage_data.get_location_city_display()
+            region_description = triage_data.get_location_display()
+            city_description = triage_data.get_location_city_display()
 
         return super().get_context_data(
             **kwargs,
@@ -199,8 +203,8 @@ class LocationView(GA360Mixin, FormView):
             why_we_ask_this_question_text="""We'll use this information to provide customised content
               relevant to your city, county or region.""",
             autocomplete_location_data=region_sector_helpers.get_region_and_cities_json_file_as_string(),
-            region=region,
-            city=city,
+            region_description=region_description,
+            city_description=city_description,
         )
 
     def get_initial(self):

--- a/tests/unit/international_online_offer/test_views.py
+++ b/tests/unit/international_online_offer/test_views.py
@@ -158,8 +158,8 @@ def test_sector(client, user, settings):
     client.force_login(user)
     response = client.get(reverse('international_online_offer:sector'))
     context = response.context_data
-    assert context['sector'] is None
-    assert context['sector_sub'] is None
+    assert context['sector_description'] is None
+    assert context['sector_sub_description'] is None
     assert response.status_code == 200
 
 
@@ -191,7 +191,7 @@ def test_sector_form_valid_saves_to_db(client, user, settings):
     url = reverse('international_online_offer:sector')
     user.hashed_uuid = '123'
     client.force_login(user)
-    response = client.post(url, {'sector_sub': 'RESIDENTS_PROPERTY_MANAGEMENT'})
+    response = client.post(url, {'sector_sub_description': 'RESIDENTS_PROPERTY_MANAGEMENT'})
     assert response.status_code == 302
 
 
@@ -201,32 +201,11 @@ def test_sector_saved_to_db_gets_labels(client, user, settings):
     url = reverse('international_online_offer:sector')
     user.hashed_uuid = '123'
     client.force_login(user)
-    response = client.post(url, {'sector_sub': 'RESIDENTS_PROPERTY_MANAGEMENT'})
+    response = client.post(url, {'sector_sub_description': 'RESIDENTS_PROPERTY_MANAGEMENT'})
     response = client.get(reverse('international_online_offer:sector'))
     context = response.context_data
-    assert context['sector'] == 'Financial and professional services'
-    assert context['sector_sub'] == 'Residents property management'
-    assert response.status_code == 200
-
-
-@pytest.mark.django_db
-def test_sector_form_valid_saves_to_session(client, settings):
-    settings.FEATURE_INTERNATIONAL_ONLINE_OFFER = True
-    url = reverse('international_online_offer:sector')
-    response = client.post(url, {'sector_sub': 'RESIDENTS_PROPERTY_MANAGEMENT'})
-    assert response.status_code == 302
-
-
-@pytest.mark.django_db
-def test_sector_saved_to_session_gets_labels(client, user, settings):
-    settings.FEATURE_INTERNATIONAL_ONLINE_OFFER = True
-    client.force_login(user)
-    url = reverse('international_online_offer:sector')
-    response = client.post(url, {'sector_sub': 'RESIDENTS_PROPERTY_MANAGEMENT'})
-    response = client.get(reverse('international_online_offer:sector'))
-    context = response.context_data
-    assert context['sector'] == 'Financial and professional services'
-    assert context['sector_sub'] == 'Residents property management'
+    assert context['sector_description'] == 'Financial and professional services'
+    assert context['sector_sub_description'] == 'Residents property management'
     assert response.status_code == 200
 
 
@@ -278,8 +257,8 @@ def test_location(client, user, settings):
     url = reverse('international_online_offer:location')
     response = client.get(url)
     context = response.context_data
-    assert context['region'] is None
-    assert context['city'] is None
+    assert context['region_description'] is None
+    assert context['city_description'] is None
     assert response.status_code == 200
 
 
@@ -324,8 +303,8 @@ def test_location_saved_to_db_gets_labels(client, user, settings):
     response = client.post(url, {'location': 'SWANSEA'})
     response = client.get(url)
     context = response.context_data
-    assert context['region'] == 'Wales'
-    assert context['city'] == 'Swansea'
+    assert context['region_description'] == 'Wales'
+    assert context['city_description'] == 'Swansea'
     assert response.status_code == 200
 
 
@@ -407,14 +386,6 @@ def test_spend_form_valid_saves_to_db(client, user, settings):
     url = reverse('international_online_offer:spend')
     user.hashed_uuid = '123'
     client.force_login(user)
-    response = client.post(url, {'spend': spends.TEN_THOUSAND_TO_FIVE_HUNDRED_THOUSAND})
-    assert response.status_code == 302
-
-
-@pytest.mark.django_db
-def test_spend_form_valid_saves_to_session(client, settings):
-    settings.FEATURE_INTERNATIONAL_ONLINE_OFFER = True
-    url = reverse('international_online_offer:spend')
     response = client.post(url, {'spend': spends.TEN_THOUSAND_TO_FIVE_HUNDRED_THOUSAND})
     assert response.status_code == 302
 


### PR DESCRIPTION
Removing session usage for EYB triage and user data as is no longer needed. User must be logged in to use the triage and profile page and so we can use the DB completely. 

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-1005
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data

### Housekeeping

N/A

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
