### PR TITLE
IGUK-477 set max length on autocomplete

### DIFF
--- a/international_online_offer/templates/eyb/triage/find_your_company.html
+++ b/international_online_offer/templates/eyb/triage/find_your_company.html
@@ -183,6 +183,8 @@
 
                 setTypeAheadInitialValue()
 
+                document.querySelector('#js-company-name-autocomplete').setAttribute('maxlength', 30)
+
                 document.querySelector('#js-company-name-autocomplete').addEventListener('focus', ()=>{
                     retrieveDNBCompanies = true
                 })


### PR DESCRIPTION
## What
Sets the max. length on the Company Lookup autocomplete to 30 characters. 
## Why
Calling the Dun and Bradstreet typeahead API with more than 30 characters results in an `HTTP 400 bad request` error. For example, [this Sentry error](https://sentry.ci.uktrade.digital/organizations/dit/issues/135362/?environment=prod&project=173&referrer=alert_email).

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-477
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

In a PR without this fix, e.g. UAT, navigate to `international/expand-your-business-in-the-uk/find-your-company`. Enter more than 30 characters. No error will be visible in the UI but will throw an error server-side which is captured by Sentry.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
