### PR TITLE
small password input box id fix for automated tests on eauk signin

### DIFF
--- a/core/static/javascript/great.password-reveal.js
+++ b/core/static/javascript/great.password-reveal.js
@@ -2,7 +2,7 @@ GreatFrontend = window.GreatFrontend || {}
 
 GreatFrontend.PasswordInput = {
   init: () => {
-    const passwordInput = document.getElementById('password-input');
+    const passwordInput = document.getElementById('id_password');
     const passwordShowButton = document.getElementById('password-show-button');
     const hiddenClass= 'great-hidden'
     const visuallyHiddenClass= 'great-visually-hidden'

--- a/core/templates/components/great/password-show-hide.html
+++ b/core/templates/components/great/password-show-hide.html
@@ -1,7 +1,7 @@
 <div class="govuk-input__wrapper govuk-password-input__wrapper great-display-flex">
     <input type="password"
            name="password"
-           id="password-input"
+           id="id_password"
            spellcheck="false"
            autocomplete="current-password"
            autocapitalize="none"
@@ -11,6 +11,6 @@
             id="password-show-button"
             class="secondary-button govuk-!-margin-left-2 great-hidden great-min-90-button"
             data-module="govuk-button"
-            aria-controls="password-input"
+            aria-controls="id_password"
             aria-label="Show password">Show</button>
 </div>


### PR DESCRIPTION
Very small fix to change the password input id in eauk signup/signin from 'password-input' to 'id_password' to remain in line with current id and pass test suite

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-35
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Frontend assets have been re-compiled.
- [x] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
