### PR TITLE
hide LTE HCSAT for non-javascript users

### DIFF
--- a/learn/templates/learn/detail_page.html
+++ b/learn/templates/learn/detail_page.html
@@ -98,7 +98,7 @@
     {% block body_inline_feedback %}{% endblock %}
     {% if not csat_complete %}
         <section id="hcsat_section"
-                 class="govuk-!-padding-bottom-6 great-bg-white clearfix govuk-!-margin-top-0 great-border-thin-top-lighter-blue">
+                 class="govuk-!-padding-bottom-6 great-bg-white clearfix govuk-!-margin-top-0 great-border-thin-top-lighter-blue great-hidden">
             <div class="container">
                 {% include 'core/includes/hcsat.html' with hcsat_form=hcsat_form hcsat_stage=hcsat_form_stage %}
             </div>
@@ -138,6 +138,8 @@
     <script src="{% static 'javascript/hcsat-feedback-form.js' %}"></script>
     <script>
         var csat_form = document.getElementById("hcsat_section")
+        // Hide for non-js users due to caching issues
+        csat_form.classList.remove('great-hidden') 
         //learn hcsat should only be shown on first article of session
         if (sessionStorage.csat_complete) {
             csat_form.classList.add('great-hidden')


### PR DESCRIPTION
## What
Initially hide hcsat on LTE articles, then show in js
## Why
Caching issues prevent this form from working on cached pages until a hcsat refactor can be performed. M&E have confirmed it's suitable to hide hcsat for only non-js users on these articles which is more suitable than uncaching all article pages. 

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-404
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.



### Security

- [x] Checked for potential security vulnerabilities
- [x] Ensured any sensitive data is handled appropriately

### Performance
- [x] Evaluated the performance impact of the changes
- [x] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
