### PR TITLE
update browsertools orb and use latest chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.2
+  browser-tools: circleci/browser-tools@1.4.8
   node: circleci/node@5.0.2
 
 ###############################################################################
@@ -110,8 +110,7 @@ jobs:
       - restore_cache:
           key: v1-deps-{{ checksum "requirements_test.txt" }}
       - run: sudo apt-get update
-      - browser-tools/install-chrome:
-          chrome-version: "116.0.5845.110"
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:
           name: Install Allure CLI


### PR DESCRIPTION
Previous circle-ci tests failing occasionally on the install chrome drive phase - [example](https://app.circleci.com/pipelines/github/uktrade/great-cms/14884/workflows/9e372e8b-5026-4323-890f-9eb8a68a66ae/jobs/85639/parallel-runs/0/steps/0-106). 

This PR updates the circle ci browser-tools orb and also uses the latest version of chrome as opposed to a pinned version.