### PR TITLE
BGST-178: trade association result logic

### DIFF
--- a/domestic_growth/helpers.py
+++ b/domestic_growth/helpers.py
@@ -80,21 +80,32 @@ def get_trade_associations_file():
     return deserialised_data
 
 
-def get_filtered_trade_associations_by_sector(trade_associations, sector):
-    res = []
+def get_trade_association_results(trade_associations, sector, sub_sector):
+    sector_tas = []
 
     for ta in trade_associations:
         if sector in ta.get('sectors'):
-            res.append(ta)
+            sector_tas.append(ta)
 
-    return res
+    if len(sector_tas) == 0:
+        return None
 
+    if not sub_sector:
+        return {
+            'sector_tas': sector_tas,
+        }
 
-def get_filtered_trade_associations_by_sub_sector(trade_associations, sub_sector):
-    res = []
+    sub_sector_tas = []
+    sector_only_tas = []
 
-    for ta in trade_associations:
+    for ta in sector_tas:
         if sub_sector in ta.get('sectors'):
-            res.append(ta)
+            ta['type'] = 'sub_sector'
+            sub_sector_tas.append(ta)
+        else:
+            ta['type'] = 'sector'
+            sector_only_tas.append(ta)
 
-    return res
+    return {
+        'sub_sector_and_sector_only_tas': sub_sector_tas + sector_only_tas,
+    }

--- a/domestic_growth/models.py
+++ b/domestic_growth/models.py
@@ -19,8 +19,7 @@ from domestic_growth.helpers import (
     get_events,
     get_triage_data,
     get_trade_associations_file,
-    get_filtered_trade_associations_by_sector,
-    get_filtered_trade_associations_by_sub_sector,
+    get_trade_association_results,
 )
 from international_online_offer.core.helpers import get_hero_image_by_sector
 
