### PR TITLE
Feature BGST-171 redirect user to triage drop off point

### DIFF
--- a/domestic_growth/helpers.py
+++ b/domestic_growth/helpers.py
@@ -3,6 +3,7 @@ import json
 from django.db.models.base import Model
 from django.forms.models import model_to_dict
 from django.http import HttpRequest
+from django.urls import reverse
 
 import domestic_growth.models as domestic_growth_models
 from directory_api_client import api_client
@@ -76,11 +77,82 @@ def get_triage_data(model: Model, session_id: str) -> Model:
         return None
 
 
-def get_triage_drop_off_point(request: HttpRequest) -> str:
+def get_session_id(request: HttpRequest) -> str:
+    """
+    returns a session ID from query string params (if present)
+    or else the session's session_key (if present)
+    """
+    session_id = None
+
+    # give preference to the session_id in a qs parameter
+    if request.GET.get('session_id', False):
+        session_id = request.GET.get('session_id')
+    elif request.session.session_key:
+        session_id = request.session.session_key
+
+    return session_id
+
+
+def is_sector_triage_question_incomplete(triage_data: Model) -> bool:
+    if hasattr(triage_data, 'dont_know_sector'):
+        return getattr(triage_data, 'sector_id') is None and not (getattr(triage_data, 'dont_know_sector', False))
+    elif hasattr(triage_data, 'cant_find_sector'):
+        return getattr(triage_data, 'sector_id') is None and not (getattr(triage_data, 'cant_find_sector', False))
+
+    return False
+
+
+def get_triage_drop_off_point(request: HttpRequest) -> str:  # NOQA: C901
     """
     returns the view name of the next unanswered triage question
     returns None if the triage has been completed
     """
+    redirect_to = None
+
+    session_id = get_session_id(request)
+    triage_model = get_triage_model(request)
+    triage_data = get_triage_data(triage_model, session_id)
+
+    # no triage data return to start of triage
+    if not triage_data and triage_model == domestic_growth_models.StartingABusinessTriage:
+        redirect_to = reverse('domestic_growth:domestic-growth-pre-start-location')
+    elif not triage_data and triage_model == domestic_growth_models.ExistingBusinessTriage:
+        redirect_to = reverse('domestic_growth:domestic-growth-existing-location')
+
+    # triage dictionaries, key = model field name, value = corresponding form url name
+    pre_start_business_triage = {
+        'postcode': reverse('domestic_growth:domestic-growth-pre-start-location'),
+        'sector_id': reverse('domestic_growth:domestic-growth-pre-start-sector'),
+    }
+
+    existing_business_triage = {
+        'postcode': reverse('domestic_growth:domestic-growth-existing-location'),
+        'sector_id': reverse('domestic_growth:domestic-growth-existing-sector'),
+        'when_set_up': reverse('domestic_growth:domestic-growth-when-set-up'),
+        'turnover': reverse('domestic_growth:domestic-growth-existing-turnover'),
+        'currently_export': reverse('domestic_growth:domestic-growth-existing-exporter'),
+    }
+
+    triage_dict = (
+        pre_start_business_triage
+        if triage_model == domestic_growth_models.StartingABusinessTriage
+        else existing_business_triage
+    )
+
+    for field_name, form_url in triage_dict.items():
+        if field_name == 'sector_id':
+            if is_sector_triage_question_incomplete(triage_data):
+                redirect_to = form_url
+                break
+        elif not getattr(triage_data, field_name, False):
+            redirect_to = form_url
+            break
+
+    # add session_id qs if it was in url
+    if redirect_to and request.GET.get('session_id', False):
+        return f'{redirect_to}?session_id={session_id}'
+
+    return redirect_to
 
 
 def get_events():

--- a/domestic_growth/models.py
+++ b/domestic_growth/models.py
@@ -19,7 +19,7 @@ from domestic_growth.helpers import (
     get_events,
     get_trade_association_results,
     get_trade_associations_file,
-    get_triage_data,
+    get_triage_data_with_sectors,
 )
 from international_online_offer.core.helpers import get_hero_image_by_sector
 
