### PR TITLE
fix design system import to use specific version instead of latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
-    "@uktrade/great-design-system": "^1.0.15",
+    "@uktrade/great-design-system": "1.0.15",
     "govuk-frontend": "^4.5.0",
     "great-styles": "github:uktrade/great-styles",
     "prop-types": "15.7.2",


### PR DESCRIPTION
## What
Set specific version of design system instead of latest
## Why
Avoid any changes not debugged in latest version of design system from pushing to great until tested

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-0.
- [x] A clear/description pull request messaged added.

### Reviewing help
### Housekeeping

### Security
- [x] Frontend assets have been re-compiled


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
