### PR TITLE
Bug IGUK-777 Fixing workflow to send user to start of EYB triage when triage or user data null

### DIFF
--- a/international_online_offer/core/helpers.py
+++ b/international_online_offer/core/helpers.py
@@ -175,10 +175,8 @@ def get_spend_choices_by_currency(currency):
 
 
 def get_current_step(user_data, triage_data):
-    if not user_data:
+    if not user_data or not triage_data:
         return 'about-your-business'
-    if not triage_data:
-        return 'business-sector'
 
     find_your_company_step = ['company_name']
     if not user_data.duns_number:


### PR DESCRIPTION
## What
Bug IGUK-777 Fixing workflow to send user to start of EYB triage when triage or user data null
## Why
Issue found when user_data or triage_data is null. Sending user to business sector has unexpected issues. Sending user to start of triage in all situations fixes problems.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-777
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [x] Documentation has been updated as necessary
- [x] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [x] Checked for potential security vulnerabilities
- [x] Ensured any sensitive data is handled appropriately

### Performance
- [x] Evaluated the performance impact of the changes
- [x] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
