### PR TITLE
IGUK-477 bug fix on typeahead for countries with an ISO code > 2 chars

### DIFF
--- a/international_online_offer/templates/eyb/triage/find_your_company.html
+++ b/international_online_offer/templates/eyb/triage/find_your_company.html
@@ -120,7 +120,10 @@
                 }
 
                 async function suggest (query, populateResults) {
-                    let queryParams = `searchTerm=${query}&countryISOAlpha2Code=${country}&candidateMaximumQuantity=25`;
+                    // some countries in dnb listed under a truncated iso2 code,
+                    // see https://directplus.documentation.dnb.com/html/resources/CountryCodes.html
+                    let countryISO2 = country.substring(0, 2)
+                    let queryParams = `searchTerm=${query}&countryISOAlpha2Code=${countryISO2}&candidateMaximumQuantity=25`;
                     // only make api call if we are going to show results
                     if (retrieveDNBCompanies == true) {
                         r = await fetch(`${typeaheadURL}?${queryParams}`);


### PR DESCRIPTION
## What
Only send the first two characters of a supported Country code to the Dun and Bradstreet typeahead API. Addresses this [Sentry error](https://sentry.ci.uktrade.digital/organizations/dit/issues/135362/activity/?project=173&referrer=RegressionActivityEmail).
## Why
Some of the ISO-2 codes of Countries supported within EYB contain > 2 characters, for example `('AE-AZ', 'Abu Dhabi')`. The Dun and Bradstreet Typeahead API returns a `400 bad request` error when > 2 characters are sent in the `countryISOAlpha2Code` query parameter. The recommendation from Dun and Bradstreet is that in these scenarios we simply send the first two characters [source](https://directplus.documentation.dnb.com/html/resources/CountryCodes.html).

A [tech. debt ticket]( https://uktrade.atlassian.net/browse/IGUK-477) has been raised to implement the remaining mappings where the Country used in Dun and Bradstreet does not correspond to the first two characters of the ISO code. For example, when calling the Typeahead API for Guernsey (`GG`), the code for United Kingdom (`GB`) should be used.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-477
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
