### PR TITLE
New region and trading bloc filters

### DIFF
--- a/core/fixtures/market-guide-sector-tags.csv
+++ b/core/fixtures/market-guide-sector-tags.csv
@@ -1,0 +1,384 @@
+Market,Sector
+Algeria,Energy
+Algeria,Education and training
+Algeria,"Agriculture, horticulture, fisheries and pets"
+Argentina,"Agriculture, horticulture, fisheries and pets"
+Argentina,Energy
+Argentina,Mining
+Argentina,Railways
+Argentina,Security
+Australia,Financial and professional services
+Australia,Technology and smart cities
+Australia,Railways
+Australia,Airports
+Australia,Security
+Australia,Automotive
+Australia,Food and drink
+Australia,Advanced engineering
+Australia,Pharmaceuticals and biotechnology
+Austria,Pharmaceuticals and biotechnology
+Austria,Financial and professional services
+Austria,Railways
+Austria,Airports
+Bahrain,Financial and professional services
+Bahrain,Education and training
+Bahrain,Healthcare services
+Bahrain,Construction
+Bahrain,Energy
+Belgium,Energy
+Belgium,Food and drink
+Belgium,Technology and smart cities
+Bosnia and Herzegovina,Pharmaceuticals and biotechnology
+Bosnia and Herzegovina,Construction
+Bosnia and Herzegovina,Energy
+Brazil,Healthcare services
+Brazil,Pharmaceuticals and biotechnology
+Brazil,Energy
+Brazil,Financial and professional services
+Brazil,Education and training
+Brazil,Aerospace
+Brunei,Energy
+Brunei,Education and training
+Brunei,Financial and professional services
+Bulgaria,Security
+Bulgaria,Energy
+Bulgaria,Construction
+Bulgaria,Healthcare services
+Bulgaria,Railways
+Bulgaria,Technology and smart cities
+Canada,Aerospace
+Canada,Food and drink
+Chile,Mining
+Chile,Construction
+Chile,Technology and smart cities
+Chile,Energy
+Chile,"Agriculture, horticulture, fisheries and pets"
+China,Financial and professional services
+China,Consumer and retail
+China,Technology and smart cities
+China,Education and training
+China,Healthcare services
+China,Pharmaceuticals and biotechnology
+Columbia,Railways
+Columbia,Construction
+Columbia,Energy
+Columbia,Pharmaceuticals and biotechnology
+Columbia,Healthcare services
+Costa Rica,Pharmaceuticals and biotechnology
+Costa Rica,Railways
+Costa Rica,Maritime
+Costa Rica,Technology and smart cities
+Costa Rica,Security
+Costa Rica,Energy
+Croatia,Energy
+Croatia,Railways
+Croatia,Maritime
+Croatia,Logistics
+Croatia,Consumer and retail
+Croatia,Technology and smart cities
+Cyprus,Energy
+Cyprus,Environment
+Czech Republic,Energy
+Czech Republic,Construction
+Czech Republic,Railways
+Czech Republic,Consumer and retail
+Denmark,Advanced engineering
+Denmark,Railways
+Denmark,Energy
+Denmark,Healthcare services
+Denmark,Security
+Denmark,Technology and smart cities
+Denmark,Maritime
+Dominican Republic,Food and drink
+Dominican Republic,Construction
+Dominican Republic,Railways
+Dominican Republic,Energy
+Dominican Republic,"Agriculture, horticulture, fisheries and pets"
+Dominican Republic,Education and training
+Dominican Republic,Healthcare services
+Egypt,Education and training
+Egypt,Energy
+Egypt,Healthcare services
+Egypt,Construction
+Egypt,Railways
+Egypt,Water
+El Salvador,Energy
+El Salvador,Security
+El Salvador,Construction
+Estonia,Technology and smart cities
+Estonia,Energy
+Estonia,Railways
+Estonia,Healthcare services
+Finland,Technology and smart cities
+Finland,Energy
+Finland,Financial and professional services
+France,Energy
+France,Food and drink
+France,Advanced engineering
+France,Technology and smart cities
+France,Construction
+France,Railways
+France,Consumer and retail
+Germany,Food and drink
+Germany,Technology and smart cities
+Germany,Energy
+Germany,Healthcare services
+Germany,Consumer and retail
+Ghana,Energy
+Ghana,Financial and professional services
+Ghana,Railways
+Ghana,Maritime
+Ghana,Construction
+Ghana,Water
+Ghana,"Agriculture, horticulture, fisheries and pets"
+Ghana,Healthcare services
+Ghana,Mining
+Guatemala,Automotive
+Guatemala,"Agriculture, horticulture, fisheries and pets"
+Guatemala,Education and training
+Honduras,Energy
+"Hong Kong, China",Education and training
+"Hong Kong, China",Financial and professional services
+"Hong Kong, China",Food and drink
+"Hong Kong, China",Healthcare services
+"Hong Kong, China",Technology and smart cities
+"Hong Kong, China",Energy
+Hungary,Energy
+Hungary,Pharmaceuticals and biotechnology
+India,Technology and smart cities
+India,Financial and professional services
+India,Automotive
+Indonesia,Railways
+Indonesia,Airports
+Indonesia,Automotive
+Indonesia,Education and training
+Indonesia,Energy
+Indonesia,Food and drink
+Indonesia,Healthcare services
+Ireland,Pharmaceuticals and biotechnology
+Ireland,Construction
+Ireland,"Agriculture, horticulture, fisheries and pets"
+Ireland,Energy
+Israel,Technology and smart cities
+Israel,Pharmaceuticals and biotechnology
+Israel,Food and drink
+Italy,Security
+Italy,Technology and smart cities
+Italy,Healthcare services
+Italy,Pharmaceuticals and biotechnology
+Italy,Aerospace
+Italy,Advanced engineering
+Ivory Coast (The Republic of Côte D’Ivoire),"Agriculture, horticulture, fisheries and pets"
+Ivory Coast (The Republic of Côte D’Ivoire),Energy
+Ivory Coast (The Republic of Côte D’Ivoire),Mining
+Jamaica,Healthcare services
+Jamaica,Technology and smart cities
+Jamaica,Energy
+Japan,Technology and smart cities
+Japan,Food and drink
+Japan,Consumer and retail
+Jordan,Energy
+Jordan,Technology and smart cities
+Jordan,Water
+Jordan,Education and training
+Kenya,Healthcare services
+Kenya,Advanced engineering
+Kosovo,Financial and professional services
+Kosovo,Railways
+Kosovo,Airports
+Kosovo,Mining
+Kosovo,Technology and smart cities
+Kosovo,Energy
+Latvia,Railways
+Latvia,Construction
+Latvia,Energy
+Latvia,Education and training
+Latvia,Technology and smart cities
+Lithuania,Railways
+Lithuania,Maritime
+Lithuania,Energy
+Lithuania,Technology and smart cities
+Malaysia,Education and training
+Malaysia,Technology and smart cities
+Malaysia,Healthcare services
+Mauritius,Education and training
+Mauritius,Financial and professional services
+Mauritius,Maritime
+Mauritius,Energy
+Mauritius,Healthcare services
+Mexico,Automotive
+Mexico,Advanced engineering
+Mexico,Food and drink
+Mexico,Education and training
+Mexico,Pharmaceuticals and biotechnology
+Mexico,Healthcare services
+Mexico,Energy
+Mexico,Financial and professional services
+Mongolia,Mining
+Mongolia,Energy
+Mongolia,"Agriculture, horticulture, fisheries and pets"
+Mongolia,Education and training
+Morocco,Railways
+Morocco,Airports
+Morocco,Construction
+Morocco,Education and training
+Morocco,Healthcare services
+New Zealand,Financial and professional services
+New Zealand,Technology and smart cities
+New Zealand,"Agriculture, horticulture, fisheries and pets"
+New Zealand,Advanced engineering
+New Zealand,Railways
+New Zealand,Construction
+New Zealand,Water
+New Zealand,Food and drink
+Nicaragua,Education and training
+Nicaragua,Construction
+Nicaragua,"Agriculture, horticulture, fisheries and pets"
+Nicaragua,Energy
+Nicaragua,Technology and smart cities
+Nigeria,Energy
+Nigeria,Financial and professional services
+Nigeria,Construction
+Nigeria,"Agriculture, horticulture, fisheries and pets"
+Norway,Energy
+Norway,Railways
+Norway,Construction
+Norway,Automotive
+Norway,Security
+Norway,Food and drink
+Norway,Technology and smart cities
+Oman,Energy
+Oman,Mining
+Oman,Security
+Oman,Technology and smart cities
+Oman,Logistics
+Oman,Healthcare services
+Panama,Pharmaceuticals and biotechnology
+Panama,Education and training
+Panama,Energy
+Panama,Security
+Paraguay,"Agriculture, horticulture, fisheries and pets"
+Paraguay,Food and drink
+Paraguay,Railways
+Paraguay,Water
+Paraguay,Construction
+Paraguay,Technology and smart cities
+Peru,Mining
+Peru,Energy
+Peru,Pharmaceuticals and biotechnology
+Peru,Security
+Philippines,Railways
+Philippines,Airports
+Philippines,Water
+Philippines,Education and training
+Philippines,Technology and smart cities
+Philippines,Healthcare services
+Philippines,Security
+Portugal,Financial and professional services
+Portugal,Pharmaceuticals and biotechnology
+Portugal,Technology and smart cities
+Portugal,Mining
+Portugal,Energy
+Qatar,Sports economy
+Qatar,Energy
+Qatar,Technology and smart cities
+Qatar,Construction
+Qatar,Healthcare services
+Qatar,Security
+Romania,Railways
+Romania,Maritime
+Romania,Automotive
+Romania,Healthcare services
+Romania,Pharmaceuticals and biotechnology
+Romania,Energy
+Romania,Security
+Romania,Consumer and retail
+Saudi Arabia,Energy
+Saudi Arabia,Education and training
+Saudi Arabia,Healthcare services
+Saudi Arabia,Financial and professional services
+Saudi Arabia,Consumer and retail
+Serbia,Automotive
+Serbia,Energy
+Serbia,Mining
+Serbia,Consumer and retail
+Singapore,Financial and professional services
+Singapore,Technology and smart cities
+Singapore,Logistics
+Singapore,Energy
+Singapore,Healthcare services
+Singapore,Maritime
+Slovakia,Automotive
+Slovakia,Healthcare services
+Slovakia,Financial and professional services
+Slovenia,Railways
+Slovenia,Energy
+South Korea,Aerospace
+South Korea,Automotive
+South Korea,Pharmaceuticals and biotechnology
+South Korea,Maritime
+South Korea,Energy
+South Korea,Technology and smart cities
+Sweden,Construction
+Sweden,Railways
+Sweden,Consumer and retail
+Sweden,Food and drink
+Sweden,Energy
+Sweden,Technology and smart cities
+Sweden,Pharmaceuticals and biotechnology
+Switzerland,Pharmaceuticals and biotechnology
+Switzerland,Security
+Switzerland,Advanced engineering
+Switzerland,Consumer and retail
+Taiwan,Energy
+Taiwan,Technology and smart cities
+Taiwan,Financial and professional services
+Taiwan,Consumer and retail
+Taiwan,Education and training
+Thailand,Automotive
+Thailand,Technology and smart cities
+Thailand,Healthcare services
+Thailand,"Agriculture, horticulture, fisheries and pets"
+Thailand,Food and drink
+Thailand,Education and training
+The Netherlands,Food and drink
+The Netherlands,Energy
+The Netherlands,Technology and smart cities
+The Netherlands,Financial and professional services
+Trinidad and Tobago,Pharmaceuticals and biotechnology
+Trinidad and Tobago,Healthcare services
+Trinidad and Tobago,Security
+Trinidad and Tobago,Energy
+Turkey,Pharmaceuticals and biotechnology
+Turkey,Healthcare services
+Turkey,Advanced engineering
+Turkey,Energy
+Turkey,Security
+Turkey,Construction
+Turkey,Railways
+Turkey,Airports
+Turkey,Water
+United Arab Emirates,Education and training
+United Arab Emirates,Energy
+United Arab Emirates,Financial and professional services
+United Arab Emirates,Healthcare services
+United Arab Emirates,Pharmaceuticals and biotechnology
+United Arab Emirates,Technology and smart cities
+United Arab Emirates,Security
+United Arab Emirates,Space
+United States,Food and drink
+United States,Technology and smart cities
+United States,Pharmaceuticals and biotechnology
+Uruguay,Energy
+Uruguay,Healthcare services
+Uruguay,Pharmaceuticals and biotechnology
+Uruguay,Technology and smart cities
+Vietnam,Education and training
+Vietnam,Energy
+Vietnam,Railways
+Vietnam,Aerospace
+Vietnam,Healthcare services
+Vietnam,Technology and smart cities
+Zimbabwe,"Agriculture, horticulture, fisheries and pets"
+Zimbabwe,Mining
+Zimbabwe,Energy

