### PR TITLE
re-add unsafe-unline to csp_script_src to re-enable inline js on site

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1022,6 +1022,7 @@ CSP_WORKER_SRC = ("'self'", "'unsafe-inline'", 'https:', 'blob:')  # noqa
 CSP_OBJECT_SRC = ("'none'",)  # noqa
 CSP_SCRIPT_SRC = (
     "'self'",
+    "'unsafe-inline'",
     "'unsafe-eval'",
     'https://www.google.com',
     'https://www.gstatic.com',


### PR DESCRIPTION
## What
Re-add unsafe-unline to csp_script_src in settings.py
## Why
<Why is this change happening, e.g. goals, use cases, stories, etc.?>
After making this initial change, inline js (react, signout etc) stopped working, so code refactors will be needed to move code out of insecure inline js before this change is re-introduced. 

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1191
- [x] A clear/description pull request messaged added.

### Housekeeping

### Security
- [x] Checked for potential security vulnerabilities
- [x] Ensured any sensitive data is handled appropriately

### Performance
- [x] Evaluated the performance impact of the changes
- [x] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
