### PR TITLE
GRTLV-353 : Hite CTA for in person events for ITW

### DIFF
--- a/export_academy/helpers.py
+++ b/export_academy/helpers.py
@@ -35,8 +35,8 @@ def get_buttons_for_event(user, event, on_confirmation=False):
         else:
             if event.closed:
                 result['disable_text'] = 'Closed for booking'
-
-    result['form_event_booking_buttons'] += get_event_booking_button(user, event)
+    if event.format == event.ONLINE:
+        result['form_event_booking_buttons'] += get_event_booking_button(user, event)
     return result
 
 

--- a/export_academy/templates/export_academy/event_details.html
+++ b/export_academy/templates/export_academy/event_details.html
@@ -33,6 +33,8 @@
             </div>
         </div>
     </section>
-    {% include './includes/event_details_banner.html' %}
+    {% if event.format == event.ONLINE %}
+        {% include './includes/event_details_banner.html' %}
+    {% endif %}
     {% include './includes/event_details_main_content.html' %}
 {% endblock %}


### PR DESCRIPTION
What
- Hide cta "Book event"(logged in ) and "Sign up to book event" (logged out) for In person events. These are for ITW
Why
- We want ITW in person events to be booked through external links which will be added in the events details , hence we want to avoid confusion by hiding the Button to book events through great.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-353
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

<img width="1382" alt="Screenshot 2024-09-25 at 12 00 52" src="https://github.com/user-attachments/assets/47734f9a-b1f1-40ff-ba5d-c64caafb8afd">

Should be able to see it for Online events

![Screenshot 2024-09-25 at 11 30 02](https://github.com/user-attachments/assets/8f8a8220-86fe-433d-b971-2039e250b13f)

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