--- a/core/management/commands/ingest_market_guide_sector_tags.py
+++ b/core/management/commands/ingest_market_guide_sector_tags.py
@@ -1,0 +1,27 @@
+import csv
+from io import StringIO
+
+from django.conf import settings
+from django.core.management import BaseCommand
+
+from core.models import SectorTag
+from domestic.models import CountryGuidePage, SectorTaggedCountryGuidePage
+
+
+class Command(BaseCommand):
+    help = 'Tags market guides against region and trading bloc'
+
+    def handle(self, *args, **options):
+        with open(
+            settings.ROOT_DIR / 'core/fixtures/market-guide-sector-tags.csv',
+            'r',
+            encoding='utf-8',
+        ) as f:
+            for row in csv.DictReader(StringIO(f.read()), delimiter=','):
+                if CountryGuidePage.objects.filter(heading=row['Market']).exists():
+                    page_id = CountryGuidePage.objects.filter(heading=row['Market'])[0].id
+                    sector_tag_id = SectorTag.objects.filter(name=row['Sector'])[0].id
+                    SectorTaggedCountryGuidePage.objects.create(content_object_id=page_id, tag_id=sector_tag_id)
+                else:
+                    self.stdout.write('Failed to find country guide page titled ' + row['Market'])
+            self.stdout.write(self.style.SUCCESS('Sectors migrated'))

