### PR TITLE
Remove file field on GreatMedia

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -42,7 +42,7 @@ from wagtail.models import Orderable, Page
 from wagtail.snippets.blocks import SnippetChooserBlock
 from wagtail.snippets.models import register_snippet
 from wagtail.utils.decorators import cached_classmethod
-from wagtailmedia.models import AbstractMedia as Media
+from wagtailmedia.models import Media
 from wagtailseo.models import SeoMixin as WagtailSeoMixin, TwitterCard
 
 from core import blocks as core_blocks, cms_panels, constants, mixins, snippet_slugs
@@ -71,11 +71,6 @@ register_snippet(Redirect)
 
 
 class GreatMedia(Media):
-    file = models.FileField(
-        upload_to='media',
-        verbose_name=_('file'),
-        help_text='File names can not exceed 96 characters',
-    )
     description = models.TextField(
         verbose_name=_('Description'), blank=True, null=True  # left null because was an existing field
     )


### PR DESCRIPTION
Removes a file field as it cannot resolve to a safe migration.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
