### PR TITLE
Bug grtlv 402 snippet headers appearing as hyperlinks in content modules

### DIFF
--- a/core/templatetags/content_tags.py
+++ b/core/templatetags/content_tags.py
@@ -720,7 +720,7 @@ def is_cheg_excluded_country(country_code):
 
 
 def convert_anchor_identifier_a_to_span(input_html):
-    # find all <a> tags used as anchor identifiers, and replace with identical spans
+    # find all <a> tags used as anchor identifiers, and replace with spans of same id
     soup = BeautifulSoup(input_html, 'html.parser')
     for anchor in soup.find_all('a', attrs={'linktype': 'anchor-target'}):
         new_tag = soup.new_tag('span')

--- a/core/templatetags/content_tags.py
+++ b/core/templatetags/content_tags.py
@@ -719,28 +719,26 @@ def is_cheg_excluded_country(country_code):
     return False
 
 
-def convert_anchor_identifier_a_to_span(soup):
+def convert_anchor_identifier_a_to_span(input_html):
+    # find all <a> tags used as anchor identifiers, and replace with identical spans
+    soup = BeautifulSoup(input_html, 'html.parser')
     for anchor in soup.find_all('a', attrs={'linktype': 'anchor-target'}):
         new_tag = soup.new_tag('span')
-
-        # Replicate <a> attributes on span
-        new_tag.string = anchor.text
-        new_tag.id = anchor.id
+        # Replicate <a> attributes on span and replace
+        new_tag.string = anchor.string
         new_tag.attrs['data-id'] = anchor.attrs['data-id']
         new_tag.attrs['id'] = anchor.attrs['id']
-
         anchor.replace_with(new_tag)
     return mark_safe(str(soup))
 
 
 @register.filter
 def convert_anchor_identifiers_to_span(value):
-    # Issue only occurs in content_modules where render_a method in core/rich_text.py is not used
+    # Issue only occurs in content_modules where render_a method in core/rich_text.py does not fire, so return as-is
     if value.block_type != 'content_module':
         return value
-    rich_text_field = value.value.content
-    soup = BeautifulSoup(rich_text_field, 'html.parser')
-    return convert_anchor_identifier_a_to_span(soup)
+    rich_text_html = value.value.content
+    return convert_anchor_identifier_a_to_span(rich_text_html)
 
 
 @register.inclusion_tag('_cta_banner.html')

--- a/core/templatetags/content_tags.py
+++ b/core/templatetags/content_tags.py
@@ -719,6 +719,30 @@ def is_cheg_excluded_country(country_code):
     return False
 
 
+def convert_anchor_identifier_a_to_span(soup):
+    for anchor in soup.find_all('a', attrs={'linktype': 'anchor-target'}):
+        new_tag = soup.new_tag('span')
+
+        # Replicate <a> attributes on span
+        new_tag.string = anchor.text
+        new_tag.id = anchor.id
+        new_tag.attrs['data-id'] = anchor.attrs['data-id']
+        new_tag.attrs['id'] = anchor.attrs['id']
+
+        anchor.replace_with(new_tag)
+    return mark_safe(str(soup))
+
+
+@register.filter
+def convert_anchor_identifiers_to_span(value):
+    # Issue only occurs in content_modules where render_a method in core/rich_text.py is not used
+    if value.block_type != 'content_module':
+        return value
+    rich_text_field = value.value.content
+    soup = BeautifulSoup(rich_text_field, 'html.parser')
+    return convert_anchor_identifier_a_to_span(soup)
+
+
 @register.inclusion_tag('_cta_banner.html')
 def render_signup_cta(background=None, link=None):
     background_class = 'great-ds-cta-banner--bg-white'

--- a/domestic/templates/domestic/includes/streamfield.html
+++ b/domestic/templates/domestic/includes/streamfield.html
@@ -1,3 +1,4 @@
+{% load convert_anchor_identifiers_to_span from content_tags %}
 {% for block in streamfield_content %}
     {% if block.block_type == 'form' %}
         {% if form %}
@@ -21,7 +22,9 @@
             </div>
         {% endif %}
     {% else %}
-        <div class="block-text">{{ block }}</div>
+        <div class="block-text">
+            {{ block | convert_anchor_identifiers_to_span }}
+        </div>
     {% endif %}
 {% endfor %}
 {% block body_js %}

--- a/tests/unit/domestic/test_templatetags.py
+++ b/tests/unit/domestic/test_templatetags.py
@@ -19,6 +19,7 @@ from domestic.templatetags.component_tags import (
     persist_language,
     replace_underscores,
 )
+from core.templatetags.content_tags import convert_anchor_identifier_a_to_span
 from tests.unit.export_academy.factories import EventFactory
 
 
@@ -445,3 +446,17 @@ def test_get_market_widget_data(
     result = get_market_widget_data('Chinax')
 
     assert result is None
+
+
+def test_anchor_is_correctly_converted_to_span():
+    input_html = '<p data-block-key="123"><a data-id="anchor" id="anchor" linktype="anchor-target">anchor text</a></p>'
+    actual_output = convert_anchor_identifier_a_to_span(input_html)
+    expected_output = '<p data-block-key="123"><span data-id="anchor" id="anchor">anchor text</span></p>'
+    assert actual_output == expected_output
+
+
+def test_regular_link_is_not_converted_to_span():
+    input_html = '<p data-block-key="321"><a href="http://www.google.com">text for regular link</a></p>'
+    actual_output = convert_anchor_identifier_a_to_span(input_html)
+    expected_output = '<p data-block-key="321"><a href="http://www.google.com">text for regular link</a></p>'
+    assert actual_output == expected_output


### PR DESCRIPTION
## What
Adding a convert_anchor_identifiers_to_span filter which can be used on streamfields to convert anchor identifiers within content snippets into spans. When not used in a snippet this already occurs as intended, but the render_a method in core/rich_text.py does not fire when the anchor is used within snippets. 

## Why
Anchor identifiers in content snippets are being returned to the wagtail page as <a> tags, introducing unwanted styling and functionality to text which should only have an additional id. 

Screenshots: 
Before: 
<img width="853" alt="Screenshot 2024-12-05 at 09 24 05" src="https://github.com/user-attachments/assets/37521161-a7b1-47a2-9313-c4fa0ce0a74e">

After: 
<img width="483" alt="Screenshot 2024-12-05 at 09 24 17" src="https://github.com/user-attachments/assets/a1249064-15d8-446d-a976-c84dada6d6df">



_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-402
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after
- [x] Documentation has been updated as necessary
- [x] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.


### Housekeeping


- [x] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [x] Checked for potential security vulnerabilities
- [x] Ensured any sensitive data is handled appropriately

### Performance
- [x] Evaluated the performance impact of the changes
- [x] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
