### PR TITLE
IGUK-381 return empty string if country not found

### DIFF
--- a/international_online_offer/services.py
+++ b/international_online_offer/services.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Tuple
 
+from rest_framework import status
+
 from directory_api_client import api_client
 from international_online_offer.core import regions
 from international_online_offer.core.professions import (
@@ -171,5 +173,10 @@ def get_countries_regions_territories():
 
 def get_country_display_name(iso2_code: str) -> str:
     response = api_client.dataservices.get_country_territory_region(iso2_code)
-    data = response.json()
-    return data['name']
+    country_display_name = ''
+
+    if response.status_code == status.HTTP_200_OK:
+        data = response.json()
+        country_display_name = data['name']
+
+    return country_display_name

--- a/tests/unit/international_online_offer/test_services.py
+++ b/tests/unit/international_online_offer/test_services.py
@@ -164,3 +164,12 @@ def test_get_countries_regions_territories(mock_get_countries_regions_territorie
 def test_get_country_region_territory(mock_get_country_region_territory):
     country_name = services.get_country_display_name('FJ')
     assert country_name == 'Fiji'
+
+
+@mock.patch(
+    'international_online_offer.services.api_client.dataservices.get_country_territory_region',
+    return_value=create_response(status_code=404),
+)
+def test_get_country_region_territory_404(mock_get_country_region_territory_404):
+    country_name = services.get_country_display_name('abcdefg')
+    assert country_name == ''


### PR DESCRIPTION
## What
Small bugfix for [this PR](https://github.com/uktrade/great-cms/pull/3607). Related [Sentry error](https://sentry.ci.uktrade.digital/organizations/dit/issues/138874/?environment=dev&project=173&referrer=alert_email).
## Why
In this line: https://github.com/uktrade/great-cms/blob/133d0526300229d5284d5438fbd37d384810d711/international_online_offer/views.py#L310 we call the `get_country_display_name` method which in turn makes an api request to get the display name of a country given an ISO2 code. There is an edge case whereby a user signs up with a regular Great account and navigates to EYB. In this case they do not have a UserData object and so the api is called with an empty string which returns a 404. This bug fix handles this scenario gracefully.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-281
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
