### PR TITLE
EYB 50 align typeface on international homepage in mobile view

### DIFF
--- a/international/templates/international/index.html
+++ b/international/templates/international/index.html
@@ -22,7 +22,7 @@
                     {% for cards in page.dep_cards %}
                         {% for card in cards.value %}
                             <div class="govuk-grid-column-one-half-from-desktop govuk-!-margin-bottom-6">
-                                {% include 'components/great/card.html' with data_attr_title=card.value.link_text data_attr_location='International homepage' title=card.value.link_text show_title_link=True url=card.value.link_url content=card.value.description image_src=card.value.link_url|get_international_icon_path is_svg_image=True classes="great-card--homepage great-international-card--cta" %}
+                                {% include 'components/great/card.html' with data_attr_title=card.value.link_text data_attr_location='International homepage' title=card.value.link_text show_title_link=True url=card.value.link_url content=card.value.description image_src=card.value.link_url|get_international_icon_path is_svg_image=True content_class="govuk-body" classes="great-card--homepage great-international-card--cta" %}
                             </div>
                         {% endfor %}
                     {% endfor %}


### PR DESCRIPTION
Ensure font size in cards of International homeapage reduces in mobile view.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/EYB-50
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Includes screenshot(s) - ideally before and after, but at least after

Before:

<img width="388" alt="Screenshot 2024-06-13 at 15 00 52" src="https://github.com/uktrade/great-cms/assets/1638245/19dbddb7-8930-47e3-aba4-827ec5f81fa7">

After:

<img width="381" alt="Screenshot 2024-06-13 at 15 01 58" src="https://github.com/uktrade/great-cms/assets/1638245/99d665b0-395c-48b7-92a6-25fc8d9b66cc">

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
