### PR TITLE
GRTLV-576: SignIn redirection to watch events

### DIFF
--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -16,7 +16,7 @@ from django.http import (
     HttpResponseRedirect,
     JsonResponse,
 )
-from django.shortcuts import get_list_or_404, get_object_or_404, redirect
+from django.shortcuts import get_list_or_404, get_object_or_404
 from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.utils.text import get_valid_filename
@@ -843,7 +843,7 @@ class EventsDetailsView(DetailView):
         ctx['signed_in'] = self.signed_in
         ctx['booked'] = self.booked
         ctx['warning_text'] = self.get_warning_text()
-        ctx['warning_call_to_action'] = self.warning_call_to_action
+        ctx['warning_call_to_action'] = self.get_warning_call_to_action()
         ctx['has_event_badges'] = len(self.get_badges_for_event(self.event)) > 0
         ctx['series'] = self.event.get_course()[0] if len(self.event.get_course()) else None
         ctx['show_past_events'] = True
@@ -871,12 +871,11 @@ class EventsDetailsView(DetailView):
                     Watch <span class="govuk-visually-hidden">event recording</span>now</a>"""
                     else:
                         return view_more_events
-                registration_link = redirect(
-                    reverse_lazy('export_academy:registration', kwargs=dict(event_id=self.event.id))
-                )
-                return f"""<a class='govuk-link'∂ href='../../..{ registration_link.url }'>
-            Sign in to watch<span class="govuk-visually-hidden"> event recording</span></a>"""
-
+                else:
+                    current_url = self.request.get_full_path()
+                    signin_link = reverse_lazy('export_academy:signin') + f'?next={current_url}'
+                    return f"""<a class='govuk-link'∂ href='{signin_link}'>
+                    Sign in to watch<span class="govuk-visually-hidden"> event recording</span></a>"""
             else:
                 return view_more_events
         return ''

--- a/export_academy/views.py
+++ b/export_academy/views.py
@@ -874,7 +874,7 @@ class EventsDetailsView(DetailView):
                 else:
                     current_url = self.request.get_full_path()
                     signin_link = reverse_lazy('export_academy:signin') + f'?next={current_url}'
-                    return f"""<a class='govuk-link'∂ href='{signin_link}'>
+                    return f"""<a class='govuk-link' href='{signin_link}'>
                     Sign in to watch<span class="govuk-visually-hidden"> event recording</span></a>"""
             else:
                 return view_more_events


### PR DESCRIPTION
## What
When you are on an event details page for a closed event. It Should not allow you to register for the event .
## Why
Registration for closed events should not be allowed. The Bug allowed users to go through ukea registration and then book onto the event even after the event was closed. This happened for already registered users as well .

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-576
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after
**BEFORE**
![Screenshot 2025-02-10 at 09 39 28](https://github.com/user-attachments/assets/691a0d64-abd5-499c-8400-2ad64b02538e)

![Screenshot 2025-02-10 at 09 40 21](https://github.com/user-attachments/assets/4c05f740-9143-40ab-843d-0dfdf8d81992)
![Screenshot 2025-02-10 at 09 40 55](https://github.com/user-attachments/assets/efce7edd-de63-4a7c-9985-c11abdff7857)

![Screenshot 2025-02-10 at 09 42 16](https://github.com/user-attachments/assets/71117b08-3f77-432e-913b-3d4d90c6899a)

**AFTER**
![Screenshot 2025-02-10 at 09 42 56](https://github.com/user-attachments/assets/a920e61b-e5cc-4184-9290-52c11f3ed60c)

![Screenshot 2025-02-10 at 09 43 28](https://github.com/user-attachments/assets/862ec650-0065-430a-b1f8-73d1cba54ab6)
![Screenshot 2025-02-10 at 09 44 00](https://github.com/user-attachments/assets/898611d9-cf33-4fde-a210-1cc70ec3c90c)


- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