--- a/domestic/fixtures/markets_filtering_fixtures.json
+++ b/domestic/fixtures/markets_filtering_fixtures.json
@@ -2033,5 +2033,25 @@
       "slug": "united-kingdom",
       "region": 440
     }
+  },
+  {
+    "model": "core.personalisationregiontag",
+    "pk": 1,
+    "fields": { "name": "Latin America and Caribbean", "slug": "latin-america-and-caribbean" }
+  },
+  {
+    "model": "core.personalisationregiontag",
+    "pk": 2,
+    "fields": { "name": "Asia Pacific", "slug": "asia-pacific" }
+  },
+  {
+    "model": "core.personalisationregiontag",
+    "pk": 3,
+    "fields": { "name": "Europe", "slug": "europe" }
+  },
+  {
+    "model": "core.personalisationregiontag",
+    "pk": 4,
+    "fields": { "name": "North America", "slug": "north-america" }
   }
 ]

--- a/domestic/templates/domestic/topic_landing_pages/markets.html
+++ b/domestic/templates/domestic/topic_landing_pages/markets.html
@@ -59,7 +59,7 @@
                                         <label for="regions" role="button">World regions</label>
                                         <div class="options checkbox-small full-height">
                                             <ul>
-                                                {% for region in regions_list %}
+                                                {% for region in region_list %}
                                                     <li class="multiple-choice margin-bottom-0">
                                                         <input type="checkbox"
                                                                value="{{ region.name }}"
