### PR TITLE
adjusted safehosts to convert comma seperated string to a list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,5 +155,6 @@ core/components/static/stylesheets/maps/
 
 #Docker config file
 Dockerfile.dev
+constraints.txt
 
 .lighthouseci/

--- a/config/env.py
+++ b/config/env.py
@@ -22,7 +22,7 @@ class BaseSettings(PydanticBaseSettings):
     secret_key: str = 'fake_secret_key'
     app_environment: str = 'dev'
 
-    safelist_hosts: str = []
+    safelist_hosts: str = ''
 
     wagtail_cache: bool = False
     wagtail_cache_timout: int = 4 * 60 * 60  # 4 hours (in seconds)

--- a/config/settings.py
+++ b/config/settings.py
@@ -29,7 +29,7 @@ APP_ENVIRONMENT = env.app_environment
 # As the app is running behind a host-based router supplied by GDS PaaS, we can open ALLOWED_HOSTS
 ALLOWED_HOSTS = ['*']
 
-SAFELIST_HOSTS = env.safelist_hosts
+SAFELIST_HOSTS = [host.strip() for host in env.safelist_hosts.split(',')]
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#append-slash
 APPEND_SLASH = True


### PR DESCRIPTION
## What
We have had a lot of sentry logs with "Error: Host is not on the safe list for international URL". This is an issue from when we implemented pydantic as the env.py file is not parsing a comma separated string to a list correctly.

log example: https://sentry.ci.uktrade.digital/organizations/dit/issues/106309/?end=2024-11-09T22%3A00%3A59&environment=prod&project=173&query=is%3Aunresolved&start=2024-11-09T19%3A00%3A00&utc=true

## Why
Fixing this bug will stop this issue for Users and in Sentry

<img width="408" alt="Screenshot 2024-11-19 at 09 43 11" src="https://github.com/user-attachments/assets/22100160-459f-4e1c-b4a3-8013656cb947">


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREAT-1337
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Includes screenshot(s) - ideally before and after, but at least after


### Merging

- [x] This PR can be merged by reviewers.
