### PR TITLE
Add canonical url to contact forms

### DIFF
--- a/contact/templates/domestic/contact/routing/step-great-account.html
+++ b/contact/templates/domestic/contact/routing/step-great-account.html
@@ -1,6 +1,12 @@
 {% extends 'domestic/contact/wizard-domestic.html' %}
+{% load contact_canonical_url_tags %}
 {% load static from static %}
 {% block head_title %}Account{% endblock %}
+{% block head_other %}
+    {{ block.super }}
+    {% get_canonical_url as canonical_url %}
+    <link rel="canonical" href="{{ canonical_url }}">
+{% endblock %}
 {% block meta_title %}Account{% endblock %}
 {% block step_title_container %}
     <div id="form-step-body-text">

--- a/contact/templatetags/contact_canonical_url_tags.py
+++ b/contact/templatetags/contact_canonical_url_tags.py
@@ -1,0 +1,11 @@
+from django import template
+
+from core.utils import derive_canonical_url
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def get_canonical_url(context):
+    request = context['request']
+    return derive_canonical_url(request)


### PR DESCRIPTION
Add canonical url to contact forms - cannot use SEOMixin as not wagtail pages

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-903
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Python requirements have been re-compiled.
- [x] Frontend assets have been re-compiled.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
