### PR TITLE
BGST-174: fixes child page navigation active item

### DIFF
--- a/domestic_growth/templates/guide-child.html
+++ b/domestic_growth/templates/guide-child.html
@@ -39,7 +39,7 @@
 
                     {% for child_page in page.get_parent.get_children %}
                         {% with page=child_page.specific parent_page_title=page.page_title %}
-                            {% if request.path == page.get_url %}
+                            {% if page.slug in request.path %}
                             <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
                                 <a class="govuk-service-navigation__link" href="{{ page.get_url }}{{ qs }}" aria-current="true">
                                     <strong class="govuk-service-navigation__active-fallback">{{ page.title }}</strong>


### PR DESCRIPTION
## What
Fixes issue with child page nav item for showing as active
## Why
To show users which child page is active


### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
