### PR TITLE
BGST-375 bug fixes on sector select

### DIFF
--- a/domestic_growth/forms.py
+++ b/domestic_growth/forms.py
@@ -3,7 +3,6 @@ from domestic_growth.choices import (
     EXISTING_BUSINESS_TURNOVER_CHOICES,
     EXISTING_BUSINESS_WHEN_SET_UP_CHOICES,
 )
-
 from great_design_system import forms
 from international_online_offer.core import region_sector_helpers
 from international_online_offer.services import get_dbt_sectors
@@ -48,16 +47,18 @@ class StartingABusinessSectorForm(forms.Form):
     )
 
     def clean(self):
-        # require either sector or explicit, I don't know yet
         cleaned_data = super().clean()
         sector = cleaned_data['sector']
         dont_know_sector_yet = cleaned_data['dont_know_sector_yet']
 
-        if not (sector or dont_know_sector_yet):
+        # require either sector or explicit, I don't know yet but not both
+        if (not (sector or dont_know_sector_yet)) or (sector and dont_know_sector_yet):
             self.add_error(
                 'sector',
                 "Enter your sector or industry and select the closest result, or select 'I don't know yet'",  # NOQA: E501
             )
+        else:
+            return cleaned_data
 
 
 class ExistingBusinessLocationForm(forms.Form):
@@ -103,11 +104,14 @@ class ExistingBusinessSectorForm(forms.Form):
         sector = cleaned_data['sector']
         cant_find_sector = cleaned_data['cant_find_sector']
 
-        if not (sector or cant_find_sector):
+        # require either sector or explicit, can't find sector but not both
+        if (not (sector or cant_find_sector)) or (sector and cant_find_sector):
             self.add_error(
                 'sector',
                 "Enter your sector or industry and select the closest result, or select 'I can't find my sector or industry'",  # NOQA: E501
             )
+        else:
+            return cleaned_data
 
 
 class ExistingBusinessWhenSetUpForm(forms.Form):

--- a/domestic_growth/templates/existing-business/triage-sector.html
+++ b/domestic_growth/templates/existing-business/triage-sector.html
@@ -1,7 +1,10 @@
 {% extends 'includes/base_triage.html' %}
 {% load static %}
 {% block form %}
-    <form method="post" autocomplete="off" data-target-market-form>
+    <form method="post"
+          autocomplete="off"
+          data-target-market-form
+          onsubmit="return onSubmitBusinessDetails()">
         {% csrf_token %}
         <div class="govuk-form-group">
             <h2 class="govuk-caption-l">

--- a/domestic_growth/templates/starting-a-business/triage-sector.html
+++ b/domestic_growth/templates/starting-a-business/triage-sector.html
@@ -1,7 +1,10 @@
 {% extends 'includes/base_triage.html' %}
 {% load static %}
 {% block form %}
-    <form method="post" autocomplete="off" data-target-market-form>
+    <form method="post"
+          autocomplete="off"
+          data-target-market-form
+          onsubmit="return onSubmitBusinessDetails()">
         {% csrf_token %}
         <div class="govuk-form-group">
             <h2 class="govuk-caption-l">

--- a/tests/unit/domestic_growth/test_forms.py
+++ b/tests/unit/domestic_growth/test_forms.py
@@ -39,6 +39,14 @@ from domestic_growth.forms import (
             {'sector': "Enter your sector or industry and select the closest result, or select 'I don't know yet'"},
         ),
         (
+            StartingABusinessSectorForm,
+            {'sector': 'SL0003', 'dont_know_sector_yet': True},
+            False,
+            {
+                'sector': "Enter your sector or industry and select the closest result, or select 'I don't know yet'"  # NOQA: E501
+            },  # NOQA: E501
+        ),
+        (
             StartingABusinessLocationForm,
             {
                 'postcode': 'BT809AQ',  # /PS-IGNORE
@@ -79,6 +87,14 @@ from domestic_growth.forms import (
         (
             ExistingBusinessSectorForm,
             {},
+            False,
+            {
+                'sector': "Enter your sector or industry and select the closest result, or select 'I can't find my sector or industry'"  # NOQA: E501
+            },  # NOQA: E501
+        ),
+        (
+            ExistingBusinessSectorForm,
+            {'sector': 'SL0003', 'cant_find_sector': True},
             False,
             {
                 'sector': "Enter your sector or industry and select the closest result, or select 'I can't find my sector or industry'"  # NOQA: E501


### PR DESCRIPTION
## What
1. Enforce mutually exclusive sector selection options
2. When a user clears the sector autocomplete ensure it is considered as an empty input instead of reverting to the previously entered sector

## Why
Raised as BGS QA item

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/BGST-375
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
