### PR TITLE
prevent caching of LTE article pages to fix LTE hcsat progression issues

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -766,7 +766,11 @@ class LessonPlaceholderPage(Page, mixins.AuthenticatedUserRequired if not settin
         return self._redirect_to_parent_module()
 
 
-class DetailPage(settings.FEATURE_DEA_V2 and CMSGenericPageAnonymous or CMSGenericPage, mixins.HCSATMixin):
+class DetailPage(
+    WagtailCacheMixin, settings.FEATURE_DEA_V2 and CMSGenericPageAnonymous or CMSGenericPage, mixins.HCSATMixin
+):
+    cache_control = 'no-cache'
+
     estimated_read_duration = models.DurationField(null=True, blank=True)
     parent_page_types = [
         'core.CuratedListPage',  # TEMPORARY: remove after topics refactor migration has run


### PR DESCRIPTION
…ed control is possible to cache only hcsat

## What
Disable caching of learn article pages, to allow hcsat to refresh correctly for non-javascript users
## Why
HCSAT form state was getting cached alongside the rest of the article page, preventing users from submitting a complete form. This allows hcsat submissions at the cost of losing caching on LTE article pages. I have had a good look into caching page snippets but don't have a working solution, so I'm pushing this out to resolve the issue on prod with a potential follow-up to cache only hcsat in the future. I will have a discussion with Hal about the trade-off of disabling caching for all users vs disabling this hcsat for non-js users, but resolving this issue until then seems sensible. 

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-404
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data -  submit hcsat on LTE on multiple browser sessions with js disabled


### Housekeeping

- [x] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security

- [x] Checked for potential security vulnerabilities


### Performance
- [x] Evaluated the performance impact of the changes
- [x] Ensured that changes do not negatively affect application scalability. - We will need to keep an eye on the number of LTE article accesses to check impact on site performance

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
