### PR TITLE
Feat/cache invalidation management command

### DIFF
--- a/config/env.py
+++ b/config/env.py
@@ -66,6 +66,7 @@ class BaseSettings(PydanticBaseSettings):
     aws_s3_host: str = 's3-eu-west-2.amazonaws.com'
     aws_s3_signature_version: str = 's3v4'
     aws_querystring_auth: bool = False
+    aws_cloudfront_distribution_id: str = None
     s3_use_sigv4: bool = True
 
     service_name: str = 'great-cms'

--- a/core/management/commands/invalidate_cache.py
+++ b/core/management/commands/invalidate_cache.py
@@ -1,0 +1,69 @@
+import sys
+from time import sleep, time
+
+import boto3
+import sentry_sdk
+from django.conf import settings
+from django.core.management import BaseCommand
+
+INVALIDATION_CHECK_INTERVAL_SECONDS = 10
+INVALIDATION_CHECK_FAILURE_COUNT = 12
+
+
+class Command(BaseCommand):
+    help = 'Invalidate CDN Cache'
+
+    def handle(self, *args, **options):
+        if not settings.WAGTAILFRONTENDCACHE:
+            sentry_sdk.capture_exception('Environment variable FRONTEND_CACHE_DISTRIBUTION_ID not set')
+            sys.exit(1)
+
+        sts_client = boto3.client('sts')
+        role_arn = settings.CF_INVALIDATION_ROLE_ARN
+        role_session_name = 'InvalidateCacheSession'
+
+        assumed_role = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=role_session_name)
+        credentials = assumed_role['Credentials']
+        session = boto3.Session(
+            aws_access_key_id=credentials['AccessKeyId'],
+            aws_secret_access_key=credentials['SecretAccessKey'],
+            aws_session_token=credentials['SessionToken'],
+        )
+
+        client = session.client('cloudfront')
+
+        for cloudfront_distribution_id in settings.WAGTAILFRONTENDCACHE:
+
+            create_invalidation_response = client.create_invalidation(
+                DistributionId=cloudfront_distribution_id,
+                InvalidationBatch={
+                    'Paths': {'Quantity': 1, 'Items': ['/*']},
+                    'CallerReference': str(time()),
+                },
+            )
+
+            invalidation_id = create_invalidation_response['Invalidation']['Id']
+            invalidation_complete = False
+            invalidation_check_count = 0
+
+            while not invalidation_complete:
+                if invalidation_check_count >= INVALIDATION_CHECK_FAILURE_COUNT:
+                    sentry_sdk.capture_exception('Cache invalidation took too long, exiting')
+                    sys.exit(1)
+
+                sleep(INVALIDATION_CHECK_INTERVAL_SECONDS)
+
+                get_invalidation_response = client.get_invalidation(
+                    DistributionId=cloudfront_distribution_id, Id=invalidation_id
+                )
+
+                invalidation_status = get_invalidation_response['Invalidation']['Status'].lower()
+
+                if invalidation_status == 'completed':
+                    invalidation_complete = True
+                    sentry_sdk.capture_message('Invalidation complete')
+                    continue
+
+                sentry_sdk.capture_message(f'Invalidation status: {invalidation_status}')
+
+                invalidation_check_count += 1


### PR DESCRIPTION
## What

Adds a management command to invalidate CloudFront cache for the service. Requires the environment variable `AWS_CLOUDFRONT_DISTRIBUTION_ID` be set and that the ECS task has the permissions `cloudfront:CreateInvalidation` and `cloudfront:GetInvalidation` on the distribution in question.

## Why

To benefit from Platform Helper version 13 and the faster deployment pipelines, this management command replaces the existing clear CDN cache stage in the application deployment pipeline.

### Workflow

- [x] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
