### PR TITLE
Return 404 if course page slug not found

### DIFF
--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -10,7 +10,7 @@ from directory_forms_api_client import actions
 from django.contrib.auth.models import AnonymousUser
 from django.db import transaction
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
-from django.shortcuts import redirect
+from django.shortcuts import get_list_or_404, redirect
 from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.utils.text import get_valid_filename
@@ -741,7 +741,7 @@ class EACourseView(TemplateView):
     template_name = 'export_academy/course_page.html'
 
     def get_context_data(self, **kwargs):
-        self.page = models.CoursePage.objects.live().filter(slug=kwargs['slug']).first()
+        self.page = get_list_or_404(models.CoursePage, live=True, slug=kwargs['slug'])[0]
         ctx = super().get_context_data(**kwargs)
         ctx['signed_in'] = True if self.request.user != AnonymousUser() else False
         ctx['page'] = self.page

--- a/tests/unit/export_academy/test_views.py
+++ b/tests/unit/export_academy/test_views.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 from urllib import parse
 
+import factory.fuzzy
 import pytest
 from directory_forms_api_client import actions
 from django.contrib.auth import get_user_model
@@ -1313,6 +1314,13 @@ def test_course_page(client, root_page):
     response = client.get(url)
     assert response.status_code == 200
     assert latest_event.name in response.rendered_content
+
+
+@pytest.mark.django_db
+def test_course_page_returns_404_for_slug_not_found(client):
+    url = reverse('export_academy:course', kwargs=dict(slug=factory.fuzzy.FuzzyText(length=50).fuzz()))
+    response = client.get(url)
+    assert response.status_code == 404
 
 
 class EventVideoOnDemandViewTest(TestCase):


### PR DESCRIPTION
PR to serve a user with a 404 error when they try to visit /export-academy/{slug} with an invalid page slug as a URL path parameter.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/jira/software/projects/KLS/boards/359?selectedIssue=KLS-1984
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
1. Visit /export-academy/{page-slug} where {page-slug} is a valid slug of type CoursePage. The course page is displayed.
2. Visit /export-academy/{invalid-page-slug} where {invalid-page-slug} is not a CoursePage. A 404 error is presented.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
