### PR TITLE
Fix footer links for privacy and cookies in base footer templates for international homepage and campaigns

### DIFF
--- a/core/templates/components/header_footer/footer_base.html
+++ b/core/templates/components/header_footer/footer_base.html
@@ -34,7 +34,7 @@
                    title="Department for Business and Trade on GOV.UK">Department for Business and Trade on GOV.UK</a>
             </li>
             <li>
-                <a href="{% slugurl 'privacy' %}" title="Privacy and cookies">Privacy</a>
+                <a href="{% slugurl 'privacy' %}" title="Privacy">Privacy</a>
             </li>
             <li>
                 <a href="/cookies" title="Cookies">Cookies</a>

--- a/core/templates/core/footer.html
+++ b/core/templates/core/footer.html
@@ -26,7 +26,7 @@
                    title="Department for Business and Trade on GOV.UK">Department for Business and Trade on GOV.UK</a>
             </li>
             <li>
-                <a href="{% slugurl 'privacy' %}" title="Privacy and cookies">Privacy and cookies</a>
+                <a href="{% slugurl 'privacy' %}" title="Privacy">Privacy</a>
             </li>
             <li>
                 <a href="/cookies" title="Cookies">Cookies</a>

--- a/international/templates/international/footer.html
+++ b/international/templates/international/footer.html
@@ -11,7 +11,15 @@
                            target="_blank"
                            rel="noopener noreferrer"
                            title="Opens in a new window"
-                           href="{{ header_footer_urls.privacy_and_cookies }}">Privacy and cookies</a>
+                           href="{{ header_footer_urls.privacy_and_cookies }}">Privacy</a>
+                    </li>
+                    <li class="govuk-footer__inline-list-item">
+                        <a class="govuk-link govuk-link--inverse"
+                           id="footer-cookies"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           title="Opens in a new window"
+                           href="/cookies/">Cookies</a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
                         <a class="govuk-link govuk-link--inverse"


### PR DESCRIPTION
Small fix to the international homepage and campaign site footer links