### PR TITLE
FEATURE-GRTLV-464: Update ga4 to be sent via middleware

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -120,6 +120,7 @@ MIDDLEWARE = [
     'core.middleware.StoreUserExpertiseMiddleware',
     'core.middleware.CheckGATags',
     'core.middleware.HHTPHeaderDisallowEmbeddingMiddleware',
+    'core.middleware.GA4TrackingMiddleware',
     # 'directory_sso_api_client.middleware.AuthenticationMiddleware',
     'great_components.middleware.NoCacheMiddlware',
     'csp.middleware.CSPMiddleware',
@@ -339,7 +340,7 @@ if DEBUG:
         'loggers': {
             'django.request': {
                 'handlers': ['console'],
-                'level': 'ERROR',
+                'level': 'INFO',
                 'propagate': True,
             },
             'mohawk': {


### PR DESCRIPTION
## What
Adding a new middleware to be run before all views to send GA4 server side and using a celery task to delay 
## Why
Previous implementation wasn't capturing across all the Views , hence adding it to middleware 

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-464
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
Server side UAT GA 
https://analytics.google.com/analytics/web/?authuser=0#/p470346173/reports/dashboard?params=_u..nav%3Dmaui%26_u.comparisonOption%3Ddisabled%26_u.date00%3D20241213%26_u.date01%3D20241216&r=lifecycle-engagement-overview&ruid=lifecycle-engagement-overview,life-cycle,engagement&collectionId=life-cycle


### Housekeeping

- [x] Added all new environment variables to Vault.

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
