### PR TITLE
GREAT-381-UKEA promotion box encroaching on inline feedback component

### DIFF
--- a/learn/templates/learn/detail_page.html
+++ b/learn/templates/learn/detail_page.html
@@ -70,7 +70,7 @@
         </div>
     </div>
 </div>
-<div class="govuk-grid-column-full govuk-!-padding-0">
+<div class="govuk-!-padding-0">
     {% include 'learn/promo.html' with bg_class='great-bg-light-blue' %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Great.gov Promo/Inline feedback form layout issue fixed - govuk-grid-column-full class removed from outer promo div in learn/detail_page.html, float:left was the source of layout issue

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/381
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
<img width="1489" alt="great381- after" src="https://github.com/uktrade/great-cms/assets/134952460/f00bdfd7-c257-48e7-b5fc-b2b1f966fe06">
<img width="1481" alt="great381-before" src="https://github.com/uktrade/great-cms/assets/134952460/25c48ff4-5bde-4f25-98f9-c4092a8977d8">

