### PR TITLE
KLS-1791 - update markup used for UKEA registration flow

### DIFF
--- a/core/templates/components/great/radios.html
+++ b/core/templates/components/great/radios.html
@@ -1,7 +1,7 @@
-{% for group, options, index in widget.optgroups %}
-    <div class="govuk-radios great-radios" data-module="govuk-radios">
+<div class="govuk-radios great-radios" data-module="govuk-radios">
+    {% for group, options, index in widget.optgroups %}
         {% for option in options %}
             <div class="govuk-radios__item govuk-!-margin-bottom-3">{% include option.template_name with widget=option %}</div>
         {% endfor %}
-    </div>
-{% endfor %}
+    {% endfor %}
+</div>

--- a/export_academy/forms.py
+++ b/export_academy/forms.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from great_components import forms
 from wagtail.admin.forms import WagtailAdminModelForm
 
-from contact import constants
+from contact import constants, widgets as contact_widgets
 from core.validators import is_valid_uk_phone_number, is_valid_uk_postcode
 from directory_constants.choices import COUNTRY_CHOICES
 
@@ -86,6 +86,7 @@ class PersonalDetails(forms.Form):
 
 
 class ExportExperience(forms.Form):
+
     export_experience = forms.ChoiceField(
         label=_('What is your export experience?'),
         choices=(
@@ -100,7 +101,7 @@ class ExportExperience(forms.Form):
             ('I have exported in the last 12 months', 'I have exported in the last 12 months'),
             ('I do not have a product for export', 'I do not have a product for export'),
         ),
-        widget=forms.RadioSelect(attrs={'id': 'hiring-select'}),
+        widget=contact_widgets.GreatRadioSelect,
         error_messages={'required': _('Choose one option about your export experience')},
     )
 
@@ -136,7 +137,7 @@ class ExportExperience(forms.Form):
             ('Both', 'Both'),
             ("I don't know", "I don't know"),
         ),
-        widget=forms.RadioSelect,
+        widget=contact_widgets.GreatRadioSelect,
         error_messages={'required': _('Choose one option about what you export')},
     )
 
@@ -181,7 +182,7 @@ class BusinessDetails(forms.Form):
             ("I don't know", "I don't know"),
             ("I'd prefer not to say", "I'd prefer not to say"),
         ),
-        widget=forms.RadioSelect,
+        widget=contact_widgets.GreatRadioSelect,
         error_messages={'required': _('Enter a turnover amount')},
     )
 
@@ -194,7 +195,7 @@ class BusinessDetails(forms.Form):
             ('not sure', "I don't know"),
             ('prefer not to say', "I'd prefer not to say"),
         ),
-        widget=forms.RadioSelect,
+        widget=contact_widgets.GreatRadioSelect,
         error_messages={'required': _('Choose number of employees')},
     )
 

--- a/export_academy/templates/export_academy/registration_form_step2.html
+++ b/export_academy/templates/export_academy/registration_form_step2.html
@@ -52,13 +52,15 @@
             </div>
             <div class="govuk-form-group govuk-!-margin-bottom-7 {% if field.errors %}govuk-form-group--error{% endif %} govuk-!-margin-bottom-2">
                 <fieldset class="govuk-fieldset">
-                    {% include 'domestic/contact/includes/govuk-form-field.html' with field=field %}
+                    <legend class="govuk-fieldset__legend govuk-label great-font-bold">{{ field.label }}</legend>
+                    {% include 'domestic/contact/includes/govuk-form-field.html' with field=field hide_label=True %}
                 </fieldset>
             </div>
         {% else %}
             <div class="govuk-form-group govuk-!-margin-bottom-7 {% if field.errors %}govuk-form-group--error{% endif %} govuk-!-margin-bottom-2">
                 <fieldset class="govuk-fieldset">
-                    {% include 'domestic/contact/includes/govuk-form-field.html' with field=field %}
+                    <legend class="govuk-fieldset__legend govuk-label great-font-bold">{{ field.label }}</legend>
+                    {% include 'domestic/contact/includes/govuk-form-field.html' with field=field hide_label=True %}
                 </fieldset>
             </div>
         {% endif %}

--- a/export_academy/templates/export_academy/registration_form_step3.html
+++ b/export_academy/templates/export_academy/registration_form_step3.html
@@ -8,7 +8,8 @@
         {% if field.name == 'annual_turnover' or field.name == 'employee_count' %}
             <div class="govuk-form-group govuk-!-margin-bottom-7 {% if field.errors %}govuk-form-group--error{% endif %} govuk-!-margin-bottom-2">
                 <fieldset class="govuk-fieldset">
-                    {% include 'domestic/contact/includes/govuk-form-field.html' with field=field %}
+                    <legend class="govuk-fieldset__legend govuk-label great-font-bold">{{ field.label }}</legend>
+                    {% include 'domestic/contact/includes/govuk-form-field.html' with field=field hide_label=True %}
                 </fieldset>
             </div>
         {% else %}


### PR DESCRIPTION
The UKEA registration flow followed an implementation pattern from great-components for radio inputs which resulted in use of unordered lists / list items to represent options. This PR updates the inputs to use the design pattern suggested in the gov.uk design-system [ref](https://design-system.service.gov.uk/components/radios/) and align with the approach taken in contact Export Support.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/jira/software/projects/KLS/boards/359?selectedIssue=KLS-1791 
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after
<img width="422" alt="Screenshot 2024-02-27 at 11 25 52" src="https://github.com/uktrade/great-cms/assets/1638245/a816a720-fe56-4953-a3a3-3a3015dc1aa6">

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
