### PR TITLE
Added base_url to context processor to use in profile.html

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -31,6 +31,7 @@ def env_vars(request):
     data['world_bank_url'] = settings.WORLD_BANK_URL
     data['data_world_bank_url'] = settings.DATA_WORLD_BANK_URL
     data['united_nations_url'] = settings.UNITED_NATIONS_URL
+    data['base_url'] = settings.BASE_URL
     return data
 
 

--- a/sso_profile/templates/business_profile/profile.html
+++ b/sso_profile/templates/business_profile/profile.html
@@ -18,7 +18,7 @@
                     {% if company.is_published %}
                         {% if company.is_published_find_a_supplier %}
                             <div>
-                                <a href="{{ services_urls.fas }}suppliers/{{ company.number }}/">View Find a Supplier profile</a>
+                                <a href="{{ base_url }}/international/buy-from-the-uk/find-a-supplier/supplier/{{ company.number }}/">View Find a Supplier profile</a>
                             </div>
                         {% endif %}
                         {% if company.is_published_investment_support_directory %}


### PR DESCRIPTION
## What
Link to view a business profile in find-a-supply leads to 404
## Why
We need to fix the url to the correct location in international.

I have added a new variable to the main context processor to give access to the project base_url. This will become useful in the near future when we clean up the templates.

To test:
1. create a new user
2. create a business profile
3. add a description
4. visit your directory-api instance admin url and manually verify the new business profile
5. return to the business profile in great and refresh the page. You should now see the 'View find a supplier' link
6. clicking the link should redirect you to the correct profile in /international

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1494
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Merging

- [x] This PR can be merged by reviewers.
