### PR TITLE
GRTLV-675: Move hcsat to ContactSuccessView from ContactView

### DIFF
--- a/international/templates/international/contact.html
+++ b/international/templates/international/contact.html
@@ -104,38 +104,3 @@
         </form>
     </div>
 {% endblock content %}
-{% block feedback_reporter %}
-    {% if not csat_complete and show_hcsat %}
-        <section id="hcsat_section"
-                 class="great-bg-white clearfix govuk-!-margin-top-0 govuk-!-padding-bottom-6 great-inline-feedback__container">
-            <div class="container">
-                <div class="great-container ">
-                    <!-- djlint:off T027-->
-                    {% include 'core/includes/hcsat.html' with hcsat_form=hcsat_form hcsat_stage=hcsat_form_stage leading_text="To help us improve our service, we'd like to know more about your experience today. It will only take a minute to complete." %}
-                    <!-- djlint:on -->
-                </div>
-            </div>
-        </section>
-    {% endif %}
-    {{ block.super }}
-{% endblock %}
-{% block body_js %}
-    {{ block.super }}
-    <script src="{% static 'javascript/govuk.js' %}"></script>
-    <script src="{% static 'javascript/hcsat-feedback-form.js' %}"></script>
-    <script>
-        var csat_form = document.getElementById("hcsat_section")
-        var inline_feedback = document.getElementById("inline_feedback_section")
-        const csat_complete_key = 'find_a_supplier_csat_complete'
-        // allow hcsat feedback to be given once, after which show 'Is this page useful?'
-        if (sessionStorage.getItem(csat_complete_key)==='true') {
-            csat_form.classList.add('great-hidden')
-            inline_feedback.classList.remove('great-hidden')
-        } else {
-            inline_feedback.classList.add('great-hidden')
-        }
-        document.addEventListener('DOMContentLoaded', () => {
-            new CsatFormHandler('csat-form', csat_complete_key);
-        });
-    </script>
-{% endblock %}

--- a/international/templates/international/contact_success.html
+++ b/international/templates/international/contact_success.html
@@ -28,3 +28,38 @@
         </div>
     </div>
 {% endblock content %}
+{% block feedback_reporter %}
+    {% if not csat_complete %}
+        <section id="hcsat_section"
+                 class="great-bg-white clearfix govuk-!-margin-top-0 govuk-!-padding-bottom-6 great-inline-feedback__container">
+            <div class="container">
+                <div class="great-container ">
+                    <!-- djlint:off T027-->
+                    {% include 'core/includes/hcsat.html' with hcsat_form=hcsat_form hcsat_stage=hcsat_form_stage leading_text="To help us improve our service, we'd like to know more about your experience today. It will only take a minute to complete." %}
+                    <!-- djlint:on -->
+                </div>
+            </div>
+        </section>
+    {% endif %}
+    {{ block.super }}
+{% endblock %}
+{% block body_js %}
+    {{ block.super }}
+    <script src="{% static 'javascript/govuk.js' %}"></script>
+    <script src="{% static 'javascript/hcsat-feedback-form.js' %}"></script>
+    <script>
+        var csat_form = document.getElementById("hcsat_section")
+        var inline_feedback = document.getElementById("inline_feedback_section")
+        const csat_complete_key = 'find_a_supplier_csat_complete'
+        // allow hcsat feedback to be given once, after which show 'Is this page useful?'
+        if (sessionStorage.getItem(csat_complete_key)==='true') {
+            csat_form.classList.add('great-hidden')
+            inline_feedback.classList.remove('great-hidden')
+        } else {
+            inline_feedback.classList.add('great-hidden')
+        }
+        document.addEventListener('DOMContentLoaded', () => {
+            new CsatFormHandler('csat-form', csat_complete_key);
+        });
+    </script>
+{% endblock %}