@@ -67,6 +67,24 @@
                                                                name="region"
                                                                {% if region.name in selected_regions %}checked{% endif %} />
                                                         <label class="market-filters-label" for="region_{{ region.id }}">{{ region.name|title }}</label>
+                                                    </li>
+                                                {% endfor %}
+                                            </ul>
+                                        </div>
+                                    </li>
+                                    <li class="filter-section">
+                                        <input type="checkbox" id="trading_blocs" checked />
+                                        <label for="trading_blocs" role="button">Trading blocs</label>
+                                        <div class="options checkbox-small full-height">
+                                            <ul>
+                                                {% for trading_bloc in trading_bloc_list %}
+                                                    <li class="multiple-choice margin-bottom-0">
+                                                        <input type="checkbox"
+                                                               value="{{ trading_bloc.name }}"
+                                                               id="trading_bloc_{{ trading_bloc.id }}"
+                                                               name="trading_bloc"
+                                                               {% if trading_bloc.name in selected_trading_blocs %}checked{% endif %} />
+                                                        <label class="market-filters-label" for="trading_bloc_{{ trading_bloc.id }}">{{ trading_bloc.name|title }}</label>
                                                     </li>
                                                 {% endfor %}
                                             </ul>
@@ -108,7 +126,7 @@
                                             </p>
                                         {% endif %}
                                     {% else %}
