### PR TITLE
Grtlv 360 bug preventing access to learn to export articles on staging dev local environments

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -484,8 +484,6 @@ elif OPENSEARCH_PROVIDER in ['localhost', 'aws']:
     connections.create_connection(
         alias='default',
         hosts=[env.str('OPENSEARCH_URL', 'localhost:9200')],
-        use_ssl=False,
-        verify_certs=False,
         connection_class=RequestsHttpConnection,
     )
     WAGTAILSEARCH_BACKENDS = {

--- a/config/settings.py
+++ b/config/settings.py
@@ -481,6 +481,13 @@ if OPENSEARCH_PROVIDER == 'govuk-paas':
     )
 # Connect to the local dockerized Opensearch instance
 elif OPENSEARCH_PROVIDER in ['localhost', 'aws']:
+    connections.create_connection(
+        alias='default',
+        hosts=[env.str('OPENSEARCH_URL', 'localhost:9200')],
+        use_ssl=False,
+        verify_certs=False,
+        connection_class=RequestsHttpConnection,
+    )
     WAGTAILSEARCH_BACKENDS = {
         'default': {
             'BACKEND': 'wagtail.search.backends.elasticsearch7',


### PR DESCRIPTION
A bug was preventing access to learn to export articles which are accessed with opensearch, and affected local, dev and staging (dev/staging use aws whereas prod/uat still use gov-paas). This was introduced during a change to support the AWS migration, and the deleted connection setup has been re-added in this PR. 

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-360
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

Error reporting on local:
<img width="865" alt="Screenshot 2024-10-02 at 09 12 30" src="https://github.com/user-attachments/assets/73c5ff3e-6a19-4f1a-835f-688c54ba8612">

Error reporting on dev/staging:
<img width="1155" alt="Screenshot 2024-10-02 at 10 14 26" src="https://github.com/user-attachments/assets/4f969f04-d5d4-4511-a0f0-3248731659f7">

After fix:
<img width="1140" alt="Screenshot 2024-10-02 at 10 14 54" src="https://github.com/user-attachments/assets/6c5482dd-6729-4818-89df-9dc0dff65ec2">



### Housekeeping

- [x] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
