### PR TITLE
IGUK-936 bug fix on scorecard calculation for upper threshold

### DIFF
--- a/international_online_offer/core/scorecard.py
+++ b/international_online_offer/core/scorecard.py
@@ -2,7 +2,7 @@ from django.db.models import Q
 from sentry_sdk import capture_message
 
 from international_investment.models import InvestmentOpportunityArticlePage
-from international_online_offer.core import hirings
+from international_online_offer.core import hirings, spends
 from international_online_offer.services import get_gva_scoring_criteria
 
 
@@ -54,11 +54,19 @@ def get_value(value_in: str) -> int:
 
 
 def is_capex_spend(spend, threshold):
-    spend_upper_value = get_value(spend)
-    return spend_upper_value >= threshold
+    # the maximum value a user can choose is £5m+ so we return true to accommodate sectors with a gva banding >£5m
+    if spend == spends.MORE_THAN_FIVE_MILLION:
+        return True
+    else:
+        spend_upper_value = get_value(spend)
+        return spend_upper_value >= threshold
 
 
 def is_labour_workforce_hire(hiring, threshold):
+    # the maximum value a user can choose is 21+ so we return true to accommodate sectors with a gva banding 21
+    if hiring == hirings.TWENTY_ONE_PLUS:
+        return True
+
     if hiring == hirings.NO_PLANS_TO_HIRE_YET:
         hiring_upper_value = 0
     else:

--- a/tests/unit/international_online_offer/test_scorecard.py
+++ b/tests/unit/international_online_offer/test_scorecard.py
@@ -32,9 +32,9 @@ def test_get_value(input, expected_result):
         [
             {
                 'full_sector_name': 'Aerospace',
-                'value_band_a_minimum': 100000000,
-                'value_band_b_minimum': 10000000,
-                'value_band_c_minimum': 1000001,
+                'value_band_a_minimum': 1000000000,
+                'value_band_b_minimum': 100000000,
+                'value_band_c_minimum': 10000000,
                 'value_band_d_minimum': 100000,
                 'value_band_e_minimum': 10000,
                 'start_date': '2021-04-01',
@@ -53,14 +53,14 @@ def test_score_is_high_value_capital_intensive(mock_gva_bandings):
     assert not scorecard.score_is_high_value(
         'Aerospace', regions.NORTHERN_IRELAND, hirings.SIX_TO_TEN, spends.FIVE_HUNDRED_THOUSAND_TO_ONE_MILLION, 'abc'
     )
-    assert scorecard.score_is_high_value(
+    assert not scorecard.score_is_high_value(
         'Aerospace',
         regions.NORTHERN_IRELAND,
         hirings.SIX_TO_TEN,
         spends.ONE_MILLION_TO_TWO_MILLION_FIVE_HUNDRED_THOUSAND,
         'abc',
     )
-    assert scorecard.score_is_high_value(
+    assert not scorecard.score_is_high_value(
         'Aerospace',
         regions.NORTHERN_IRELAND,
         hirings.SIX_TO_TEN,
@@ -113,7 +113,7 @@ def test_score_is_high_value_labour_intensive(mock_gva_bandings):
         spends.LESS_THAN_FIVE_HUNDRED_THOUSAND,
         'abc',
     )
-    assert not scorecard.score_is_high_value(
+    assert scorecard.score_is_high_value(
         'Food and drink',
         regions.NORTHERN_IRELAND,
         hirings.TWENTY_ONE_PLUS,


### PR DESCRIPTION
## What
Bug fix on scorecard calculation for upper thresholds in spend/labour hire.
## Why
The maximum values that a user can choose for spend is £5m+ and labour 21+. The previous implementation took the value before the '+' and used that when determining if a proposal was high or low value. This worked well for most sectors, however, some sub sectors such as 'Airports' have a GVA banding greater than £5m/21 employees. In these cases a proposal was incorrectly scored as low value.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IGUK-936
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
