### PR TITLE
Cache events by user

### DIFF
--- a/export_academy/urls.py
+++ b/export_academy/urls.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.decorators import login_required
 from django.urls import path
-from django.views.decorators.cache import cache_page
 
 from core import snippet_slugs
 from core.urls import SIGNUP_URL
@@ -13,7 +12,7 @@ app_name = 'export_academy'
 urlpatterns = [
     path(
         'events/',
-        cache_page(60 * 15)(views.EventListView.as_view()),
+        views.EventListView.as_view(),
         {
             'slug': snippet_slugs.EXPORT_ACADEMY_LISTING_PAGE_HERO,
             'snippet_import_path': 'core.models.HeroSnippet',  # see core.mixins.GetSnippetContentMixin

--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -87,8 +87,8 @@ class BespokeBreadcrumbMixin(TemplateView):
         return super().get_context_data(bespoke_breadcrumbs=bespoke_breadcrumbs, **kwargs)
 
 
-@method_decorator(vary_on_cookie, name='dispatch')
 @method_decorator(cache_page(60 * 5), name='dispatch')
+@method_decorator(vary_on_cookie, name='dispatch')
 class EventListView(GetBreadcrumbsMixin, GA360Mixin, core_mixins.GetSnippetContentMixin, FilterView, ListView):
     model = models.Event
     queryset = model.upcoming

--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -20,6 +20,8 @@ from django.shortcuts import get_list_or_404, get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.utils.text import get_valid_filename
+from django.views.decorators.cache import cache_page
+from django.views.decorators.vary import vary_on_cookie
 from django.views.generic import (
     DetailView,
     FormView,
@@ -85,6 +87,8 @@ class BespokeBreadcrumbMixin(TemplateView):
         return super().get_context_data(bespoke_breadcrumbs=bespoke_breadcrumbs, **kwargs)
 
 
+@method_decorator(vary_on_cookie, name='dispatch')
+@method_decorator(cache_page(60 * 5), name='dispatch')
 class EventListView(GetBreadcrumbsMixin, GA360Mixin, core_mixins.GetSnippetContentMixin, FilterView, ListView):
     model = models.Event
     queryset = model.upcoming


### PR DESCRIPTION
This ticket fixes a bug on the Events listing cache where users were seeing events as Booked. It ensures caching is only done on a per-user basis (by Cookie). 

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1230
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
