### PR TITLE
Add a management command to delete UKEA data based on user email

### DIFF
--- a/export_academy/management/commands/delete_ukea_data.py
+++ b/export_academy/management/commands/delete_ukea_data.py
@@ -1,0 +1,34 @@
+from django.core.management import BaseCommand
+
+from export_academy.models import Booking, Registration, VideoOnDemandPageTracking
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('email', type=str, help='Email address of the user ukea data to delete')
+        parser.add_argument('--dry-run', action='store_true', help='Only show what would be deleted')
+
+    def handle(self, *args, **options):
+        email = options['email']
+        dry_run = options['dry_run']
+        try:
+            registration = Registration.objects.filter(email=email).first()
+            if not registration:
+                self.stdout.write(self.style.WARNING(f'No registarions found with email: {email} '))
+                return
+            bookings = Booking.objects.filter(registration=registration)
+            vod_trackings = VideoOnDemandPageTracking.objects.filter(user_email=email)
+
+            self.stdout.write(f'Registration ID: {registration.id}')
+            self.stdout.write(f'Bookings to delete: {bookings.count()}')
+            self.stdout.write(f'VOD tracking entries to delete: {vod_trackings.count()}')
+
+            if dry_run:
+                self.stdout.write(self.style.WARNING('Dry run -- no data updated.'))
+                return
+            bookings.delete()
+            vod_trackings.delete()
+            registration.delete()
+            self.stdout.write(self.style.SUCCESS(f'All UKEA data related to email {email} has been deleted '))
+        except Exception as exception:
+            self.stdout.write(self.style.ERROR(exception))


### PR DESCRIPTION
## What
Request from User to delete their data from GREAT . 
## Why
Most of the data held can be deleted using the archive_user management command in directory-sso but UKEA data is help standalone . This management command will delete that data based on the user email address 

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-707
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