-                                        {% if selected_sectors or selected_regions %}
+                                        {% if selected_sectors or selected_regions or selected_trading_blocs %}
                                             <h3 class="margin-bottom-15">
                                                 There {{ number_of_results|pluralize:"is,are" }} {{ number_of_results }} market{{ number_of_results|pluralize:",s" }}
                                                 {% if selected_sectors %}
@@ -124,7 +142,25 @@
                                                     {% for region in selected_regions %}
                                                         <span class="bold">{{ region }}</span>
                                                         {% if not forloop.last %}or{% endif %}
-                                                        {% if forloop.last %}region{{ number_of_regions|pluralize:",s" }}.{% endif %}
+                                                        {% if forloop.last %}
+                                                            {% if not selected_trading_blocs %}
+                                                                region{{ number_of_regions|pluralize:",s" }}.
+                                                            {% else %}
+                                                                region{{ number_of_regions|pluralize:",s" }}
+                                                            {% endif %}
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                {% endif %}
+                                                {% if selected_trading_blocs %}
+                                                    {% if selected_regions %}
+                                                        and the
+                                                    {% else %}
+                                                        in the
+                                                    {% endif %}
+                                                    {% for trading_bloc in selected_trading_blocs %}
+                                                        <span class="bold">{{ trading_bloc }}</span>
+                                                        {% if not forloop.last %}or{% endif %}
+                                                        {% if forloop.last %}trading bloc{{ number_of_trading_blocs|pluralize:",s" }}.{% endif %}
                                                     {% endfor %}
                                                 {% endif %}
                                             </h3>

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -175,3 +175,4 @@ international_investment/migrations/0004_investmentopportunityarticlepage.py
 tests/unit/international_investment_support_directory/test_forms.py
 core/fixtures/countries-territories-and-regions-5.35-custom-export-OFFICIAL.csv
 core/fixtures/countries-and-territories-trading-blocs-25.0-custom-export-OFFICIAL.csv
+core/fixtures/market-guide-sector-tags.csv


### PR DESCRIPTION
## What
This PR updates the markets landing page to use the new region tag and trade bloc tag fields on the country guide page model. This is a simple extension of the original implementation.
## Why
The new list of official region tags is much shorter and is missing redundant regions like Antarctica. And the trading bloc filters allow users with a trading bloc in mind to narrow down results that way.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/ET-420
- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/ET-419
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.


### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