--- a/international/views.py
+++ b/international/views.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlparse
-
 from directory_forms_api_client import actions
 from directory_forms_api_client.helpers import Sender
 from django.http import HttpResponseBadRequest, HttpResponseRedirect, JsonResponse
@@ -16,12 +14,11 @@ from core.mixins import HCSATMixin
 from international import forms
 
 
-class ContactView(WagtailCacheMixin, GA360Mixin, HCSATMixin, FormView):  # /PS-IGNORE
+class ContactView(WagtailCacheMixin, GA360Mixin, FormView):  # /PS-IGNORE
     form_class = forms.ContactForm
     template_name = 'international/contact.html'
     subject = 'Great.gov.uk International contact form'
 
-    hcsat_service_name = 'find_a_supplier'
     cache_control = 'no-cache'
 
     def __init__(self):
@@ -44,22 +41,8 @@ class ContactView(WagtailCacheMixin, GA360Mixin, HCSATMixin, FormView):  # /PS-I
             success_url = success_url + '?next=' + check_url_host_is_safelisted(self.request)
         return success_url
 
-    def is_find_a_supplier_submission(self):
-        next_url = self.request.GET.get('next', '')
-        parsed_next_url = urlparse(next_url)
-        if parsed_next_url.scheme and parsed_next_url.netloc:
-            return False  # Contact form
-        return True  # HCSAT form
-
     def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs, back_url=self.get_back_url())
-        context = self.set_csat_and_stage(self.request, context, self.hcsat_service_name, self.get_form_class())
-        if self.is_find_a_supplier_submission():
-            if 'buy-from-the-uk' in self.request.GET.get('next', ''):
-                context['show_hcsat'] = True
-        if 'form' in kwargs:  # pass back errors from form_invalid
-            context['hcsat_form'] = kwargs['form']
-        return context
+        return super().get_context_data(**kwargs, back_url=self.get_back_url())
 
     def submit_feedback(self, form):
         cleaned_data = form.cleaned_data
@@ -89,16 +72,47 @@ class ContactView(WagtailCacheMixin, GA360Mixin, HCSATMixin, FormView):  # /PS-I
         response = action.save(cleaned_data)
         response.raise_for_status()
 
-    def get_form_class(self):
-        if not self.is_find_a_supplier_submission():
-            return forms.ContactForm
-        elif 'buy-from-the-uk' in self.request.GET.get('next', ''):
-            return HCSATForm
-        else:
-            return forms.ContactForm
+    def form_valid(self, form):
+        self.submit_feedback(form)
+        return super().form_valid(form)
+
+
+class ContactSuccessView(WagtailCacheMixin, HCSATMixin, FormView, GA360Mixin, TemplateView):  # /PS-IGNORE
+    template_name = 'international/contact_success.html'
+    subject = 'Great.gov.uk International contact form success'
+    hcsat_service_name = 'find_a_supplier'
+    cache_control = 'no-cache'
+    form_class = HCSATForm
+
+    def __init__(self):
+        super().__init__()
+        self.set_ga360_payload(
+            page_id='Contact',
+            business_unit='Great.gov.uk International',
+            site_section='contact',
+        )
+
+    def get_success_url(self):
+        success_url = reverse_lazy('international:contact-success')
+        if self.request.GET.get('next'):
+            success_url = success_url + '?next=' + check_url_host_is_safelisted(self.request)
+        return success_url
+
+    def get_back_url(self):
+        back_url = '/international/'
+        if self.request.GET.get('next'):
+            back_url = check_url_host_is_safelisted(self.request)
+        return back_url
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs, back_url=self.get_back_url())
+        context = self.set_csat_and_stage(self.request, context, self.hcsat_service_name, self.form_class)
+        if 'form' in kwargs:  # pass back errors from form_invalid
+            context['hcsat_form'] = kwargs['form']
+        return context
 
     def post(self, request, *args, **kwargs):
-        form_class = self.get_form_class()
+        form_class = self.form_class
 
         hcsat = self.get_hcsat(request, self.hcsat_service_name)
         post_data = self.request.POST
