### PR TITLE
bugfix: Fix campaign sites expiring after a year from first publish

### DIFF
--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -662,12 +662,12 @@ def register_em_feature(features):
 
 
 # Sets a default expiry date for a subsection of page types
-@hooks.register('before_publish_page')
+@hooks.register('after_publish_page')
 def set_default_expiry_date(request, page):
     page_template_names = ['microsites/micro_site_page.html']
 
     # Checks if the page type is in the list and whether it already has an expiry date
-    if page.template in page_template_names and page.expire_at is None:
+    if page.template in page_template_names:
         now = datetime.datetime.now()
         page.expire_at = now.replace(year=now.year + 1)
         page.save_revision()


### PR DESCRIPTION
…regardless of edits or republishing, campaign sites will now expire one year since last published

## What
A bug was introduced a year ago, which has set the expiry date of all campaign sites as a year after they were published, or if they are old campaign sites then they will expire very soon (a year from their first publish after the bug was introduced 28/2/24). 

Some campaign sites have already expired, which prevents access to these pages. This includes pages with paid marketing leading to them, so stakeholders are keen to get this fixed as soon as possible. Manually republishing does not reset the expiry, so stakeholders have no way to restore the pages without taking a fresh copy which impacts SEO. 

## Why
Prevent campaign sites from expiring when we do not want this to occur. 

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-598
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

### Housekeeping


- [x] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [x] Checked for potential security vulnerabilities
- [x] Ensured any sensitive data is handled appropriately

### Performance
- [x] Evaluated the performance impact of the changes
- [x] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
