### PR TITLE
Fix HCSAT combine command to persist original creation date

### DIFF
--- a/core/management/commands/combine_hcsat.py
+++ b/core/management/commands/combine_hcsat.py
@@ -27,6 +27,9 @@ class Command(BaseCommand):
             for hcsat in model.objects.all():
                 serialized_obj = serialize_hcsat(hcsat)
                 object, created = HCSAT.objects.get_or_create(**serialized_obj)
+                # Even though 'created' is passed through above it gets overwritten, so fix here for reporting
+                object.created = serialized_obj['created']
+                object.save()
                 if created:
                     self.stdout.write(self.style.SUCCESS('New obj created'))
                 else:


### PR DESCRIPTION
## What
<What is this PR doing, e.g. implementations, algorithms, etc.?>
update to management command to persist original created timestamp from old hcsat tables into new one
## Why
<Why is this change happening, e.g. goals, use cases, stories, etc.?>
The creation of the new table entry was overwriting the previous 'created' date and making it seem in reporting like all hcsat's came in on the same day and impacting quarterly progress reporting. This will fix that issue. 

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-378
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help


### Housekeeping

- [x] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [x] Frontend assets have been re-compiled
- [x] Checked for potential security vulnerabilities
- [x] Ensured any sensitive data is handled appropriately

### Performance
- [x] Evaluated the performance impact of the changes
- [x] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
