### PR TITLE
EYB import trade associations management command update to cater for non sequential Ids 

### DIFF
--- a/core/management/commands/eyb_import_trade_associations.py
+++ b/core/management/commands/eyb_import_trade_associations.py
@@ -16,14 +16,14 @@ class Command(BaseCommand):
             bucket_name=settings.AWS_STORAGE_BUCKET_NAME_DATA_SCIENCE,
         )
         data = tablib.import_set(file, format='csv', headers=True)
+        TradeAssociation.objects.all().delete()
         for item in data:
-            if not TradeAssociation.objects.filter(trade_association_id=item[0]).exists():
-                TradeAssociation.objects.create(
-                    trade_association_id=item[0],
-                    sector_grouping=item[1],
-                    association_name=item[2],
-                    website_link=item[3],
-                    sector=item[4],
-                    brief_description=item[5],
-                )
+            TradeAssociation.objects.create(
+                trade_association_id=item[0],
+                sector_grouping=item[1],
+                association_name=item[2],
+                website_link=item[3],
+                sector=item[4],
+                brief_description=item[5],
+            )
         self.stdout.write(self.style.SUCCESS('All done with trade associations, bye!'))

--- a/tests/unit/core/management/commands/test_import_eyb_data.py
+++ b/tests/unit/core/management/commands/test_import_eyb_data.py
@@ -10,8 +10,44 @@ from django.core.management import call_command
 @pytest.mark.django_db
 def test_import_eyb_data(mgm_cmd):
     with patch('core.helpers.get_s3_file_stream') as mock_work_function:
-        call_command(mgm_cmd, stdout=StringIO())
-        assert mock_work_function.called
+        with patch('tablib.import_set') as mock_import_set:
+            mock_import_set.return_value = tablib.Dataset(
+                [
+                    'TRADE_ASSOCIATION_0001',
+                    'Manufacturing, Energy and Infrastructure 1',
+                    'UK H2 Mobility 1',
+                    'http://www.ukh2mobility.co.uk/',
+                    'Energy',
+                    'Some test description here',
+                ],
+                [
+                    'TRADE_ASSOCIATION_0002',
+                    'Manufacturing, Food and Infrastructure 2',
+                    'UK H2 Mobility 2',
+                    'http://www.ukh2mobility.co.uk/',
+                    'Food and Drink',
+                    'Some test description here',
+                ],
+                [
+                    'TRADE_ASSOCIATION_0003',
+                    'Manufacturing, Technology and Infrastructure 3',
+                    'UK H2 Mobility 3',
+                    'http://www.ukh2mobility.co.uk/',
+                    'Technology',
+                    'Some test description here',
+                ],
+                headers=[
+                    'trade_assocation_id',
+                    'sector_grouping',
+                    'association_name',
+                    'website_link',
+                    'sector',
+                    'brief_description',
+                ],
+            )
+            mock_work_function.return_value = None
+            call_command(mgm_cmd, stdout=StringIO())
+            assert mock_work_function.called
 
 
 @pytest.mark.parametrize('mgm_cmd', [('eyb_import_salary_data')])


### PR DESCRIPTION
Noticed that the Ids we get in the export for data workspace arent honoured. It would seem that a delete and reimport is done their side and so we cannot check exists on this id. Changing script to delete and re-import all records. No other records are bound to these Ids so is safe. 

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-1030
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Housekeeping

N/A

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