@@ -250,7 +249,7 @@ class DomesticGrowthGuidePage(WagtailCacheMixin, SeoMixin, cms_panels.DomesticGr
 
         postcode = triage_data['postcode']
         sector = triage_data['sector']
-        sub_sector = triage_data['sub_sector']
+        sub_sector = triage_data.get('sub_sector', None)
 
         if postcode and sector:
             context['qs'] = f'?postcode={postcode}&sector={sector}'
@@ -259,16 +258,14 @@ class DomesticGrowthGuidePage(WagtailCacheMixin, SeoMixin, cms_panels.DomesticGr
             context['local_support_data'] = helpers.get_local_support_by_postcode(postcode)
 
         if sector:
-            trade_associations = get_filtered_trade_associations_by_sector(trade_associations, sector)
+            sector_trade_associations = get_trade_association_results(trade_associations, sector, None)
 
-            context['trade_associations'] = trade_associations
+            context['trade_associations'] = sector_trade_associations
             context['hero_image_url'] = get_hero_image_by_sector(sector)
             context['sector'] = sector
 
             if sub_sector:
-                context['trade_associations'] = get_filtered_trade_associations_by_sub_sector(
-                    trade_associations, sub_sector
-                )
+                context['trade_associations'] = get_trade_association_results(trade_associations, sector, sub_sector)
                 context['sub_sector'] = sub_sector
         else:
             context['trade_associations'] = None

--- a/domestic_growth/static/js/trade-associations.js
+++ b/domestic_growth/static/js/trade-associations.js
@@ -1,0 +1,33 @@
+;(function () {
+  const hidden_ta_trigger = document.querySelector('[data-hidden-ta-trigger]')
+  const show_ta_trigger = document.querySelector('[data-show-ta-trigger]')
+
+  if (hidden_ta_trigger && show_ta_trigger) {
+    hidden_ta_trigger.addEventListener('click', (e) => {
+      document
+        .querySelectorAll('[data-hidden-ta="true"]')
+        .forEach((el, index) => {
+          if (index <= 4) {
+            el.classList = ''
+            el.dataset.hiddenTa = 'false'
+          }
+        })
+
+      show_ta_trigger.classList =
+        'govuk-!-margin-bottom-0 great-ds-button great-ds-button--secondary'
+    })
+
+    show_ta_trigger.addEventListener('click', (e) => {
+      document.querySelectorAll('[data-hidden-ta="false"]').forEach((el) => {
+        el.classList = 'govuk-!-display-none'
+        el.dataset.hiddenTa = 'true'
+      })
+
+      show_ta_trigger.classList = 'govuk-!-display-none'
+
+      document.getElementById('trade-associations').scrollIntoView()
+    })
+
+    show_ta_trigger.classList = 'govuk-!-display-none'
+  }
+})()

--- a/domestic_growth/templates/guide.html
+++ b/domestic_growth/templates/guide.html
@@ -138,7 +138,8 @@
                         {% endif %}
                     {% endif %}
 
-                    <div class="great-ds-bg-white great-ds-border-top-blue-3 govuk-!-margin-bottom-9 bgs-box-shadow">
+                    {% if trade_associations %}
+                    <div class="great-ds-bg-white great-ds-border-top-blue-3 govuk-!-margin-bottom-9 bgs-box-shadow" id="trade-associations">
                         <div class="govuk-!-padding-6 great-ds-border-bottom-light-grey-2">
                             {% if page.trade_associations_title %}
                                 <h3 class="govuk-heading-s govuk-!-margin-bottom-4">{{ page.trade_associations_title }}</h3>
@@ -150,9 +151,9 @@
                         </div>
 
                         <div class="govuk-!-padding-top-3 govuk-!-padding-right-6 govuk-!-padding-bottom-6 govuk-!-padding-left-6">
-                            {% if trade_associations %}
-                                {% for ta in trade_associations %}
-                                    <div {% if forloop.counter > 3 %}data-hidden-ta class="govuk-!-display-none"{% endif %}>
+                            {% if trade_associations.sub_sector_and_sector_only_tas %}
+                                {% for ta in trade_associations.sub_sector_and_sector_only_tas %}
+                                    <div {% if forloop.counter > 3 %}data-hidden-ta="true"  class="govuk-!-display-none"{% endif %}>
                                         <div class="great-ds-border-bottom-light-grey-1 govuk-!-padding-bottom-6 govuk-!-margin-bottom-2">
                                             {% include "_card.html" with href=ta.url type="unmounted" title=ta.name description=ta.description id=ta.id classes="great-ds-card--full great-ds-card--no-border great-ds-card--no-content-margin" hideArrow="true" %}
                                             
@@ -163,24 +164,47 @@
                                             </div>
                                             {% endwith %}
 
-                                            {% if sub_sector %}
+                                            {% if sub_sector and ta.type == 'sub_sector' %}
                                                 {% include "includes/_sector-tag.html" with text=sub_sector %}
-                                            {% elif sector %}
+                                            {% endif %}
+
+                                            {% if sector and ta.type == 'sector' %}
+                                                {% include "includes/_sector-tag.html" with text=sector %}
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            {% elif trade_associations.sector_tas %}
+                                {% for ta in trade_associations.sector_tas %}
+                                    <div {% if forloop.counter > 3 %}data-hidden-ta="true" class="govuk-!-display-none"{% endif %}>
+                                        <div class="great-ds-border-bottom-light-grey-1 govuk-!-padding-bottom-6 govuk-!-margin-bottom-2">
+                                            {% include "_card.html" with href=ta.url type="unmounted" title=ta.name description=ta.description id=ta.id classes="great-ds-card--full great-ds-card--no-border great-ds-card--no-content-margin" hideArrow="true" %}
+                                            
+                                            {% with card_meta_data=ta.url|get_url_favicon_and_domain %}
+                                            <div class="great-ds-card__metadata govuk-!-padding-bottom-3">
+                                                <img class="great-ds-card__metadata-icon" src="/static/icons/favicons/{{ card_meta_data.filename }}.png" alt="" aria-hidden="true" onerror="this.src='/static/icons/favicons/icon-favicon-placeholder.png'">
+                                                <span class="great-ds-card__metadata-text">{{ card_meta_data.domain }}</span>
+                                            </div>
+                                            {% endwith %}
+
+                                            {% if sector %}
                                                 {% include "includes/_sector-tag.html" with text=sector %}
                                             {% endif %}
                                         </div>
                                     </div>
                                 {% endfor %}
                             {% else %}
-                                <p class="govuk-body">Please choose a sector</p>
+                                <div class="govuk-!-padding-6 great-ds-bg-light-blue">
+                                    <p class="govuk-body">To view trade associations <a href="" class="govuk-link">enter your sector or industry</a></p>
+                                </div>
                             {% endif %}
                         </div>
-                        {% if trade_associations %}
                         <div class="govuk-!-padding-6 great-ds-border-top-light-grey-1">
                             <button data-hidden-ta-trigger class="govuk-!-margin-bottom-0 great-ds-button great-ds-button--secondary">Show more</button>
+                            <button data-show-ta-trigger class="govuk-!-margin-bottom-0 great-ds-button great-ds-button--secondary">Show less</button>
                         </div>
-                        {% endif %}
                     </div>
+                    {% endif %}
                 </div>
                 <div class="govuk-grid-column-one-third">
                     {% include 'includes/_email-guide-form.html' %}
@@ -196,12 +220,5 @@
 {% endblock %}
 {% block body_js %}
     {{ block.super }}
-    <script>
-        const hidden_ta_trigger = document.querySelector('[data-hidden-ta-trigger]');
-
-        hidden_ta_trigger.addEventListener('click', (e) => {
-            document.querySelectorAll('[data-hidden-ta]').forEach(el => el.classList = '');
-            hidden_ta_trigger.remove();
-        });
-    </script>
+    <script type="text/javascript" src="/static/js/trade-associations.js"></script>
 {% endblock %}

--- a/tests/unit/domestic_growth/test_helpers.py
+++ b/tests/unit/domestic_growth/test_helpers.py
@@ -9,47 +9,41 @@ from domestic_growth.constants import (
     START_UP_GUIDE_URL,
 )
 from domestic_growth.helpers import (
-    get_filtered_trade_associations_by_sector,
-    get_filtered_trade_associations_by_sub_sector,
     get_triage_data,
+    get_trade_association_results,
 )
 from domestic_growth.models import ExistingBusinessTriage, StartingABusinessTriage
 
 
 @pytest.mark.parametrize(
-    'sector, ta_data, expected_output',
+    'trade_associations, sector, sub_sector, expected_output',
     (
         (
-            'Food and drink',
             [{'sectors': 'Food and drink'}, {'sectors': 'Aerospace'}],
-            [{'sectors': 'Food and drink'}],
+            'Food and drink',
+            None,
+            {'sector_tas': [{'sectors': 'Food and drink'}]},
         ),
-    ),
-)
-def test_get_filtered_trade_associations_by_sector(
-    sector,
-    ta_data,
-    expected_output,
-):
-    assert get_filtered_trade_associations_by_sector(ta_data, sector) == expected_output
-
-
-@pytest.mark.parametrize(
-    'sub_sector, ta_data, expected_output',
-    (
         (
-            'Toys',
-            [{'sectors': 'Consumer and retail : Toys'}, {'sectors': 'Aerospace'}],
-            [{'sectors': 'Consumer and retail : Toys'}],
+            [{'sectors': 'Food and drink'}, {'sectors': 'Aerospace'}, {'sectors': 'Food and drink : Tea'}],
+            'Food and drink',
+            'Tea',
+            {
+                'sub_sector_and_sector_only_tas': [
+                    {'sectors': 'Food and drink : Tea', 'type': 'sub_sector'},
+                    {'sectors': 'Food and drink', 'type': 'sector'},
+                ]
+            },
         ),
     ),
 )
-def test_get_filtered_trade_associations_by_sub_sector(
+def test_get_trade_association_results(
+    trade_associations,
+    sector,
     sub_sector,
-    ta_data,
     expected_output,
 ):
-    assert get_filtered_trade_associations_by_sub_sector(ta_data, sub_sector) == expected_output
+    assert get_trade_association_results(trade_associations, sector, sub_sector) == expected_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
Adds refined display logic for trade associations based on sector and sub sector
## Why
To show most appropriate TAs to the user

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
