### PR TITLE
Adjust country names and append 'the' to countries such as 'Maldives'

### DIFF
--- a/activitystream/serializers.py
+++ b/activitystream/serializers.py
@@ -10,8 +10,6 @@ from core.models import (
     GreatMedia,
     MicrositePage,
 )
-from learn.models import CsatUserFeedback as LearnToExportCsatUserFeedback
-from find_a_buyer.models import CsatUserFeedback as FindABuyerCsatUserFeedback
 from domestic.models import ArticlePage
 from export_academy.models import (
     Booking,
@@ -20,7 +18,9 @@ from export_academy.models import (
     Registration,
     VideoOnDemandPageTracking,
 )
+from find_a_buyer.models import CsatUserFeedback as FindABuyerCsatUserFeedback
 from international_online_offer.models import CsatFeedback, TriageData, UserData
+from learn.models import CsatUserFeedback as LearnToExportCsatUserFeedback
 
 logger = logging.getLogger(__name__)
 

--- a/activitystream/views.py
+++ b/activitystream/views.py
@@ -43,8 +43,6 @@ from activitystream.serializers import (
     PageSerializer,
 )
 from core.models import CsatUserFeedback as WhereToExportCsatUserFeedback, MicrositePage
-from learn.models import CsatUserFeedback as LearnToExportCsatUserFeedback
-from find_a_buyer.models import CsatUserFeedback as FindABuyerCsatUserFeedback
 from domestic.models import ArticlePage, CountryGuidePage
 from export_academy.models import (
     Booking,
@@ -53,7 +51,9 @@ from export_academy.models import (
     Registration,
     VideoOnDemandPageTracking,
 )
+from find_a_buyer.models import CsatUserFeedback as FindABuyerCsatUserFeedback
 from international_online_offer.models import CsatFeedback, TriageData, UserData
+from learn.models import CsatUserFeedback as LearnToExportCsatUserFeedback
 
 
 class ActivityStreamView(ListAPIView):

--- a/core/templatetags/content_tags.py
+++ b/core/templatetags/content_tags.py
@@ -609,3 +609,38 @@ def get_meta_tag_icon_path(url):
         return '/static/icons/guidance.svg'
 
     return '/static/icons/hand.svg'
+
+
+@register.simple_tag()
+def change_country_name_to_include_the(country_name):
+
+    countries_starting_with_the = [
+        'bahamas',
+        'cayman islands',
+        'central african republic',
+        'channel islands',
+        'comoros',
+        'czech republic',
+        'dominican republic',
+        'falkland islands',
+        'faroe islands',
+        'gambia',
+        'isle of man',
+        'ivory coast',
+        'leeward islands',
+        'maldives',
+        'marshall islands',
+        'netherlands',
+        'netherlands antilles',
+        'philippines',
+        'solomon islands',
+        'turks and caicos islands',
+        'united arab emirates',
+        'united kingdom',
+        'united states',
+        'virgin islands',
+    ]
+
+    if country_name.lower() in countries_starting_with_the:
+        return f'the {country_name.lower().title().replace(" Of ", " of ").replace(" And ", " and ")}'
+    return country_name.lower().title()

--- a/domestic/templates/domestic/country_guide.html
+++ b/domestic/templates/domestic/country_guide.html
@@ -15,7 +15,7 @@
             <div class="container">
                 <div class="grid-row">
                     <div class="column-three-quarters-l teaser">
-                        <h1>Exporting guide to {{ page.heading }}</h1>
+                        <h1>Exporting from the UK to {% change_country_name_to_include_the page.heading %}: A market guide</h1>
                         <h2 class="visually-hidden">Overview</h2>
                         {% if features.FEATURE_PRODUCT_EXPERIMENT_LINKS %}
                             <div class="govuk-!-margin-bottom-6">

--- a/tests/unit/core/test_templatetags.py
+++ b/tests/unit/core/test_templatetags.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 from core.models import CuratedListPage, DetailPage, LessonPlaceholderPage, TopicPage
 from core.templatetags.content_tags import (
     add_anchor_classes,
+    change_country_name_to_include_the,
     extract_domain,
     get_backlinked_url,
     get_category_title_for_lesson,
@@ -1151,3 +1152,17 @@ def test_h3_if(condition, else_heading, expected_output):
 )
 def test_val_to_int(float, expected):
     assert val_to_int(float) == expected
+
+
+@pytest.mark.parametrize(
+    'country_name, expected_output',
+    (
+        ('England', 'England'),
+        ('england', 'England'),
+        ('IsLe Of mAn', 'the Isle of Man'),
+        ('turks and caicos islands', 'the Turks and Caicos Islands'),
+        ('United states', 'the United States'),
+    ),
+)
+def test_change_country_name_to_include_the(country_name, expected_output):
+    assert change_country_name_to_include_the(country_name) == expected_output


### PR DESCRIPTION
The H1 tag in market guides is now created using the page title and a templatetag to make the country name more readable i.e.

'United Kingdom' will become 'the United Kingdom
'England' will stay as 'England'

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-273
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
