### PR TITLE
ET-551: guided journey - ukea events only future events

### DIFF
--- a/core/helpers.py
+++ b/core/helpers.py
@@ -855,7 +855,7 @@ def get_trade_barrier_count(market, sector):
 
 
 def get_ukea_events(all_events, market, sector):
-    events = all_events
+    events = all_events.filter(closed=False)
 
     market_and_sector_events = events.filter(
         country_tags__name__contains=market,


### PR DESCRIPTION
## What
Only show bookable ukea events to users
## Why
So that users only see ukea events they can attend

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
