### PR TITLE
Greatuk 877 feature integrate opensearch into searchpage

### DIFF
--- a/search/templates/search_opensearch.html
+++ b/search/templates/search_opensearch.html
@@ -1,0 +1,112 @@
+{% extends 'domestic/base.html' %}
+{% load static %}
+{% load humanize %}
+{% block head_css %}
+    {{ block.super }}
+    <link href="{% static 'styles/default.css' %}"
+          rel="stylesheet"
+          type="text/css" />
+    <link href="{% static 'styles/pages/search-results.css' %}"
+          rel="stylesheet"
+          type="text/css" />
+{% endblock %}
+{% block head_title %}Search{% endblock %}
+{% block meta_title %}Search{% endblock %}
+{% block css_layout_class %}
+    search-results-page
+{% endblock css_layout_class %}
+{% block content %}
+    <section id="search-results-information">
+        {% if submitted %}
+            <div class="container">
+                {% include 'components/message_box_with_icon.html' with icon="✓" heading="Your feedback has been sent" %}
+            </div>
+        {% endif %}
+        <div class="container">
+            <h1 class="heading-xlarge">
+                {% if search_query %}
+                    Search results for <span class="great-highlighted-text">{{ search_query }}</span>
+                {% else %}
+                    Search
+                {% endif %}
+            </h1>
+            <!-- Search Input -->
+            <div class="actions">
+                {% if search_query %}
+                    {% if search_results %}
+                        <p>
+                            <a href="#search-results-list" class="bland">
+                                {{ search_results_count|intcomma }} result{{ search_results_count|pluralize }} found<span class="verbose">for {{ search_query }}</span>
+                            </a>
+                        </p>
+                    {% else %}
+                        <p class="added-margin-bottom">No results found. Please try again.</p>
+                    {% endif %}
+                {% else %}
+                    <p>
+                        <p class="added-margin-bottom">Search for articles, events, and resources</p>
+                    </p>
+                {% endif %}
+                <a href="{% url 'search:feedback' %}?page={{ current_page }}&q={{ search_query }}"
+                   class="font-xsmall link">Did you find what you were looking for?</a>
+                <form id="search-form"
+                      action="{% url 'search:search' %}"
+                      class="search"
+                      method="get"
+                      aria-label="Search form">
+                    <label class="verbose" id="search-again-label" for="search-again-input">Search again</label>
+                    <input autocomplete="off"
+                           class="text form-control"
+                           name="q"
+                           placeholder=""
+                           type="search"
+                           value="{{ query }}"
+                           id="search-again-input">
+                    <input class="submit search-button" type="submit" value="Go">
+                </form>
+            </div>
+        </div>
+    </section>
+    {% if search_results %}
+        <section id="search-results-list" class="search-results-list">
+            <div class="container">
+                <h2 class="verbose">Results found</h2>
+                <p class="information verbose">
+                    Displaying items <b>{{ first_item_number }}&nbsp;-&nbsp;{{ last_item_number }}</b> of <b>{{ total_results }}</b> in total
+                </p>
+                <!-- Search Results -->
+                <ul class="results" aria-label="Search results">
+                    {% for result in search_results %}
+                        <li>
+                            <span class="type">{{ result.content_type }}</span>
+                            <a class="title link" href="{{ result.url }}">{{ result.title }}</a>
+                            <p class="description">{{ results.search_description }}</p>
+                        </li>
+                    {% endfor %}
+                </ul>
+                <!-- Pagination -->
+                <div class="pagination">
+                    <p class="verbose">Displaying page {{ page_num }} of total {{ total_pages }}</p>
+                    {% if search_results.has_previous %}
+                        <a class="button primary-button"
+                           rel="prev"
+                           href="{% url 'search:search' %}?page={{ search_results.previous_page_number }}&q={{ search_query }}">Previous</a>
+                    {% endif %}
+                    <ol class="navigation" role="navigation" aria-label="Page navigation">
+                        {% for page_num in search_results.paginator.page_range %}
+                            <li>
+                                <a rel="prev"
+                                   href="{% url 'search:search' %}?page={{ page_num }}&q={{ search_query }}"><span class="verbose">Page</span>{{ page_num }}</a>
+                            </li>
+                        {% endfor %}
+                    </ol>
+                    {% if search_results.has_next %}
+                        <a class="button secondary-button pagination-next"
+                           rel="next"
+                           href="{% url 'search:search' %}?page={{ search_results.next_page_number }}&q={{ search_query }}">Next</a>
+                    {% endif %}
+                </div>
+            </div>
+        </section>
+    {% endif %}
+{% endblock %}

