### PR TITLE
BGST-417: Make export support pages work in new bgs url structure

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -2310,8 +2310,10 @@ class SupportPage(SeoMixin, cms_panels.SupportPanels, Page):
     parent_page_types = [
         'core.Support',
         'core.SupportPage',
+        'domestic.DomesticHomePage',
+        'domestic.GreatDomesticHomePage',
     ]
-    subpage_types = ['core.SupportPage']
+    subpage_types = ['core.SupportPage', 'core.TaskBasedCategoryPage']
 
     class Meta:
         verbose_name = 'Support page'
@@ -2470,6 +2472,7 @@ class TaskBasedCategoryPage(cms_panels.TaskBasedCategoryPage, Page):
     template = 'domestic/contact/export-support/task-based-category-page.html'
     parent_page_types = [
         'core.Support',
+        'core.SupportPage',
     ]
     subpage_types = ['core.TaskBasedSubCategoryPage']
 


### PR DESCRIPTION
## What
Makes export support pages work in new BGS url structure
## Why
To allow for proposed new url structure for export support pages

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
