### PR TITLE
IGUK-416 Feature adding industries dropdown to buy from the UK index

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
       - run:
           name: Install @uktrade/great-design-system
           command: |
-            npm install @uktrade/great-design-system@latest
+            npm install @uktrade/great-design-system
       - restore_cache:
           key: v1-deps-{{ checksum "package-lock.json" }}
       - run:
@@ -202,7 +202,7 @@ jobs:
       - run:
           name: Install @uktrade/great-design-system
           command: |
-            npm install @uktrade/great-design-system@latest
+            npm install @uktrade/great-design-system
       - restore_cache:
           key: v1-deps-{{ checksum "package-lock.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - run:
           name: Install @uktrade/great-design-system
           command: |
-            npm install @uktrade/great-design-system@latest
+            npm install @uktrade/great-design-system@0.0.11
       - restore_cache:
           key: v1-deps-{{ checksum "package-lock.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - run:
           name: Install @uktrade/great-design-system
           command: |
-            npm install @uktrade/great-design-system@0.0.11
+            npm install @uktrade/great-design-system
       - restore_cache:
           key: v1-deps-{{ checksum "package-lock.json" }}
       - run:

--- a/international_buy_from_the_uk/forms.py
+++ b/international_buy_from_the_uk/forms.py
@@ -169,6 +169,21 @@ class SearchForm(forms.Form):
     )
 
 
+class IndexSearchForm(forms.Form):
+    q = forms.CharField(
+        label='What product or service are you buying?',
+        max_length=255,
+        widget=TextInput(attrs={'class': 'govuk-input'}),
+        required=False,
+    )
+    industries = ChoiceField(
+        label='Industry',
+        required=False,
+        widget=Select(attrs={'class': 'govuk-select govuk-!-width-full'}),
+        choices=(('', 'All industries'),) + INDUSTRIES,
+    )
+
+
 class FindASupplierContactForm(GovNotifyEmailActionMixin, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/international_buy_from_the_uk/models.py
+++ b/international_buy_from_the_uk/models.py
@@ -1,4 +1,7 @@
+from django.shortcuts import render
+
 from domestic.models import BaseContentPage
+from international_buy_from_the_uk.forms import IndexSearchForm
 
 
 class BuyFromTheUKIndexPage(BaseContentPage):
@@ -8,19 +11,19 @@ class BuyFromTheUKIndexPage(BaseContentPage):
     subpage_types = []
     template = 'buy_from_the_uk/index.html'
 
-    def get_context(self, request, *args, **kwargs):
-        context = super().get_context(request, *args, **kwargs)
+    def serve(self, request, *args, **kwargs):
+        form = IndexSearchForm()
+
+        # Set breadcrumbs and render the page
         breadcrumbs = [
             {'name': 'Home', 'url': '/international/'},
         ]
-        context.update(
-            breadcrumbs=breadcrumbs,
+        return render(
+            request,
+            'buy_from_the_uk/index.html',
+            {
+                'form': form,
+                'page': self,
+                'breadcrumbs': breadcrumbs,
+            },
         )
-        self.set_ga360_payload(
-            page_id='Index',
-            business_unit='Buy from the UK',
-            site_section='index',
-        )
-        self.add_ga360_data_to_payload(request)
-        context['ga360'] = self.ga360_payload
-        return context

--- a/international_buy_from_the_uk/templates/buy_from_the_uk/index.html
+++ b/international_buy_from_the_uk/templates/buy_from_the_uk/index.html
@@ -21,20 +21,18 @@
                 </div>
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds-from-desktop">
-                        <label class="govuk-label govuk-label--s">What product or service are you buying?</label>
-                        <input class="govuk-input" name="q" id="q">
+                        {% include 'international/includes/form_field.html' with field=form.q %}
                     </input>
                 </div>
                 <div class="govuk-grid-column-one-third-from-desktop">
+                    {% include 'international/includes/form_field.html' with field=form.industries %}
                     <input class="govuk-visually-hidden" name="page" id="page" value=1>
                 </input>
             </div>
         </div>
-        <div class="govuk-grid-row">
+        <div class="govuk-grid-row govuk-!-margin-top-4">
             <div class="govuk-grid-column-two-thirds-from-desktop">
-                <button type="submit"
-                        class="govuk-button govuk-!-margin-top-4"
-                        data-module="govuk-button">Find suppliers</button>
+                {% include 'international/includes/submit_button.html' with button_text='Find suppliers' %}
             </div>
         </div>
     </form>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/polyfill": "^7.12.1",
         "@fortawesome/fontawesome-free": "^5.15.4",
-        "@uktrade/great-design-system": "^0.0.11",
+        "@uktrade/great-design-system": "0.0.11",
         "govuk-frontend": "^4.5.0",
         "great-styles": "github:uktrade/great-styles",
         "prop-types": "15.7.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
-    "@uktrade/great-design-system": "^0.0.11",
+    "@uktrade/great-design-system": "0.0.11",
     "govuk-frontend": "^4.5.0",
     "great-styles": "github:uktrade/great-styles",
     "prop-types": "15.7.2",


### PR DESCRIPTION
Adding industries dropdown to buy from the UK index page which allows users to select a industry to pre-populate the search when navigating to find a supplier search for companies.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-416
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after
<img width="1275" alt="image" src="https://github.com/user-attachments/assets/3cee8c39-ff72-48ae-9028-68bb4996e345">

### Housekeeping

N/A

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