--- a/search/urls.py
+++ b/search/urls.py
@@ -1,7 +1,13 @@
+from django.conf import settings
 from django.urls import path
 from great_components.decorators import skip_ga360
 
-import search.views
+from search.views import (
+    OpensearchView,
+    SearchFeedbackFormView,
+    SearchFeedbackSuccessView,
+    SearchView,
+)
 
 app_name = 'search'
 
@@ -10,14 +16,28 @@ app_name = 'search'
 
 urlpatterns = [
     path(
-        '',
-        skip_ga360(search.views.SearchView.as_view()),
-        name='search',
-    ),
-    path(
         'feedback/',
-        search.views.SearchFeedbackFormView.as_view(),
+        SearchFeedbackFormView.as_view(),
         name='feedback',
     ),
-    path('feedback/success', search.views.SearchFeedbackSuccessView.as_view(), name='feedback-success'),
+    path('feedback/success', SearchFeedbackSuccessView.as_view(), name='feedback-success'),
 ]
+
+# Serve search page linked to gov-pass
+if settings.OPENSEARCH_PROVIDER == 'govuk-paas':
+    urlpatterns += [
+        path(
+            '',
+            skip_ga360(SearchView.as_view()),
+            name='search',
+        )
+    ]
+# Serve search page linked to AWS Opensearch
+elif settings.OPENSEARCH_PROVIDER in ['localhost', 'aws']:
+    urlpatterns += [
+        path(
+            '',
+            skip_ga360(OpensearchView.as_view()),
+            name='search',
+        )
+    ]

--- a/tests/unit/search/test_views.py
+++ b/tests/unit/search/test_views.py
@@ -27,7 +27,7 @@ def test_search_view(mock_search, client, root_page):
     mock_search.return_value = Page.objects.filter(id__in=[test_page_1.id, test_page_2.id])
 
     # Perform search
-    search_results = Page.objects.search("Test Page")
+    search_results = Page.objects.search('Test Page')
 
     # Assert that the search results contain the expected pages
     assert test_page_1 in search_results
@@ -35,7 +35,7 @@ def test_search_view(mock_search, client, root_page):
 
     # Perform a search that should return no results
     mock_search.return_value = Page.objects.none()
-    search_results_empty = Page.objects.search("Nonexistent Page")
+    search_results_empty = Page.objects.search('Nonexistent Page')
     assert not search_results_empty
 
     # Verify that the search method was called

--- a/tests/unit/search/test_views.py
+++ b/tests/unit/search/test_views.py
@@ -1,130 +1,45 @@
-import json
-from unittest.mock import Mock, call, patch
+from unittest.mock import call, patch
 
 import pytest
-import requests
 from django.test import RequestFactory, modify_settings
 from django.urls import reverse
 from freezegun import freeze_time
+from wagtail.models import Page
+from wagtail_factories import PageFactory
 
 from search import views
 
 pytestmark = pytest.mark.django_db
 
 
-def test_search_view(client):
-    """We mock the call to ActivityStream"""
+@pytest.mark.django_db
+@patch('wagtail.models.Page.objects.search')
+def test_search_view(mock_search, client, root_page):
+    # Test base page response
+    response = client.get(reverse('search:search'))
+    assert response.status_code == 200
 
