### PR TITLE
ET-420: New region and trading bloc filters

### DIFF
--- a/domestic/fixtures/markets_filtering_fixtures.json
+++ b/domestic/fixtures/markets_filtering_fixtures.json
@@ -2033,5 +2033,25 @@
       "slug": "united-kingdom",
       "region": 440
     }
+  },
+  {
+    "model": "core.personalisationregiontag",
+    "pk": 1,
+    "fields": { "name": "Latin America and Caribbean", "slug": "latin-america-and-caribbean" }
+  },
+  {
+    "model": "core.personalisationregiontag",
+    "pk": 2,
+    "fields": { "name": "Asia Pacific", "slug": "asia-pacific" }
+  },
+  {
+    "model": "core.personalisationregiontag",
+    "pk": 3,
+    "fields": { "name": "Europe", "slug": "europe" }
+  },
+  {
+    "model": "core.personalisationregiontag",
+    "pk": 4,
+    "fields": { "name": "North America", "slug": "north-america" }
   }
 ]

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -56,7 +56,6 @@ from core.models import (
     IndustryTag,
     PersonalisationRegionTag,
     PersonalisationTradingBlocTag,
-    Region,
     SectorTag,
     SeoMixin,
     Tag,
@@ -586,6 +585,7 @@ class MarketsTopicLandingPage(
 
     SORTBY_QUERYSTRING_NAME = 'sortby'
     REGION_QUERYSTRING_NAME = 'region'
+    TRADING_BLOC_QUERYSTRING_NAME = 'trading_bloc'
     SECTOR_QUERYSTRING_NAME = 'sector'
 
     SORTBY_OPTION_TITLE = 'title'
@@ -632,6 +632,7 @@ class MarketsTopicLandingPage(
         # querystring args come in as plus-quoted strings which are the name
         sectors = [unquote_plus(x) for x in self.get_selected_sectors(request)]
         regions = [unquote_plus(x) for x in self.get_selected_regions(request)]
+        trading_blocs = [unquote_plus(x) for x in self.get_selected_trading_blocs(request)]
 
         #  We need to only apply these if truthy, else we end up getting no results
         if sectors:
@@ -640,7 +641,11 @@ class MarketsTopicLandingPage(
             )
         if regions:
             market_pages_qs = market_pages_qs.filter(
-                country__region__name__in=regions,
+                region_tags__name__in=regions,
+            )
+        if trading_blocs:
+            market_pages_qs = market_pages_qs.filter(
+                trading_bloc_tags__name__in=trading_blocs,
             )
 
         return self.sort_results(
@@ -663,8 +668,8 @@ class MarketsTopicLandingPage(
         selected = set(request.GET.getlist(self.REGION_QUERYSTRING_NAME))
         # chain unselected items queryset onto selected items queryset to sort selected items ahead of unselected
         regions = chain(
-            Region.objects.order_by('name').filter(name__in=selected).all(),
-            Region.objects.order_by('name').exclude(name__in=selected).all(),
+            PersonalisationRegionTag.objects.order_by('name').filter(name__in=selected).all(),
+            PersonalisationRegionTag.objects.order_by('name').exclude(name__in=selected).all(),
         )
         return regions
 
@@ -676,11 +681,23 @@ class MarketsTopicLandingPage(
         )
         return sectors
 
+    def get_trading_bloc_list(self, request):
+        selected = set(request.GET.getlist(self.TRADING_BLOC_QUERYSTRING_NAME))
+        # chain unselected items queryset onto selected items queryset to sort selected items ahead of unselected
+        trading_blocs = chain(
+            PersonalisationTradingBlocTag.objects.order_by('name').filter(name__in=selected).all(),
+            PersonalisationTradingBlocTag.objects.order_by('name').exclude(name__in=selected).all(),
+        )
+        return trading_blocs
+
     def get_selected_sectors(self, request) -> list:
         return request.GET.getlist(self.SECTOR_QUERYSTRING_NAME)
 
     def get_selected_regions(self, request) -> list:
         return request.GET.getlist(self.REGION_QUERYSTRING_NAME)
+
+    def get_selected_trading_blocs(self, request) -> list:
+        return request.GET.getlist(self.TRADING_BLOC_QUERYSTRING_NAME)
 
     def get_context(self, request):
         context = super().get_context(request)
@@ -691,12 +708,15 @@ class MarketsTopicLandingPage(
         context['sortby'] = self._get_sortby(request)
 
         context['sector_list'] = self.get_sector_list(request)
-        context['regions_list'] = self.get_regions_list(request)
+        context['region_list'] = self.get_regions_list(request)
+        context['trading_bloc_list'] = self.get_trading_bloc_list(request)
 
         context['selected_sectors'] = self.get_selected_sectors(request)
         context['selected_regions'] = self.get_selected_regions(request)
+        context['selected_trading_blocs'] = self.get_selected_trading_blocs(request)
 
         context['number_of_regions'] = len(context['selected_regions'])
+        context['number_of_trading_blocs'] = len(context['selected_trading_blocs'])
 
         context['paginated_results'] = paginated_results
         context['number_of_results'] = relevant_markets.count()

--- a/domestic/models.py
+++ b/domestic/models.py
@@ -668,8 +668,14 @@ class MarketsTopicLandingPage(
         selected = set(request.GET.getlist(self.REGION_QUERYSTRING_NAME))
         # chain unselected items queryset onto selected items queryset to sort selected items ahead of unselected
         regions = chain(
-            PersonalisationRegionTag.objects.order_by('name').filter(name__in=selected).all(),
-            PersonalisationRegionTag.objects.order_by('name').exclude(name__in=selected).all(),
+            PersonalisationRegionTag.objects.order_by('name')
+            .filter(name__in=selected)
+            .filter(models.Exists(RegionTaggedCountryGuidePage.objects.filter(tag_id=models.OuterRef('id'))))
+            .all(),
+            PersonalisationRegionTag.objects.order_by('name')
+            .exclude(name__in=selected)
+            .filter(models.Exists(RegionTaggedCountryGuidePage.objects.filter(tag_id=models.OuterRef('id'))))
+            .all(),
         )
         return regions
 
@@ -685,8 +691,14 @@ class MarketsTopicLandingPage(
         selected = set(request.GET.getlist(self.TRADING_BLOC_QUERYSTRING_NAME))
         # chain unselected items queryset onto selected items queryset to sort selected items ahead of unselected
         trading_blocs = chain(
-            PersonalisationTradingBlocTag.objects.order_by('name').filter(name__in=selected).all(),
-            PersonalisationTradingBlocTag.objects.order_by('name').exclude(name__in=selected).all(),
+            PersonalisationTradingBlocTag.objects.order_by('name')
+            .filter(name__in=selected)
+            .filter(models.Exists(TradingBlocTaggedCountryGuidePage.objects.filter(tag_id=models.OuterRef('id'))))
+            .all(),
+            PersonalisationTradingBlocTag.objects.order_by('name')
+            .exclude(name__in=selected)
+            .filter(models.Exists(TradingBlocTaggedCountryGuidePage.objects.filter(tag_id=models.OuterRef('id'))))
+            .all(),
         )
         return trading_blocs
 

--- a/domestic/templates/domestic/topic_landing_pages/markets.html
+++ b/domestic/templates/domestic/topic_landing_pages/markets.html
@@ -59,7 +59,7 @@
                                         <label for="regions" role="button">World regions</label>
                                         <div class="options checkbox-small full-height">
                                             <ul>
-                                                {% for region in regions_list %}
+                                                {% for region in region_list %}
                                                     <li class="multiple-choice margin-bottom-0">
                                                         <input type="checkbox"
                                                                value="{{ region.name }}"
@@ -67,6 +67,24 @@
                                                                name="region"
                                                                {% if region.name in selected_regions %}checked{% endif %} />
                                                         <label class="market-filters-label" for="region_{{ region.id }}">{{ region.name|title }}</label>
+                                                    </li>
+                                                {% endfor %}
+                                            </ul>
+                                        </div>
+                                    </li>
+                                    <li class="filter-section">
+                                        <input type="checkbox" id="trading_blocs" checked />
+                                        <label for="trading_blocs" role="button">Trading blocs</label>
+                                        <div class="options checkbox-small full-height">
+                                            <ul>
+                                                {% for trading_bloc in trading_bloc_list %}
+                                                    <li class="multiple-choice margin-bottom-0">
+                                                        <input type="checkbox"
+                                                               value="{{ trading_bloc.name }}"
+                                                               id="trading_bloc_{{ trading_bloc.id }}"
+                                                               name="trading_bloc"
+                                                               {% if trading_bloc.name in selected_trading_blocs %}checked{% endif %} />
+                                                        <label class="market-filters-label" for="trading_bloc_{{ trading_bloc.id }}">{{ trading_bloc.name|title }}</label>
                                                     </li>
                                                 {% endfor %}
                                             </ul>
@@ -108,7 +126,7 @@
                                             </p>
                                         {% endif %}
                                     {% else %}
-                                        {% if selected_sectors or selected_regions %}
+                                        {% if selected_sectors or selected_regions or selected_trading_blocs %}
                                             <h3 class="margin-bottom-15">
                                                 There {{ number_of_results|pluralize:"is,are" }} {{ number_of_results }} market{{ number_of_results|pluralize:",s" }}
                                                 {% if selected_sectors %}
@@ -124,7 +142,25 @@
                                                     {% for region in selected_regions %}
                                                         <span class="bold">{{ region }}</span>
                                                         {% if not forloop.last %}or{% endif %}
-                                                        {% if forloop.last %}region{{ number_of_regions|pluralize:",s" }}.{% endif %}
+                                                        {% if forloop.last %}
+                                                            region{{ number_of_regions|pluralize:",s" }}
+                                                            {% if selected_trading_blocs %}
+                                                            {% else %}
+                                                                .
+                                                            {% endif %}
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                {% endif %}
+                                                {% if selected_trading_blocs %}
+                                                    {% if selected_regions %}
+                                                        and the
+                                                    {% else %}
+                                                        in the
+                                                    {% endif %}
+                                                    {% for trading_bloc in selected_trading_blocs %}
+                                                        <span class="bold">{{ trading_bloc }}</span>
+                                                        {% if not forloop.last %}or{% endif %}
+                                                        {% if forloop.last %}trading bloc{{ number_of_trading_blocs|pluralize:",s" }}.{% endif %}
                                                     {% endfor %}
                                                 {% endif %}
                                             </h3>

--- a/domestic/templates/domestic/topic_landing_pages/markets.html
+++ b/domestic/templates/domestic/topic_landing_pages/markets.html
@@ -143,10 +143,10 @@
                                                         <span class="bold">{{ region }}</span>
                                                         {% if not forloop.last %}or{% endif %}
                                                         {% if forloop.last %}
-                                                            region{{ number_of_regions|pluralize:",s" }}
-                                                            {% if selected_trading_blocs %}
+                                                            {% if not selected_trading_blocs %}
+                                                                region{{ number_of_regions|pluralize:",s" }}.
                                                             {% else %}
-                                                                .
+                                                                region{{ number_of_regions|pluralize:",s" }}
                                                             {% endif %}
                                                         {% endif %}
                                                     {% endfor %}


### PR DESCRIPTION
## What
This PR updates the markets landing page to use the new region tag and trade bloc tag fields on the country guide page model. This is a simple extension of the original implementation.
## Why
The new list of official region tags is much shorter and is missing redundant regions like Antarctica. And the trading bloc filters allow users with a trading bloc in mind to narrow down results that way.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/ET-420
- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/ET-419
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.


### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
