### PR TITLE
Feature grtlv 364 add values data layer

### DIFF
--- a/core/static/javascript/dit.tagging.js
+++ b/core/static/javascript/dit.tagging.js
@@ -70,25 +70,19 @@ dit.tagging.base = new function() {
 
         function sendVideoEvent(video, action) {
             var videoPercent = 0
+            var videoStatus = 'progress'
             const currentPercent = calculateVideoPercent(video[0]);
-                if (currentPercent >= 25 && currentPercent < 50)
-                    {
-                        action = 'progress'
-                        videoPercent = 25
-                    }
+                if (currentPercent < 25)
+                    videoPercent = 0;
+                else if (currentPercent >= 25 && currentPercent < 50)
+                        videoPercent = 25;
                 else if (currentPercent >= 50 && currentPercent < 75)
-                    {
-                        action = 'progress'
-                        videoPercent = 50
-                    }
-
+                        videoPercent = 50;
                 else if (currentPercent >= 75 && currentPercent < 100)
-                    {
-                        action = 'progress'
-                        videoPercent = 75
-                    }
+                        videoPercent = 75;
+
                 else {
-                        action = 'ended'
+                        videoStatus = 'ended'
                         videoPercent = 100
                     }
 
@@ -107,6 +101,7 @@ dit.tagging.base = new function() {
             }
             videoEvent['video_percent'] = videoPercent
             videoEvent['video_title'] = title
+            videoEvent['video_status'] = videoStatus
             sendEvent(videoEvent);
         }
 

--- a/core/static/javascript/dit.tagging.js
+++ b/core/static/javascript/dit.tagging.js
@@ -42,7 +42,8 @@ dit.tagging.base = new function() {
         }
 
         function addTaggingForVideos() {
-            $("#hero-campaign-section-watch-video-button").click(function() { sendVideoEvent($(this), 'play') });
+
+            $("#hero-campaign-section-watch-video-button").on('click',function() { sendVideoEvent($(this), 'play') });
             $('video')
                 .on('play', function() { sendVideoEvent($(this), 'play') })
                 .on('pause', function() { sendVideoEvent($(this), 'pause') })
@@ -63,11 +64,38 @@ dit.tagging.base = new function() {
             sendEvent(linkEvent(action, type, element, value, destination));
         }
 
+        function calculateVideoPercent(video) {
+            return Math.floor((video.currentTime / video.duration) * 100);
+        }
+
         function sendVideoEvent(video, action) {
+            var videoPercent = 0
+            const currentPercent = calculateVideoPercent(video[0]);
+                if (currentPercent >= 25 && currentPercent < 50)
+                    {
+                        action = 'progress'
+                        videoPercent = 25
+                    }
+                else if (currentPercent >= 50 && currentPercent < 75)
+                    {
+                        action = 'progress'
+                        videoPercent = 50
+                    }
+
+                else if (currentPercent >= 75 && currentPercent < 100)
+                    {
+                        action = 'progress'
+                        videoPercent = 75
+                    }
+                else {
+                        action = 'ended'
+                        videoPercent = 100
+                    }
+
             var type = video.data('ga-type') || 'video';
             var element = video.data('ga-element') || inferElement(video);
             var value = video.data('ga-value') || inferVideoValue(video);
-
+            var title = video.data('title')
             var videoEvent = event(action, type, element, value)
 
             if (video.length>0) {
@@ -77,6 +105,8 @@ dit.tagging.base = new function() {
             if (eventTitle) {
                 videoEvent['eventTitle'] = eventTitle.getAttribute('data-ga-event-title');
             }
+            videoEvent['video_percent'] = videoPercent
+            videoEvent['video_title'] = title
             sendEvent(videoEvent);
         }
 

--- a/core/templatetags/video_tags.py
+++ b/core/templatetags/video_tags.py
@@ -32,7 +32,7 @@ def render_video(block, event_name=None):  # noqa: C901
     video_transcript = getattr(block['video'], 'transcript', '')
 
     video = block['video']
-
+    video_title = video.title
     timestamp_to_allow_poster_image_to_work_on_mobile_safari = '#t=0.1'
 
     sources_data = []
@@ -101,7 +101,9 @@ def render_video(block, event_name=None):  # noqa: C901
     rendered = format_html(
         f"""
             <video preload="metadata" controls controlsList="nodownload"
-            {_get_poster_attribute(video)}{VIDEO_DURATION_DATA_ATTR_NAME}="{video_duration}">
+            {_get_poster_attribute(video)}
+            data-title="{video_title}"
+            {VIDEO_DURATION_DATA_ATTR_NAME}="{video_duration}">
                 {sources}
                 {subtitles}
                 Your browser does not support the video tag.

--- a/tests/unit/core/test_templatetags.py
+++ b/tests/unit/core/test_templatetags.py
@@ -19,6 +19,7 @@ from core.templatetags.content_tags import (
     extract_domain,
     get_backlinked_url,
     get_category_title_for_lesson,
+    get_exopps_country_slug,
     get_icon_path,
     get_inline_feedback_visibility,
     get_international_icon_path,
@@ -28,23 +29,22 @@ from core.templatetags.content_tags import (
     get_text_blocks,
     get_topic_blocks,
     get_topic_title_for_lesson,
+    get_visa_and_travel_country_slug,
     h3_if,
     handle_external_links,
     highlighted_text,
+    is_cheg_excluded_country,
     is_email,
     is_lesson_page,
     is_placeholder_page,
     make_bold,
     remove_bold_from_headings,
     show_feedback,
+    split_title,
     str_to_datetime,
     tag_text_mapper,
     url_type,
     val_to_int,
-    get_exopps_country_slug,
-    get_visa_and_travel_country_slug,
-    split_title,
-    is_cheg_excluded_country,
 )
 from core.templatetags.object_tags import get_item
 from core.templatetags.progress_bar import progress_bar
@@ -70,17 +70,19 @@ def test_render_video_tag__with_thumbnail():
         thumbnail=mock_thumbnail,
         subtitles=[],
         transcript='Transcript text',
+        title='File title',
     )
     block = dict(video=video_mock)
     html = render_video(block)
 
-    assert (
-        # Whitespace in this string is important for matching output
-        '<video preload="metadata" controls controlsList="nodownload"\n'
-        '            poster="https://example.com/thumb.png" data-v-duration="120">'
-    ) in html
+    assert '<video preload="metadata"' in html
+    assert 'controls controlsList="nodownload"' in html
+    assert 'poster="https://example.com/thumb.png"' in html
+    assert 'data-v-duration="120"' in html
+    assert 'data-title="File title"' in html
     assert '<source src="/media/foo.mp4#t=0.1" type="video/mp4">' in html
     assert 'Your browser does not support the video tag.' in html
+    assert 'Transcript text' in html
 
 
 def test_render_video_tag__without_thumbnail():
@@ -90,13 +92,17 @@ def test_render_video_tag__without_thumbnail():
         thumbnail=None,
         subtitles=[],
         transcript='Transcript text',
+        title='File title',
     )
     block = dict(video=video_mock)
     html = render_video(block)
-    # Whitespace in this string is important for matching output
-    assert '<video preload="metadata" controls controlsList="nodownload"\n            data-v-duration="120">' in html
+    assert '<video preload="metadata"' in html
+    assert 'controls controlsList="nodownload"' in html
+    assert 'data-v-duration="120"' in html
+    assert 'data-title="File title"' in html
     assert '<source src="/media/foo.mp4#t=0.1" type="video/mp4">' in html
     assert 'Your browser does not support the video tag.' in html
+    assert 'Transcript text' in html
 
 
 def test_render_video_tag__with_subtitles():
@@ -119,11 +125,14 @@ def test_render_video_tag__with_subtitles():
             },
         ],
         transcript='Transcript text',
+        title='File title',
     )
     block = dict(video=video_mock)
     html = render_video(block)
     # Whitespace in this string is important for matching output
-    assert '<video preload="metadata" controls controlsList="nodownload"\n            data-v-duration="120">' in html
+    assert '<video preload="metadata"' in html
+    assert 'controls controlsList="nodownload"' in html
+    assert 'data-v-duration="120"' in html
     assert '<source src="/media/foo.mp4#t=0.1" type="video/mp4">' in html
     assert 'Your browser does not support the video tag.' in html
     assert (
@@ -134,6 +143,8 @@ def test_render_video_tag__with_subtitles():
         '<track label="English"\n       kind="subtitles"\n       srclang="en"\n       src="/subtitles/123/en/content.vtt"'  # noqa:E501
         in html
     )
+    assert 'data-title="File title"' in html
+    assert 'Transcript text' in html
 
 
 def test_render_video_tag__without_title_or_event():


### PR DESCRIPTION
## What
Google Tag Manager needs to capture the percent of video , status and title when a user performs any action with the video on the pages.
## Why
Needed to analyse where user is stopping / watching the EA event videos.

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-364
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after
- [x] Documentation has been updated as necessary
![image](https://github.com/user-attachments/assets/98684099-d857-4a93-a1c0-91724e9074fb)


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
