### PR TITLE
add conditional to only initialise hcsat javascript when hcsat form i…

### DIFF
--- a/sso_profile/templates/business_profile/profile.html
+++ b/sso_profile/templates/business_profile/profile.html
@@ -419,10 +419,12 @@
 {{ block.super }}
 <script src="{% static 'javascript/govuk.js' %}"></script>
 <script>window.GOVUKFrontend.initAll()</script>
-<script src="{% static 'javascript/hcsat-feedback-form.js' %}"></script>
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        new CsatFormHandler('csat-form');
-    });
-</script>
+{% if company.is_published %}
+    <script src="{% static 'javascript/hcsat-feedback-form.js' %}"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            new CsatFormHandler('csat-form');
+        });
+    </script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
…s loaded to fix unhandled error

## What
Add a conditional to only initialise the hcsat javascript when the business profile has been published - the same conditional used to load the form. 
## Why
The hcsat javascript expects the hcsat form to be present on the page, so when attempting to find form elements this causes an error when the form is not loaded. This will only load the javascript when the form is loaded, preventing the error appearing on sentry: https://sentry.ci.uktrade.digital/organizations/dit/issues/128620/?environment=uat&project=173&query=is%3Aunresolved

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-499
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.


### Housekeeping

- [x] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [x] Checked for potential security vulnerabilities
- [x] Ensured any sensitive data is handled appropriately

### Performance
- [x] Evaluated the performance impact of the changes
- [x] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
