### PR TITLE
fix: move breadcrumbs to top of webpage

### DIFF
--- a/export_academy/templates/export_academy/landing_page.html
+++ b/export_academy/templates/export_academy/landing_page.html
@@ -6,6 +6,9 @@
 {% load event_list_buttons %}
 {% load add_govuk_classes from content_tags %}
 {% block content %}
+    {% block breadcrumbs %}
+        {% include 'components/breadcrumbs_cms.html' %}
+    {% endblock %}
     <div class="great great-hero-box-shadow-bottom">
         {% image page.hero_image original as rendition %}
         <section class="background-white govuk-!-padding-bottom-0">
@@ -34,9 +37,6 @@
             </div>
         </div>
     </section>
-    {% block breadcrumbs %}
-        {% include 'components/breadcrumbs_cms.html' %}
-    {% endblock %}
     {% if page.banner_label %}
         <div class="govuk-!-static-padding-top-6 govuk-!-static-padding-bottom-6">
             {% include 'components/informative_banner.html' with banner_label=page.banner_label banner_content=page.banner_content %}
@@ -62,7 +62,6 @@
             </div>
         </div>
     </section>
-
     <section class="great great-bg-light-blue panels-container govuk-!-padding-bottom-0">
         {% for contentSection in page.events_and_series %}
             {% if contentSection.block_type == 'Panels_Section' %}
@@ -77,21 +76,22 @@
                             <div class="govuk-grid-column-one-third govuk-!-padding-bottom-6">
                                 {% image panel.value.image fill-640x360 as thumbnail %}
                                 {% include 'components/great/card.html' with url=panel.value.link title=panel.value.title show_title_link=True image_src=thumbnail.url image_alt=panel.value.image.alt_text content=panel.value.description %}
-                            </div>  
+                            </div>
                         {% endfor %}
                     </div>
                 </div>
                 {% if contentSection.value.next_cta %}
-                <div class="great-container govuk-!-padding-bottom-7">{% include_block contentSection.value.next_cta %}</div>
+                    <div class="great-container govuk-!-padding-bottom-7">{% include_block contentSection.value.next_cta %}</div>
                 {% endif %}
             {% elif contentSection.block_type == 'Series_Section' %}
                 {% if features.FEATURE_COURSES_LANDING_PAGE %}
                     <div class="govuk-width-container great-container  govuk-!-padding-bottom-0">
-                        <p> {{contentSection.value.series_section_description | richtext}} </p>
+                        <p>{{ contentSection.value.series_section_description | richtext }}</p>
                         <div class="govuk-grid-row great-flex-grid great-bg-light-blue">
-                            {% for series in contentSection.value.series_list%}
+                            {% for series in contentSection.value.series_list %}
                                 <div class="govuk-grid-column-full courses-container govuk-!-margin-bottom-8">
-                                    <a href="{{ series.value.course_cta_url }}" class="govuk-!-display-block">
+                                    <a href="{{ series.value.course_cta_url }}"
+                                       class="govuk-!-display-block">
                                         <div class="great-bg-white great-display-flex-from-desktop">
                                             <div class="courses-container__text great-dep-homepage-title__text">
                                                 <h3 class="govuk-!-static-margin-bottom-4">{{ series.value.course_name }}</h3>
@@ -99,26 +99,26 @@
                                                 <ul>
                                                     <li class="govuk-!-static-margin-top-3">
                                                         <img class="great-blue-tick govuk-!-static-margin-right-1"
-                                                            src="{% static 'icons/blue-tick.svg' %}"
-                                                            height="30"
-                                                            aria-hidden="true"
-                                                            alt="" />
+                                                             src="{% static 'icons/blue-tick.svg' %}"
+                                                             height="30"
+                                                             aria-hidden="true"
+                                                             alt="" />
                                                         <span class="great-vertical-align-middle">{{ series.value.course_feature_one }}</span>
                                                     </li>
                                                     <li class="govuk-!-static-margin-top-3">
                                                         <img class="great-blue-tick govuk-!-static-margin-right-1"
-                                                            src="{% static 'icons/blue-tick.svg' %}"
-                                                            height="30"
-                                                            aria-hidden="true"
-                                                            alt="" />
+                                                             src="{% static 'icons/blue-tick.svg' %}"
+                                                             height="30"
+                                                             aria-hidden="true"
+                                                             alt="" />
                                                         <span>{{ series.value.course_feature_two }}</span>
                                                     </li>
                                                     <li class="govuk-!-static-margin-top-3">
                                                         <img class="great-blue-tick govuk-!-static-margin-right-1"
-                                                            src="{% static 'icons/blue-tick.svg' %}"
-                                                            height="30"
-                                                            aria-hidden="true"
-                                                            alt="" />
+                                                             src="{% static 'icons/blue-tick.svg' %}"
+                                                             height="30"
+                                                             aria-hidden="true"
+                                                             alt="" />
                                                         <span>{{ series.value.course_feature_three }}</span>
                                                     </li>
                                                 </ul>
@@ -128,12 +128,12 @@
                                             </div>
                                             {% image series.value.course_image original as course_rendition %}
                                             <img class="courses-container__img"
-                                                src="{{ course_rendition.url }}"
-                                                alt="">
+                                                 src="{{ course_rendition.url }}"
+                                                 alt="">
                                         </div>
                                     </a>
                                 </div>
-                            {% endfor%}
+                            {% endfor %}
                         </div>
                     </div>
                 {% endif %}


### PR DESCRIPTION
CONTEXT: This changeset updates the UK Export Academy landing page template so that the position of the breadcrumbs component is displayed directly below the nav bar.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-121
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
<img width="1478" alt="85277329-0bab-40a2-91de-307b9a617861" src="https://github.com/uktrade/great-cms/assets/113309035/28f80337-dea3-44ff-b349-4b41fbff99b7">

![Screenshot 2024-06-04 at 15 15 27](https://github.com/uktrade/great-cms/assets/113309035/7ae45efe-5ba5-4de6-bc60-e42e39a98404)