@@ -115,10 +129,9 @@ class ContactView(WagtailCacheMixin, GA360Mixin, HCSATMixin, FormView):  # /PS-I
         form = form_class(post_data)
 
         if form.is_valid():
-            if self.is_find_a_supplier_submission():
-                if 'buy-from-the-uk' in self.request.GET.get('next', ''):
-                    form = form_class(post_data, instance=hcsat)
-                    form.is_valid()
+            if 'buy-from-the-uk' in self.request.GET.get('next', ''):
+                form = form_class(post_data, instance=hcsat)
+                form.is_valid()
             return self.form_valid(form)
         else:
             return self.form_invalid(form)
@@ -130,55 +143,26 @@ class ContactView(WagtailCacheMixin, GA360Mixin, HCSATMixin, FormView):  # /PS-I
         return self.render_to_response(self.get_context_data(form=form))
 
     def form_valid(self, form):
-        if self.is_find_a_supplier_submission() and 'buy-from-the-uk' in self.request.GET.get('next', ''):
-            super().form_valid(form)
+        super().form_valid(form)
 
-            js_enabled = False
+        js_enabled = False
 
-            hcsat = form.save(commit=False)
+        hcsat = form.save(commit=False)
 
-            if 'js_enabled' in self.request.get_full_path():
-                hcsat.stage = HCSatStage.NOT_STARTED.value
-                js_enabled = True
+        if 'js_enabled' in self.request.get_full_path():
+            hcsat.stage = HCSatStage.NOT_STARTED.value
+            js_enabled = True
 
-            hcsat = self.persist_existing_satisfaction(self.request, self.hcsat_service_name, hcsat)
+        hcsat = self.persist_existing_satisfaction(self.request, self.hcsat_service_name, hcsat)
 
-            # Apply data specific to this service
-            hcsat.URL = '/international/buy-from-the-uk/'
-            hcsat.user_journey = 'COMPANY_CONTACT'
-            hcsat.session_key = self.request.session.session_key
-            hcsat.save(js_enabled=js_enabled)
+        # Apply data specific to this service
+        hcsat.URL = '/international/buy-from-the-uk/'
+        hcsat.user_journey = 'COMPANY_CONTACT'
+        hcsat.session_key = self.request.session.session_key
+        hcsat.save(js_enabled=js_enabled)
 
-            self.request.session[f'{self.hcsat_service_name}_hcsat_id'] = hcsat.id
+        self.request.session[f'{self.hcsat_service_name}_hcsat_id'] = hcsat.id
 
-            if 'js_enabled' in self.request.get_full_path():
-                return JsonResponse({'pk': hcsat.pk})
-            return HttpResponseRedirect(self.get_success_url())
-        else:
-            self.submit_feedback(form)
-        return super().form_valid(form)
-
-
-class ContactSuccessView(WagtailCacheMixin, GA360Mixin, TemplateView):  # /PS-IGNORE
-    template_name = 'international/contact_success.html'
-    subject = 'Great.gov.uk International contact form success'
-
-    cache_control = 'no-cache'
-
-    def __init__(self):
-        super().__init__()
-        self.set_ga360_payload(
-            page_id='Contact',
-            business_unit='Great.gov.uk International',
-            site_section='contact',
-        )
-
-    def get_back_url(self):
-        back_url = '/international/'
-        if self.request.GET.get('next'):
-            back_url = check_url_host_is_safelisted(self.request)
-        return back_url
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs, back_url=self.get_back_url())
-        return context
+        if 'js_enabled' in self.request.get_full_path():
+            return JsonResponse({'pk': hcsat.pk})
+        return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
## What
The FAs HCSAt isnot being shown in production . 
## Why
This is because when a new View was created , the HCSAT wasn't moved with it . The update to teamplate and view to move the HCSAt to the correct place.

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-675
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