-    with patch('search.helpers.search_with_activitystream') as search:
-        mock_results = json.dumps(
-            {
-                'took': 17,
-                'timed_out': False,
-                '_shards': {'total': 4, 'successful': 4, 'skipped': 0, 'failed': 0},
-                'hits': {
-                    'total': {
-                        'value': 5,
-                        'relation': 'eq',
-                        # This is an ActivityStream-V2-style/ES7-style 'total' field -
-                        # AS-V1/ES6 returned an int not a dict
-                    },
-                    'max_score': 0.2876821,
-                    'hits': [
-                        {
-                            '_index': 'objects__feed_id_first_feed__date_2019',
-                            '_type': '_doc',
-                            '_id': 'dit:exportOpportunities:Opportunity:2',
-                            '_score': 0.2876821,
-                            '_source': {
-                                'type': ['Document', 'dit:Opportunity'],
-                                'title': 'France - Data analysis services',
-                                'content': 'The purpose of this contract is to analyze...',
-                                'url': 'www.great.gov.uk/opportunities/1',
-                            },
-                        },
-                        {
-                            '_index': 'objects__feed_id_first_feed__date_2019',
-                            '_type': '_doc',
-                            '_id': 'dit:exportOpportunities:Opportunity:2',
-                            '_score': 0.18232156,
-                            '_source': {
-                                'type': ['Document', 'dit:Opportunity'],
-                                'title': 'Germany - snow clearing',
-                                'content': 'Winter services for the properties1) Former...',
-                                'url': 'www.great.gov.uk/opportunities/2',
-                            },
-                        },
-                    ],
-                },
-            }
-        )
-        search.return_value = Mock(status_code=200, content=mock_results)
+    # Create test data
+    test_page_1 = PageFactory(title='Test Page 1', parent=root_page)
+    test_page_2 = PageFactory(title='Test Page 2', parent=root_page)
 
-        response = client.get(reverse('search:search'), data={'q': 'services'})
-        context = response.context_data
+    # Mock search results
+    mock_search.return_value = Page.objects.filter(id__in=[test_page_1.id, test_page_2.id])
 
-        assert response.status_code == 200
-        assert context['results'] == [
-            {
-                'type': 'Export opportunity',
-                'title': 'France - Data analysis services',
-                'content': 'The purpose of this contract is to analyze...',
-                'url': 'www.great.gov.uk/opportunities/1',
-            },
-            {
-                'type': 'Export opportunity',
-                'title': 'Germany - snow clearing',
-                'content': 'Winter services for the properties1) Former...',
-                'url': 'www.great.gov.uk/opportunities/2',
-            },
-        ]
+    # Perform search
+    search_results = Page.objects.search("Test Page")
 
-        """ What if there are no results? """
-        search.return_value = Mock(
-            status_code=200,
-            content=json.dumps(
-                {
-                    'took': 17,
-                    'timed_out': False,
-                    '_shards': {'total': 4, 'successful': 4, 'skipped': 0, 'failed': 0},
-                    'hits': {
-                        'total': {
-                            'value': 0,
-                            'relation': 'eq',
-                        },
-                        'hits': [],
-                    },
-                }
-            ),
-        )
+    # Assert that the search results contain the expected pages
+    assert test_page_1 in search_results
+    assert test_page_2 in search_results
 
-        response = client.get(reverse('search:search'), data={'q': 'services'})
-        context = response.context_data
+    # Perform a search that should return no results
+    mock_search.return_value = Page.objects.none()
+    search_results_empty = Page.objects.search("Nonexistent Page")
+    assert not search_results_empty
 
-        assert response.status_code == 200
-        assert context['results'] == []
-
-        """ What if ActivitySteam sends an error? """
-        search.return_value = Mock(status_code=500, content='[service overloaded]')
-
-        response = client.get(reverse('search:search'), data={'q': 'services'})
-        context = response.context_data
-
-        assert response.status_code == 200
-        # This can be handled on the front end as we wish
-        assert context['error_message'] == '[service overloaded]'
-        assert context['error_status_code'] == 500
-
-        """ What if ActivitySteam is down? """
-        search.side_effect = requests.exceptions.ConnectionError
-
-        response = client.get(reverse('search:search'), data={'q': 'services'})
-        context = response.context_data
-
-        assert response.status_code == 200
-        # This can be handled on the front end as we wish
-        assert context['error_message'] == 'Activity Stream connection failed'
-        assert context['error_status_code'] == 500
+    # Verify that the search method was called
+    mock_search.assert_called()
 
 
 def test_search_feedback_view(client):


### PR DESCRIPTION
This ticket adds hooks the frontend /search page up tot he Opensearch backend. 

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-877
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
