### PR TITLE
Kls 1789: ukea event title links

### DIFF
--- a/core/templatetags/content_tags.py
+++ b/core/templatetags/content_tags.py
@@ -534,3 +534,11 @@ def get_inline_feedback_visibility(page_url):
         result['show_page_useful'] = True
 
     return result
+
+
+@register.filter
+def h3_if(condition, else_heading):
+    if condition:
+        return 'h3'
+    else:
+        return else_heading

--- a/export_academy/templates/export_academy/event_list.html
+++ b/export_academy/templates/export_academy/event_list.html
@@ -5,6 +5,7 @@
 {% load breadcrumbs from component_tags %}
 {% load pagination from component_tags %}
 {% load append_past_year_seperator from component_tags %}
+{% load h3_if from content_tags %}
 {% block head_title %}Events – UK Export Academy{% endblock %}
 {% block content %}
     <div id="breadcrumbs" class="great-display-from-tablet">
@@ -82,8 +83,13 @@
                                 <h2 class="past-year-seperator govuk-!-padding-left-3 govuk-!-padding-bottom-30">{{ event.past_year_seperator }}</h2>
                             {% endif %}
                             <div class="govuk-!-padding-left-3 govuk-!-margin-bottom-2 govuk-!-padding-right-3">
+                                <{{ event.past_year_seperator|h3_if:'h2' }} class="govuk-heading-s govuk-!-margin-bottom-0">
                                 <a href="{{ event.get_absolute_url }}"
-                                   class="govuk-link govuk-heading-s great-title-link">{{ event.name }}<span class="great-visually-hidden">– {{ event.start_date|date:"d F" }} at {{ event.start_date|time:"gA" }}</span></a>
+                                   class="govuk-link govuk-heading-s great-title-link">
+                                    {{ event.name }}
+                                    <span class="great-visually-hidden">– {{ event.start_date|date:"d F" }} at {{ event.start_date|time:"gA" }}</span>
+                                </a>
+                                </{{ event.past_year_seperator|h3_if:'h2' }}>
                             </div>
                             <div class="govuk-!-padding-left-3 govuk-!-padding-right-3 great-display-until-tablet">
                                 {% include 'export_academy/includes/event_duration.html' %}

--- a/tests/unit/core/test_templatetags.py
+++ b/tests/unit/core/test_templatetags.py
@@ -26,6 +26,7 @@ from core.templatetags.content_tags import (
     get_text_blocks,
     get_topic_blocks,
     get_topic_title_for_lesson,
+    h3_if,
     handle_external_links,
     highlighted_text,
     is_email,
@@ -1006,3 +1007,15 @@ def test_show_feedback(input_url, expected_output):
 )
 def test_get_inline_feedback_visibility(input_url, expected_output):
     assert get_inline_feedback_visibility(input_url) == expected_output
+
+
+@pytest.mark.parametrize(
+    'condition, else_heading, expected_output',
+    (
+        (True, 'h2', 'h3'),
+        (False, 'h2', 'h2'),
+    ),
+)
+def test_h3_if(condition, else_heading, expected_output):
+    result = h3_if(condition, else_heading)
+    assert result == expected_output


### PR DESCRIPTION
Make event title links h2 or h3 depending on page context

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