@@ -244,7 +244,7 @@ class DomesticGrowthGuidePage(WagtailCacheMixin, SeoMixin, cms_panels.DomesticGr
     def get_context(self, request):
         context = super(DomesticGrowthGuidePage, self).get_context(request)
 
-        triage_data, business_type = get_triage_data(request)
+        triage_data = get_triage_data_with_sectors(request)
         trade_associations = get_trade_associations_file()
 
         postcode = triage_data['postcode']
@@ -361,16 +361,12 @@ class DomesticGrowthChildGuidePage(WagtailCacheMixin, SeoMixin, cms_panels.Domes
     def get_context(self, request):
         context = super(DomesticGrowthChildGuidePage, self).get_context(request)
 
-        triage_data, business_type = get_triage_data(request)
+        triage_data = get_triage_data_with_sectors(request)
 
         # all triages contain sector and postcode
         postcode = triage_data['postcode']
         sector = triage_data['sector']
         sub_sector = triage_data.get('sub_sector', None)
-
-        if business_type == constants.ESTABLISHED_OR_START_UP_BUSINESS_TYPE:
-            # we have the business type and some additional triage fields
-            pass
 
         if postcode and sector:
             context['qs'] = f'?postcode={postcode}&sector={sector}'
@@ -567,15 +563,11 @@ class DomesticGrowthDynamicChildGuidePage(
     def get_context(self, request):
         context = super(DomesticGrowthDynamicChildGuidePage, self).get_context(request)
 
-        triage_data, business_type = get_triage_data(request)
+        triage_data = get_triage_data_with_sectors(request)
 
         # all triages contain sector and postcode
         postcode = triage_data['postcode']
         sector = triage_data['sector']
-
-        if business_type == constants.ESTABLISHED_OR_START_UP_BUSINESS_TYPE:
-            # we have the business type and some additional triage fields
-            pass
 
         currently_export = triage_data.get('currently_export', False)
 

--- a/domestic_growth/views.py
+++ b/domestic_growth/views.py
@@ -21,7 +21,7 @@ from domestic_growth.forms import (
     StartingABusinessLocationForm,
     StartingABusinessSectorForm,
 )
-from domestic_growth.helpers import get_triage_data_for_form_init
+from domestic_growth.helpers import get_triage_data
 from domestic_growth.models import ExistingBusinessTriage, StartingABusinessTriage
 from international_online_offer.core import region_sector_helpers
 from international_online_offer.services import get_dbt_sectors
@@ -67,7 +67,7 @@ class BaseTriageFormView(FormView):
         return url
 
     def get_initial(self):
-        triage_data = get_triage_data_for_form_init(self.triage_model, self.session_id)
+        triage_data = get_triage_data(self.triage_model, self.session_id)
         if triage_data:
             return {self.triage_field_name: getattr(triage_data, self.triage_field_name, None)}
 
@@ -130,7 +130,7 @@ class StartingABusinessSectorFormView(BaseTriageFormView):
         return super().get_url_with_optional_session_id_param(PRE_START_GUIDE_URL)
 
     def get_initial(self):
-        triage_data = get_triage_data_for_form_init(StartingABusinessTriage, self.session_id)
+        triage_data = get_triage_data(StartingABusinessTriage, self.session_id)
         if triage_data:
             return {
                 'sector': getattr(triage_data, 'sector_id', None),
@@ -196,7 +196,7 @@ class ExistingBusinessSectorFormView(BaseTriageFormView):
         )
 
     def get_initial(self):
-        triage_data = get_triage_data_for_form_init(ExistingBusinessTriage, self.session_id)
+        triage_data = get_triage_data(ExistingBusinessTriage, self.session_id)
         if triage_data:
             return {
                 'sector': getattr(triage_data, 'sector_id', None),
@@ -300,7 +300,7 @@ class ExistingBusinessCurrentlyExportFormView(BaseTriageFormView):
         return {'back_url': back_url, **ctx_data}
 
     def get_initial(self):
-        triage_data = get_triage_data_for_form_init(ExistingBusinessTriage, self.session_id)
+        triage_data = get_triage_data(ExistingBusinessTriage, self.session_id)
         if triage_data:
             return {
                 self.triage_field_name: 'YES' if getattr(triage_data, self.triage_field_name, False) else 'NO',

--- a/tests/unit/domestic_growth/test_helpers.py
+++ b/tests/unit/domestic_growth/test_helpers.py
@@ -1,6 +1,9 @@
+from unittest import mock
+
 import pytest
 from django.test.client import RequestFactory
 
+from domestic_growth.choices import LESS_THAN_3_YEARS_AGO
 from domestic_growth.constants import (
     ESTABLISHED_GUIDE_URL,
     ESTABLISHED_OR_START_UP_BUSINESS_TYPE,
@@ -11,6 +14,7 @@ from domestic_growth.constants import (
 from domestic_growth.helpers import (
     get_trade_association_results,
     get_triage_data_with_sectors,
+    get_triage_drop_off_point,
 )
 from domestic_growth.models import ExistingBusinessTriage, StartingABusinessTriage
 
@@ -97,3 +101,124 @@ def test_get_triage_data(mock_get_dbt_sectors, guide_url, business_type):
 
     for key in mock_triage_data.keys():
         assert triage_data[key] == mock_triage_data[key]
+
+
+@pytest.mark.parametrize(
+    'guide_url, session_id_qs_param, expected_redirect_url',
+    (
+        (ESTABLISHED_GUIDE_URL, None, '/support-in-uk/existing/location/'),
+        (START_UP_GUIDE_URL, None, '/support-in-uk/existing/location/'),
+        (PRE_START_GUIDE_URL, None, '/support-in-uk/pre-start/location/'),
+        (ESTABLISHED_GUIDE_URL, '1234', '/support-in-uk/existing/location/?session_id=1234'),
+        (START_UP_GUIDE_URL, '1234', '/support-in-uk/existing/location/?session_id=1234'),
+        (PRE_START_GUIDE_URL, '1234', '/support-in-uk/pre-start/location/?session_id=1234'),
+    ),
+)
+@pytest.mark.django_db
+def test_get_triage_drop_off_point_no_triage_data(
+    mock_get_dbt_sectors, guide_url, session_id_qs_param, expected_redirect_url
+):
+    factory = RequestFactory()
+
+    if session_id_qs_param:
+        req = factory.get(guide_url + f'?session_id={session_id_qs_param}')
+    else:
+        req = factory.get(guide_url)
+        req.session = mock.Mock()
+        req.session.session_key = '1234'
+
+    redirect_url = get_triage_drop_off_point(req)
+
+    assert redirect_url == expected_redirect_url
+
+
+@pytest.mark.django_db
+def test_get_triage_drop_off_point_prestart(mock_get_dbt_sectors, client):
+    factory = RequestFactory()
+
+    StartingABusinessTriage.objects.create(session_id='1')
+    req = factory.get(PRE_START_GUIDE_URL + '?session_id=1')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url == '/support-in-uk/pre-start/location/?session_id=1'
+
+    StartingABusinessTriage.objects.create(session_id='2', postcode='BT123AQ')  # /PS-IGNORE
+    req = factory.get(PRE_START_GUIDE_URL + '?session_id=2')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url == '/support-in-uk/pre-start/sector/?session_id=2'
+
+    StartingABusinessTriage.objects.create(session_id='3', postcode='BT123AQ', sector_id='SL0003')  # /PS-IGNORE
+    req = factory.get(PRE_START_GUIDE_URL + '?session_id=3')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url is None
+
+    StartingABusinessTriage.objects.create(session_id='4', postcode='BT123AQ', dont_know_sector=True)  # /PS-IGNORE
+    req = factory.get(PRE_START_GUIDE_URL + '?session_id=4')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url is None
+
+
+@pytest.mark.django_db
+def test_get_triage_drop_off_point_existing(mock_get_dbt_sectors):
+    factory = RequestFactory()
+
+    ExistingBusinessTriage.objects.create(session_id='1')
+    req = factory.get(ESTABLISHED_GUIDE_URL + '?session_id=1')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url == '/support-in-uk/existing/location/?session_id=1'
+
+    ExistingBusinessTriage.objects.create(session_id='2', postcode='BT123AQ')  # /PS-IGNORE
+    req = factory.get(ESTABLISHED_GUIDE_URL + '?session_id=2')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url == '/support-in-uk/existing/sector/?session_id=2'
+
+    ExistingBusinessTriage.objects.create(session_id='3', postcode='BT123AQ', sector_id='SL0003')  # /PS-IGNORE
+    req = factory.get(ESTABLISHED_GUIDE_URL + '?session_id=3')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url == '/support-in-uk/existing/set-up/?session_id=3'
+
+    ExistingBusinessTriage.objects.create(session_id='4', postcode='BT123AQ', cant_find_sector=True)  # /PS-IGNORE
+    req = factory.get(ESTABLISHED_GUIDE_URL + '?session_id=4')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url == '/support-in-uk/existing/set-up/?session_id=4'
+
+    ExistingBusinessTriage.objects.create(
+        session_id='5', postcode='BT123AQ', sector_id='SL0003', when_set_up=LESS_THAN_3_YEARS_AGO  # /PS-IGNORE
+    )
+    req = factory.get(ESTABLISHED_GUIDE_URL + '?session_id=5')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url == '/support-in-uk/existing/turnover/?session_id=5'
+
+    ExistingBusinessTriage.objects.create(
+        session_id='6',
+        postcode='BT123AQ',  # /PS-IGNORE
+        sector_id='SL0003',
+        when_set_up=LESS_THAN_3_YEARS_AGO,
+        turnover='2M_TO_5M',  # /PS-IGNORE
+    )
+    req = factory.get(ESTABLISHED_GUIDE_URL + '?session_id=6')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url == '/support-in-uk/existing/exporter/?session_id=6'
+
+    ExistingBusinessTriage.objects.create(
+        session_id='7',
+        postcode='BT123AQ',  # /PS-IGNORE
+        sector_id='SL0003',
+        when_set_up=LESS_THAN_3_YEARS_AGO,
+        turnover='2M_TO_5M',
+        currently_export=True,
+    )
+    req = factory.get(ESTABLISHED_GUIDE_URL + '?session_id=7')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url is None
+
+    ExistingBusinessTriage.objects.create(
+        session_id='8',
+        postcode='BT123AQ',  # /PS-IGNORE
+        cant_find_sector=True,
+        when_set_up=LESS_THAN_3_YEARS_AGO,
+        turnover='2M_TO_5M',
+        currently_export=True,
+    )
+    req = factory.get(ESTABLISHED_GUIDE_URL + '?session_id=8')
+    redirect_url = get_triage_drop_off_point(req)
+    assert redirect_url is None

--- a/tests/unit/domestic_growth/test_helpers.py
+++ b/tests/unit/domestic_growth/test_helpers.py
@@ -8,7 +8,10 @@ from domestic_growth.constants import (
     PRE_START_GUIDE_URL,
     START_UP_GUIDE_URL,
 )
-from domestic_growth.helpers import get_trade_association_results, get_triage_data
+from domestic_growth.helpers import (
+    get_trade_association_results,
+    get_triage_data_with_sectors,
+)
 from domestic_growth.models import ExistingBusinessTriage, StartingABusinessTriage
 
 
@@ -90,9 +93,7 @@ def test_get_triage_data(mock_get_dbt_sectors, guide_url, business_type):
 
     req = factory.get(guide_url + f"?session_id={mock_triage_data['session_id']}")
 
-    triage_data, returned_business_type = get_triage_data(req)
-
-    assert returned_business_type == business_type
+    triage_data = get_triage_data_with_sectors(req)
 
     for key in mock_triage_data.keys():
         assert triage_data[key] == mock_triage_data[key]


### PR DESCRIPTION
## What
Introduces a helper function that returns a view URL of the next triage question where a user has not answered the complete triage.
## Why
For use in navigation components when the user tries to access the Guide URL.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/BGST-171
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
