### PR TITLE
Bug greatuk 1769 microsite menu links not working with multi site

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -2057,9 +2057,15 @@ class MicrositePage(cms_panels.MicrositePanels, Page):
         index.SearchField('cta_teaser'),
     ]
 
-    def get_parent_page(self):
+    def get_parent_page(self, request=None):
         current_page = self.specific
         parent_page = self.get_parent().specific
+        if request:
+            requested_page = self.find_for_request(request, request.path)
+            if requested_page:
+                current_page = requested_page
+                parent_page = current_page.get_parent()
+
         while type(parent_page) is not Microsite:
             if type(parent_page) is not MicrositePage:
                 break
@@ -2072,7 +2078,7 @@ class MicrositePage(cms_panels.MicrositePanels, Page):
 
     # Return the children of the top level Microsite parent of current page
     def get_menu_items(self, request=None):
-        parent_page = self.get_parent_page()
+        parent_page = self.get_parent_page(request)
         menu_items = []
 
         multiple_languages = len(settings.LANGUAGES) > 1
@@ -2107,7 +2113,7 @@ class MicrositePage(cms_panels.MicrositePanels, Page):
 
     # Return the children of the top level Microsite parent of current page
     def get_bgs_menu_items(self, request=None):
-        parent_page = self.get_parent_page()
+        parent_page = self.get_parent_page(request)
         bgs_menu_items = []
 
         multiple_languages = len(settings.LANGUAGES) > 1

--- a/core/models.py
+++ b/core/models.py
@@ -2057,6 +2057,7 @@ class MicrositePage(cms_panels.MicrositePanels, Page):
         index.SearchField('cta_teaser'),
     ]
 
+    # TODO GREATUK-1774 reverse mult-site changes
     def get_parent_page(self, request=None):
         current_page = self.specific
         parent_page = self.get_parent().specific

--- a/domestic/views/campaign.py
+++ b/domestic/views/campaign.py
@@ -151,6 +151,7 @@ class CampaignView(BaseNotifyUserFormView):
         self.email_body = self.form_config['email_body'] if self.form_type else None
         self.email_subject = self.form_config['email_subject'] if self.form_type else None
         self.location = get_location(request)
+        self.request = request
         return super().setup(request, *args, **kwargs)
 
     def get_form_class(self):
@@ -177,13 +178,17 @@ class CampaignView(BaseNotifyUserFormView):
         include_link_to_great = page.get_include_link_to_great() if hasattr(page, 'get_include_link_to_great') else ''
         use_domestic_logo = page.get_use_domestic_header_logo() if hasattr(page, 'get_use_domestic_header_logo') else ''
         site_title = page.get_site_title() if hasattr(page, 'get_site_title') else ''
-        menu_items = page.get_menu_items() if hasattr(page, 'get_menu_items') else ''
-        bgs_menu_items = page.get_bgs_menu_items() if hasattr(page, 'get_bgs_menu_items') else ''
+        menu_items = page.get_menu_items(self.request) if hasattr(page, 'get_menu_items') else ''
+        bgs_menu_items = page.get_bgs_menu_items(self.request) if hasattr(page, 'get_bgs_menu_items') else ''
         site_href = (
-            page.get_menu_items()[0]['href'] if hasattr(page, 'get_menu_items') and page.get_menu_items() else ''
+            page.get_menu_items(self.request)[0]['href']
+            if hasattr(page, 'get_menu_items') and page.get_menu_items(self.request)
+            else ''
         )
         great_logo_href = (
-            page.get_menu_items()[0]['href'] if hasattr(page, 'get_menu_items') and page.get_menu_items() else ''
+            page.get_menu_items(self.request)[0]['href']
+            if hasattr(page, 'get_menu_items') and page.get_menu_items(self.request)
+            else ''
         )
         microsite_context = microsite_header(self.request)
         microsite_context['include_link_to_great'] = include_link_to_great

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -14,7 +14,7 @@ from wagtail.blocks.stream_block import StreamBlockValidationError
 from wagtail.fields import StreamField
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
-from wagtail.models import Collection
+from wagtail.models import Collection, Site
 from wagtail.test.utils import WagtailPageTests, WagtailTestUtils
 from wagtail_factories import ImageFactory
 
@@ -896,6 +896,35 @@ class MicrositePageTests(SetUpLocaleMixin, WagtailPageTests):
 
         menu_item_url = menu_items[0]['href'].lstrip('/') if menu_items else ''
         assert menu_item_url, 'Menu item URL should not be empty after stripping leading slash'
+
+    def test_multi_site_get_menu_items(self):
+        root_bgs = MicrositeFactory(title='root_bgs')
+        MicrositePageFactory(page_title='home', title='home', parent=root_bgs)
+        Site.objects.create(
+            hostname='www.bgs.gov.uk', root_page=root_bgs, site_name="Business Growth Site", is_default_site=True
+        )
+        root_great = MicrositeFactory(title='root_bgs')
+        home = MicrositePageFactory(page_title='home_great', title='microsite', parent=root_great)
+        Site.objects.create(
+            hostname='greatcms.trade.great', root_page=root_great, site_name="Great", is_default_site=True
+        )
+        factory = RequestFactory()
+        request = factory.get(home.url)
+        request.path = home.url
+        menu_items = home.get_menu_items(request)
+
+        assert menu_items, 'Menu items should not be empty'
+
+        for item in menu_items:
+            assert 'text' in item, 'Menu item should have a text key'
+            assert 'href' in item, 'Menu item should have an href key'
+
+        assert menu_items[0]['text'] == 'Home', 'First menu item should be Home'
+        assert menu_items[0]['href'], 'First menu item should have a non-empty href'
+
+        menu_item_url = menu_items[0]['href'].lstrip('/') if menu_items else ''
+        assert menu_item_url, 'Menu item URL should not be empty after stripping leading slash'
+        assert menu_item_url == 'http://greatcms.trade.great/microsite/?lang=en-gb'
 
     def test_get_site_title(self):
         root = MicrositeFactory(title='root')

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -901,12 +901,12 @@ class MicrositePageTests(SetUpLocaleMixin, WagtailPageTests):
         root_bgs = MicrositeFactory(title='root_bgs')
         MicrositePageFactory(page_title='home', title='home', parent=root_bgs)
         Site.objects.create(
-            hostname='www.bgs.gov.uk', root_page=root_bgs, site_name="Business Growth Site", is_default_site=True
+            hostname='www.bgs.gov.uk', root_page=root_bgs, site_name='Business Growth Site', is_default_site=True
         )
         root_great = MicrositeFactory(title='root_bgs')
         home = MicrositePageFactory(page_title='home_great', title='microsite', parent=root_great)
         Site.objects.create(
-            hostname='greatcms.trade.great', root_page=root_great, site_name="Great", is_default_site=True
+            hostname='greatcms.trade.great', root_page=root_great, site_name='Great', is_default_site=True
         )
         factory = RequestFactory()
         request = factory.get(home.url)


### PR DESCRIPTION
## What
Campaign site menu links should reflect the request domain
## Why
Page links must be for the domain user is using in a multi-site setup so they are not navigated to a different site.


### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1769
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
