### PR TITLE
Added a condition to EventVideoView to check user auth and redirect t…

### DIFF
--- a/tests/unit/export_academy/test_views.py
+++ b/tests/unit/export_academy/test_views.py
@@ -498,6 +498,15 @@ def test_export_academy_booking_cancellation_success(mock_notify_cancellation, c
 
 
 @pytest.mark.django_db
+def test_event_video_view_redirect_for_unauthenticated_user(client, user):
+    event = factories.EventFactory(name='Test event name', description='Test description')
+    url = reverse('export_academy:event-video', kwargs=dict(pk=event.id))
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.url == event.get_absolute_url()
+
+
+@pytest.mark.django_db
 def test_event_video_view_with_video(client, user):
     event = factories.EventFactory(name='Test event name', description='Test description')
     url = reverse('export_academy:event-video', kwargs=dict(pk=event.id))


### PR DESCRIPTION
This PR is to apply a redirect to the event video page in EA. Currently, unauthenticated users are met with an error page when the expected behaviour is be be redirected to the event page so they can sign in.

This [link](url)](https://www.great.gov.uk/export-academy/event/01f03edc-81da-4f3c-a932-62b7dc6e67c8/) will display the event video is you are signed in.

The error has been fixed by adding a new if condition to only call the update_booking helper function is the user is authenticated else redirect to the event url (event.get_absolute_url())

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-62
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
