### PR TITLE
GRTLV-383-ltr direction added for play button

### DIFF
--- a/core/templates/microsites/includes/microsite_detail_content.html
+++ b/core/templates/microsites/includes/microsite_detail_content.html
@@ -20,7 +20,7 @@
                                 <source src="{{ source.src }}" type="{{ source.type }}">
                             {% endfor %}
                     </video>
-                    <div class="great-hero__video-control-container">
+                    <div class="great-hero__video-control-container" dir="ltr">
                         <button id="js-video-control" class="great-hero-video-control great-hero__video-control-pause" aria-pressed="false" aria-label="Pause video">
                             <span class="great-hero__video-control-icon">
                                 <span class="great-visually-hidden">Pause</span>


### PR DESCRIPTION
## What
Add ltr direction for div containing hero video play button
## Why
In rtl direction (arabic version of the site) the play button is malformed

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-383
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after
<img width="88" alt="Screenshot 2024-10-23 at 11 29 00" src="https://github.com/user-attachments/assets/596a43ac-deec-4256-8995-036c35c193fb">
<img width="82" alt="Screenshot 2024-10-23 at 11 28 48" src="https://github.com/user-attachments/assets/2db71710-d76c-4ccb-b1d6-107b65750d51">

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
