### PR TITLE
BGST-375 add back link logic for guide -> triage

### DIFF
--- a/domestic_growth/models.py
+++ b/domestic_growth/models.py
@@ -293,15 +293,17 @@ class DomesticGrowthGuidePage(
         sector = triage_data['sector']
         sub_sector = triage_data.get('sub_sector', None)
 
+        params = {}
         if postcode and sector:
             params = {
                 'postcode': postcode,
                 'sector': sector,
             }
 
-            if request.GET.get('session_id', False):
-                params['session_id'] = request.GET.get('session_id')
+        if request.GET.get('session_id', False):
+            params['session_id'] = request.GET.get('session_id')
 
+        if params:
             context['qs'] = f'?{urlencode(params)}'
 
         if postcode:
@@ -425,15 +427,17 @@ class DomesticGrowthChildGuidePage(
         sector = triage_data['sector']
         sub_sector = triage_data.get('sub_sector', None)
 
+        params = {}
         if postcode and sector:
             params = {
                 'postcode': postcode,
                 'sector': sector,
             }
 
-            if request.GET.get('session_id', False):
-                params['session_id'] = request.GET.get('session_id')
+        if request.GET.get('session_id', False):
+            params['session_id'] = request.GET.get('session_id')
 
+        if params:
             context['qs'] = f'?{urlencode(params)}'
 
         if postcode:
@@ -640,15 +644,17 @@ class DomesticGrowthDynamicChildGuidePage(
 
         currently_export = triage_data.get('currently_export', False)
 
+        params = {}
         if postcode and sector:
             params = {
                 'postcode': postcode,
                 'sector': sector,
             }
 
-            if request.GET.get('session_id', False):
-                params['session_id'] = request.GET.get('session_id')
+        if request.GET.get('session_id', False):
+            params['session_id'] = request.GET.get('session_id')
 
+        if params:
             context['qs'] = f'?{urlencode(params)}'
 
         if postcode:

--- a/domestic_growth/views.py
+++ b/domestic_growth/views.py
@@ -99,8 +99,13 @@ class StartingABusinessLocationFormView(BaseTriageFormView):
 
     def get_context_data(self, **kwargs):
         ctx_data = super().get_context_data(**kwargs)
+        back_url = (
+            f'{PRE_START_GUIDE_URL}?session_id={self.session_id}'
+            if PRE_START_GUIDE_URL in self.request.META.get('HTTP_REFERER', [])
+            else '/'
+        )
 
-        return {'back_url': '/', **ctx_data}
+        return {'back_url': back_url, **ctx_data}
 
 
 class StartingABusinessSectorFormView(BaseTriageFormView):
@@ -164,8 +169,15 @@ class ExistingBusinessLocationFormView(BaseTriageFormView):
 
     def get_context_data(self, **kwargs):
         ctx_data = super().get_context_data(**kwargs)
+        http_referer = self.request.META.get('HTTP_REFERER', [])
+        back_url = '/'
 
-        return {'back_url': '/', **ctx_data}
+        if START_UP_GUIDE_URL in http_referer:
+            back_url = f'{START_UP_GUIDE_URL}?session_id={self.session_id}'
+        elif ESTABLISHED_GUIDE_URL in http_referer:
+            back_url = f'{ESTABLISHED_GUIDE_URL}?session_id={self.session_id}'
+
+        return {'back_url': back_url, **ctx_data}
 
 
 class ExistingBusinessSectorFormView(BaseTriageFormView):


### PR DESCRIPTION
## What
Fixes two bugs identified during BGST QA:
1. Clicking 'Change answers link' should work correctly within guide pages, i.e. persist `session_id` as querystring parameters.
2. When the user navigates to the first step of the triage via 'Change answers link' on a Dynamic Guide page the back button on the triage should take the user back to the Dynamic Guide.

## Why
Raised as BGST QA item.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/BGST-375
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
