### PR TITLE
Added cached_property to .stats() in CountryGuidePage to speed page l…

### DIFF
--- a/domestic/models.py
+++ b/domestic/models.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
 from django.http import Http404
+from django.utils.functional import cached_property
 from great_components.mixins import GA360Mixin  # /PS-IGNORE
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalManyToManyField
@@ -1147,7 +1148,7 @@ class CountryGuidePage(cms_panels.CountryGuidePagePanels, BaseContentPage):
 
         return ctas
 
-    @property
+    @cached_property
     def stats(self):
         iso2 = getattr(self.country, 'iso2', None)
 


### PR DESCRIPTION
…oading

## What
Market guide page load speeds a re poor across GOV PaaS and DBT PaaS. The cause is due multiple api calls being made to data-api via a Model method.


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1512
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
