### PR TITLE
IGUK-753 Show more info needed banner

### DIFF
--- a/international_online_offer/templates/eyb/base.html
+++ b/international_online_offer/templates/eyb/base.html
@@ -15,7 +15,7 @@
     </div>
 {% endblock %}
 {% block content %}
-    {% if request.GET.resume and not form.errors %}
+    {% if request.GET.resume and not form.errors and not user_registered_pre_dnb_lookup %}
         <div class="great-container">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">

--- a/international_online_offer/templates/eyb/triage/find_your_company.html
+++ b/international_online_offer/templates/eyb/triage/find_your_company.html
@@ -20,6 +20,23 @@
     <div class="great-container">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
+                {% if user_registered_pre_dnb_lookup and request.GET.resume %}
+                    <div class="govuk-notification-banner govuk-!-width"
+                         role="status"
+                         aria-labelledby="govuk-notification-banner-title"
+                         data-module="govuk-notification-banner">
+                        <div class="govuk-notification-banner__header">
+                            <h2 class="govuk-notification-banner__title"
+                                id="govuk-notification-banner-title">Important</h2>
+                        </div>
+                        <div class="govuk-notification-banner__content">
+                            <h3 class="govuk-notification-banner__heading">More information needed</h3>
+                            <p class="govuk-body">
+                                Search for your company name or enter company details manually, to continue using this service.
+                            </p>
+                        </div>
+                    </div>
+                {% endif %}
                 {% comment %}
                     lifting error messaging into this template and hardcoding id
                     as we use hidden fields which cannot be linked to via href
@@ -90,7 +107,8 @@
                             <div class="govuk-button-group">
                                 {% include "_button.html" with text=progress_button_text classes="govuk-!-margin-right-2" %}
                                 <span class="govuk-body"> or <a class="govuk-link govuk-!-margin-left-1"
-    href="{% url 'international_online_offer:company-details' %}{% if request.GET.company_location_change %}?company_location_change=true{% endif %}{% if request.GET.next %}?next={{ request.GET.next }}&back={% url 'international_online_offer:find-your-company' %}?next={{ request.GET.next }}{% endif %}">Enter company details manually</a> </span>
+    href="{% url 'international_online_offer:company-details' %}{% if request.GET.company_location_change %}?company_location_change=true{% elif request.GET.next %}?next={{ request.GET.next }}&back={% url 'international_online_offer:find-your-company' %}?next={{ request.GET.next }}{% elif user_registered_pre_dnb_lookup and request.GET.resume %}?resume={{ request.GET.resume }}&user_registered_pre_dnb_lookup={{ user_registered_pre_dnb_lookup }}{% endif %}">
+                                Enter company details manually</a> </span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## What
When a user who registered pre-Dun and Bradstreet integration (03/10/24) signs-in they are redirected to the company lookup screen with a 'more information needed' banner.
## Why
We currently redirect users who entered their company details manually (before we introduced the D&B lookup) to the D&B look up question, to either search the D&B lookup for their company information or to enter more manual details (address), so their EYB record can be ingested by Data Hub.

However, we do not explain to users why we are displaying this question when they sign back in. We need to give them better [visibility of system status](https://www.nngroup.com/articles/ten-usability-heuristics/#toc-1-visibility-of-system-status-1) so the service is predictable and trustworthy.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-753
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Includes screenshot(s) - ideally before and after, but at least after

<img width="936" alt="Screenshot 2025-01-14 at 16 48 16" src="https://github.com/user-attachments/assets/aa89bf3d-bc9d-46a4-b734-09ac07cec93a" />

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
