### PR TITLE
GRTLV-211: Where to Export HCSAT - Data workspace

### DIFF
--- a/activitystream/filters.py
+++ b/activitystream/filters.py
@@ -44,3 +44,11 @@ class ActivityStreamCmsContentFilter(FilterSet):
     def filter_after(self, queryset, name, value):
         value = value or '0'
         return queryset.filter(id__gt=value)
+
+
+class ActivityStreamWhereToExportFilter(FilterSet):
+    after = CharFilter(method='filter_after')
+
+    def filter_after(self, queryset, name, value):
+        value = value or '0'
+        return queryset.filter(id__gt=value)

--- a/activitystream/pagination.py
+++ b/activitystream/pagination.py
@@ -56,3 +56,14 @@ class ActivityStreamCmsContentPagination(ActivityStreamBasePagination):
         self.next_value = page[-1].id if page else ''
         self.request = request
         return page
+
+
+class ActivityStreamWhereToExportPagination(ActivityStreamBasePagination):
+    page_size = 100
+
+    def paginate_queryset(self, queryset, request, view=None):
+        self.has_next = queryset.count() > self.page_size
+        page = list(queryset[: self.page_size])
+        self.next_value = page[-1].modified.timestamp() if page else ''
+        self.request = request
+        return page

--- a/activitystream/serializers.py
+++ b/activitystream/serializers.py
@@ -6,6 +6,7 @@ from wagtail.models import Page
 from wagtail.rich_text import RichText, get_text_for_indexing
 
 from core.models import GreatMedia, MicrositePage
+from core.models import CsatUserFeedback as WhereToExportCsatUserFeedback
 from domestic.models import ArticlePage
 from export_academy.models import (
     Booking,
@@ -599,6 +600,46 @@ class ActivityStreamExportAcademyCsatUserFeedbackDataSerializer(serializers.Mode
         Prefix field names to match activity stream format
         """
         prefix = 'dit:exportAcademy:csatFeedbackData'
+        type = 'Update'
+
+        return {
+            'id': f'{prefix}:{instance.id}:{type}',
+            'type': f'{type}',
+            'object': {
+                'id': f'{prefix}:{instance.id}',
+                'type': prefix,
+                **{f'{k}': v for k, v in super().to_representation(instance).items()},
+            },
+        }
+
+
+class ActivityStreamWhereToExportCsatUserFeedbackDataSerializer(serializers.ModelSerializer):
+    """
+    Where to Export's CSAT Feedback Data serializer for activity stream.
+    """
+
+    feedback_submission_date = serializers.DateTimeField(source='created')  # noqa: N815
+    url = serializers.CharField(source='URL')  # noqa: N815
+
+    class Meta:
+        model = WhereToExportCsatUserFeedback
+        fields = [
+            'id',
+            'feedback_submission_date',
+            'url',
+            'user_journey',
+            'satisfaction_rating',
+            'experienced_issue',
+            'other_detail',
+            'service_improvements_feedback',
+            'likelihood_of_return',
+        ]
+
+    def to_representation(self, instance):
+        """
+        Prefix field names to match activity stream format
+        """
+        prefix = 'dit:whereToExport:csatFeedbackData'
         type = 'Update'
 
         return {

--- a/activitystream/urls.py
+++ b/activitystream/urls.py
@@ -66,4 +66,9 @@ urlpatterns = [
         skip_ga360(activitystream.views.ActivityStreamExportAcademyCsatFeedbackDataView.as_view()),
         name='ukea-csats',
     ),
+    path(
+        'wheretoexport-csats/',
+        skip_ga360(activitystream.views.ActivityStreamWhereToExportCsatFeedbackDataView.as_view()),
+        name='wheretoexport-csats',
+    ),
 ]

--- a/activitystream/views.py
+++ b/activitystream/views.py
@@ -18,12 +18,14 @@ from activitystream.filters import (
     ActivityStreamCmsContentFilter,
     ActivityStreamExpandYourBusinessFilter,
     ActivityStreamExportAcademyFilter,
+    ActivityStreamWhereToExportFilter,
     PageFilter,
 )
 from activitystream.pagination import (
     ActivityStreamCmsContentPagination,
     ActivityStreamExpandYourBusinessPagination,
     ActivityStreamExportAcademyPagination,
+    ActivityStreamWhereToExportPagination,
 )
 from activitystream.serializers import (
     ActivityStreamCmsContentSerializer,
@@ -35,9 +37,11 @@ from activitystream.serializers import (
     ActivityStreamExportAcademyEventSerializer,
     ActivityStreamExportAcademyRegistrationSerializer,
     ActivityStreamExportAcademyVideoOnDemandPageTrackingSerializer,
+    ActivityStreamWhereToExportCsatUserFeedbackDataSerializer,
     PageSerializer,
 )
 from core.models import MicrositePage
+from core.models import CsatUserFeedback as WhereToExportCsatUserFeedback
 from domestic.models import ArticlePage, CountryGuidePage
 from export_academy.models import (
     Booking,
@@ -265,3 +269,18 @@ class ActivityStreamExportAcademyCsatFeedbackDataView(ActivityStreamExportAcadem
 
     queryset = CsatUserFeedback.objects.all()
     serializer_class = ActivityStreamExportAcademyCsatUserFeedbackDataSerializer
+
+
+class ActivityStreamWhereToExportBaseView(ActivityStreamBaseView):
+    filterset_class = ActivityStreamWhereToExportFilter
+    pagination_class = ActivityStreamWhereToExportPagination
+
+    def get_queryset(self):
+        return self.queryset.order_by('modified')
+
+
+class ActivityStreamWhereToExportCsatFeedbackDataView(ActivityStreamExportAcademyBaseView):
+    """View to list export academy csat feedback data for the activity stream"""
+
+    queryset = WhereToExportCsatUserFeedback.objects.all()
+    serializer_class = ActivityStreamWhereToExportCsatUserFeedbackDataSerializer


### PR DESCRIPTION
Publish data on activitystream url for WTE HCSAT . 

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-211
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.



### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
