### PR TITLE
Update campaign site pages to get the current page from the root site

### DIFF
--- a/domestic/views/campaign.py
+++ b/domestic/views/campaign.py
@@ -5,7 +5,7 @@ from django.http import Http404
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.translation import get_language
-from wagtail.models import Locale
+from wagtail.models import Locale, Site
 
 from contact.views import BaseNotifyUserFormView
 from core.context_processors import microsite_footer, microsite_header
@@ -38,7 +38,7 @@ class CampaignView(BaseNotifyUserFormView):
         user_template=settings.CAMPAIGN_USER_NOTIFY_TEMPLATE_ID,
     )
 
-    def get_current_page(self):
+    def get_current_page(self, request=None):
         if self.page_slug is None:
             return None
         try:
@@ -48,39 +48,31 @@ class CampaignView(BaseNotifyUserFormView):
             from config.settings import LANGUAGE_CODE
 
             current_locale = Locale.objects.get(language_code=LANGUAGE_CODE)
-        return self.get_correct_page(current_locale)
+        return self.get_correct_page(current_locale, request)
 
-    def get_correct_page(self, current_locale):
-        if self.page_class.objects.live().filter(slug=self.page_slug).count() > 0:
-            if (
-                self.page_class.objects.live()
-                .filter(slug=self.page_slug, locale_id=current_locale, url_path__endswith=self.path)
-                .count()
-                == 1  # noqa: W503
-            ):
-                return self.page_class.objects.live().get(
-                    slug=self.page_slug, locale_id=current_locale, url_path__endswith=self.path
-                )
-            else:
-                from config.settings import LANGUAGE_CODE
-
-                default_locale = Locale.objects.get(language_code=LANGUAGE_CODE)
+    def get_correct_page(self, current_locale, request=None):
+        if request:
+            site = Site.find_for_request(request)
+            pages = self.page_class.objects.live().descendant_of(site.root_page)
+            if pages.filter(slug=self.page_slug).count() > 0:
                 if (
-                    self.page_class.objects.live()
-                    .filter(slug=self.page_slug, locale_id=default_locale, url_path__endswith=self.path)
-                    .count()
-                    == 1
+                    pages.filter(slug=self.page_slug, locale_id=current_locale, url_path__endswith=self.path).count()
+                    == 1  # noqa: W503
                 ):
-                    return self.page_class.objects.live().get(
-                        slug=self.page_slug, locale_id=default_locale, url_path__endswith=self.path
-                    )
+                    return pages.get(slug=self.page_slug, locale_id=current_locale, url_path__endswith=self.path)
                 else:
-                    return (
-                        self.page_class.objects.live()
-                        .filter(slug=self.page_slug, url_path__endswith=self.path)
-                        .order_by('-path')
-                        .first()
-                    )
+                    from config.settings import LANGUAGE_CODE
+
+                    default_locale = Locale.objects.get(language_code=LANGUAGE_CODE)
+                    if (
+                        pages.filter(
+                            slug=self.page_slug, locale_id=default_locale, url_path__endswith=self.path
+                        ).count()
+                        == 1
+                    ):
+                        return pages.get(slug=self.page_slug, locale_id=default_locale, url_path__endswith=self.path)
+                    else:
+                        return pages.filter(slug=self.page_slug, url_path__endswith=self.path).order_by('-path').first()
 
     def get_form_value(self):
         values = [
@@ -142,7 +134,8 @@ class CampaignView(BaseNotifyUserFormView):
         self.form_success = True if 'form_success=True' in request.get_full_path() else False
         self.success_url = self.get_success_url()
         self.path = request.path
-        self.current_page = self.get_current_page()
+        self.request = request
+        self.current_page = self.get_current_page(request)
         self.available_languages = self.get_languages()['available_languages'] if self.current_page else None
         self.current_language = self.get_languages()['current_language'] if self.current_page else None
         self.form_config = self.get_form_value() if self.current_page else None
@@ -151,7 +144,6 @@ class CampaignView(BaseNotifyUserFormView):
         self.email_body = self.form_config['email_body'] if self.form_type else None
         self.email_subject = self.form_config['email_subject'] if self.form_type else None
         self.location = get_location(request)
-        self.request = request
         return super().setup(request, *args, **kwargs)
 
     def get_form_class(self):

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -4,7 +4,6 @@ from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 from urllib.parse import urlencode
 
-from django.utils import translation
 import pytest
 from directory_forms_api_client import actions
 from django.conf import settings

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -21,7 +21,7 @@ from wagtail.images.views.chooser import (
     ImageUploadViewMixin,
     SelectFormatResponseMixin,
 )
-from wagtail.models import Locale
+from wagtail.models import Locale, Site
 
 from core import cms_slugs, forms, helpers, serializers, views
 from core.models import HCSAT
@@ -1081,13 +1081,13 @@ class TestMicrositeLocales(TestCase):
     @pytest.fixture(autouse=True)
     def en_microsite(self):
         root = MicrositeFactory(title='root', slug='microsites', parent=self.domestic_homepage)
-
         self.en_microsite = MicrositePageFactory(
             page_title='microsite home title en-gb',
             page_subheading='a microsite subheading en-gb',
             slug='microsite-page-home',
             parent=root,
         )
+        Site.objects.create(hostname='greatcms.trade.great', root_page=root, site_name='Great', is_default_site=True)
         self.url = reverse_lazy('core:microsites', kwargs={'page_slug': '/microsite-page-home'})
 
     def test_correct_translation_english(self):

--- a/tests/unit/core/test_views.py
+++ b/tests/unit/core/test_views.py
@@ -1068,7 +1068,6 @@ class TestMicrositeLocales(TestCase):
         self.client = Client()
         self.en_locale = Locale.objects.get_or_create(language_code='en-gb')
         self.es_locale = Locale.objects.get_or_create(language_code='es')
-        self.ar_locale = Locale.objects.get_or_create(language_code='ar')
         self.fr_locale = Locale.objects.get_or_create(language_code='fr')
         self.pt_locale = Locale.objects.get_or_create(language_code='pt')
         self.ko_locale = Locale.objects.get_or_create(language_code='ko')
@@ -1097,13 +1096,16 @@ class TestMicrositeLocales(TestCase):
         assert 'microsite home title en-gb' in html_response and 'a microsite subheading en-gb' in html_response
 
     def test_correct_translation_for_spanish(self):
-        translation.activate('es')
         site_es = self.en_microsite.copy_for_translation(self.es_locale[0], copy_parents=True)
         site_es.page_title = 'página de inicio del micrositio'
         site_es.page_subheading = 'Subtítulo de la Página de Inicio del Micrositio'
-        site_es.slug = self.en_microsite.slug
+
+        site_es.save()
         revision = site_es.save_revision()
         revision.publish()
+        spanish_site = Site.objects.get(hostname='greatcms.trade.great')
+        spanish_site.root_page = site_es.get_parent()
+        spanish_site.save()
 
         url_spanish = self.url + '?lang=es'
         response = self.client.get(url_spanish, HTTP_ACCEPT_LANGUAGE='es')
@@ -1112,24 +1114,35 @@ class TestMicrositeLocales(TestCase):
         assert 'Subtítulo de la Página de Inicio del Micrositio' in html_response
 
     def test_correct_translation_french(self):
-        site_fr = self.en_microsite.copy_for_translation(self.fr_locale[0], copy_parents=True, alias=True)
+        site_fr = self.en_microsite.copy_for_translation(self.fr_locale[0], copy_parents=True)
         site_fr.page_title = 'page d&amp;#x27;accueil du microsite'
         site_fr.page_subheading = 'Sous-titre de la page d&#x27;accueil du microsite'
+
         site_fr.save()
+        revision = site_fr.save_revision()
+        revision.publish()
+        french_site = Site.objects.get(hostname='greatcms.trade.great')
+        french_site.root_page = site_fr.get_parent()
+        french_site.save()
 
         url_french = self.url + '?lang=fr'
         response = self.client.get(url_french)
         html_response = response.content.decode('utf-8')
-        assert (
-            'page d&amp;#x27;accueil du microsite' in html_response
-            and 'Sous-titre de la page d&amp;#x27;accueil du microsite' in html_response  # noqa: W503
-        )
+        assert 'page d&amp;#x27;accueil du microsite' in html_response
+        assert 'Sous-titre de la page d&amp;#x27;accueil du microsite' in html_response
 
     def test_correct_translation_portguese(self):
-        site_pt = self.en_microsite.copy_for_translation(self.pt_locale[0], copy_parents=True, alias=True)
+        site_pt = self.en_microsite.copy_for_translation(self.pt_locale[0], copy_parents=True)
         site_pt.page_title = 'página inicial do microsite'
         site_pt.page_subheading = 'Subtítulo de la Página de Inicio del Micrositio'
+
         site_pt.save()
+        revision = site_pt.save_revision()
+        revision.publish()
+        portguese_site = Site.objects.get(hostname='greatcms.trade.great')
+        portguese_site.root_page = site_pt.get_parent()
+        portguese_site.save()
+
         url_portugeuse = self.url + '?lang=pt'
         response = self.client.get(url_portugeuse)
         html_response = response.content.decode('utf-8')
@@ -1139,10 +1152,17 @@ class TestMicrositeLocales(TestCase):
         )
 
     def test_correct_translation_korean(self):
-        site_ko = self.en_microsite.copy_for_translation(self.ko_locale[0], copy_parents=True, alias=True)
+        site_ko = self.en_microsite.copy_for_translation(self.ko_locale[0], copy_parents=True)
         site_ko.page_title = '페이지 제목: 무역 기회 창출: 영국-대한민국 수출 포럼'
         site_ko.page_subheading = '부제: 국제 무역과 경제 성장을 위한 강력한 동반자관계 구축'
         site_ko.save()
+
+        revision = site_ko.save_revision()
+        revision.publish()
+        korean_site = Site.objects.get(hostname='greatcms.trade.great')
+        korean_site.root_page = site_ko.get_parent()
+        korean_site.save()
+
         url_korean = self.url + '?lang=ko'
         response = self.client.get(url_korean)
         html_response = response.content.decode('utf-8')
@@ -1152,20 +1172,34 @@ class TestMicrositeLocales(TestCase):
         )
 
     def test_correct_translation_mandarin(self):
-        site_zh = self.en_microsite.copy_for_translation(self.zh_locale[0], copy_parents=True, alias=True)
+        site_zh = self.en_microsite.copy_for_translation(self.zh_locale[0], copy_parents=True)
         site_zh.page_title = '微型网站首页'
         site_zh.page_subheading = '微型网站主页字幕'
         site_zh.save()
+
+        revision = site_zh.save_revision()
+        revision.publish()
+        mandarin_site = Site.objects.get(hostname='greatcms.trade.great')
+        mandarin_site.root_page = site_zh.get_parent()
+        mandarin_site.save()
+
         url_mandarin = self.url + '?lang=zh-cn'
         response = self.client.get(url_mandarin)
         html_response = response.content.decode('utf-8')
         assert site_zh.page_title in html_response and site_zh.page_subheading in html_response  # noqa: W503
 
     def test_correct_translation_malay(self):
-        site_ms = self.en_microsite.copy_for_translation(self.ms_locale[0], copy_parents=True, alias=True)
+        site_ms = self.en_microsite.copy_for_translation(self.ms_locale[0], copy_parents=True)
         site_ms.page_title = 'laman utama laman mikro'
         site_ms.page_subheading = 'Sarikata Halaman Utama Microsite'
         site_ms.save()
+
+        revision = site_ms.save_revision()
+        revision.publish()
+        malay_site = Site.objects.get(hostname='greatcms.trade.great')
+        malay_site.root_page = site_ms.get_parent()
+        malay_site.save()
+
         url_malay = self.url + '?lang=ms'
         response = self.client.get(url_malay)
         html_response = response.content.decode('utf-8')

--- a/tests/unit/domestic/views/test_views.py
+++ b/tests/unit/domestic/views/test_views.py
@@ -410,7 +410,9 @@ class CampaignViewTestCase(WagtailPageTests, TestCase):
             slug='test-article-three', article_body=article_body3, parent=self.parent_page, article_title='test'
         )
 
-        self.site = Site.objects.create(hostname='greatcms.trade.great', root_page=self.domestic_homepage, site_name='Great', is_default_site=True) # noqa
+        self.site = Site.objects.create(
+            hostname='greatcms.trade.great', root_page=self.domestic_homepage, site_name='Great', is_default_site=True
+        )  # noqa
 
     def test_no_page_slug(self):
         url = reverse_lazy('domestic:campaigns', kwargs={'page_slug': None})
@@ -424,7 +426,12 @@ class CampaignViewTestCase(WagtailPageTests, TestCase):
 
     def test_get_current_page(self):
         self.listing_page = ArticleListingPageFactory(
-            slug='test-listing', title='test', landing_page_title='test', hero_teaser='list one', parent = self.domestic_homepage) # noqa
+            slug='test-listing',
+            title='test',
+            landing_page_title='test',
+            hero_teaser='list one',
+            parent=self.domestic_homepage,
+        )  # noqa
 
         self.article = ArticlePageFactory(slug='test-article-one', parent=self.listing_page, article_title='test')
 

--- a/tests/unit/domestic/views/test_views.py
+++ b/tests/unit/domestic/views/test_views.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import activate
 from wagtail.models import Locale, Site
@@ -410,6 +410,8 @@ class CampaignViewTestCase(WagtailPageTests, TestCase):
             slug='test-article-three', article_body=article_body3, parent=self.parent_page, article_title='test'
         )
 
+        self.site = Site.objects.create(hostname='greatcms.trade.great', root_page=self.domestic_homepage, site_name='Great', is_default_site=True) # noqa
+
     def test_no_page_slug(self):
         url = reverse_lazy('domestic:campaigns', kwargs={'page_slug': None})
         request = self.client.get(url)
@@ -422,18 +424,17 @@ class CampaignViewTestCase(WagtailPageTests, TestCase):
 
     def test_get_current_page(self):
         self.listing_page = ArticleListingPageFactory(
-            slug='test-listing', title='test', landing_page_title='test', hero_teaser='list one'
-        )
-        ArticlePageFactory(slug='test-article-one', parent=self.listing_page, article_title='test')
-        Site.objects.create(
-            hostname='greatcms.trade.great', root_page=self.listing_page, site_name='Great', is_default_site=True
-        )  # noqa
+            slug='test-listing', title='test', landing_page_title='test', hero_teaser='list one', parent = self.domestic_homepage) # noqa
+
+        self.article = ArticlePageFactory(slug='test-article-one', parent=self.listing_page, article_title='test')
+
+        factory = RequestFactory()
         url = '/campaigns/test-article-one/'
-        request = self.client.get(url)
+        request = factory.get(url)
         view = domestic.views.campaign.CampaignView()
         view.setup(request, page_slug='test-article-one')
         self.assertEqual(view.path, url)
-        self.assertNotEqual(view.current_page, None)
+        self.assertIsNotNone(view.current_page)
 
     def test_get_languages_with_only_one_language(self):
         url = reverse_lazy('domestic:campaigns', kwargs={'page_slug': 'test-article-one'})

--- a/tests/unit/domestic/views/test_views.py
+++ b/tests/unit/domestic/views/test_views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import activate
-from wagtail.models import Locale
+from wagtail.models import Locale, Site
 from wagtail.test.utils import WagtailPageTests
 
 import domestic.forms
@@ -425,13 +425,15 @@ class CampaignViewTestCase(WagtailPageTests, TestCase):
             slug='test-listing', title='test', landing_page_title='test', hero_teaser='list one'
         )
         ArticlePageFactory(slug='test-article-one', parent=self.listing_page, article_title='test')
+        Site.objects.create(
+            hostname='greatcms.trade.great', root_page=self.listing_page, site_name='Great', is_default_site=True
+        )  # noqa
         url = '/campaigns/test-article-one/'
         request = self.client.get(url)
-        view = domestic.views.campaign.CampaignView(request=request)
-        path = view.request.context_data['view'].path
-        current_page = view.request.context_data['view'].current_page
-        self.assertEqual(path, url)
-        self.assertNotEqual(current_page, None)
+        view = domestic.views.campaign.CampaignView()
+        view.setup(request, page_slug='test-article-one')
+        self.assertEqual(view.path, url)
+        self.assertNotEqual(view.current_page, None)
 
     def test_get_languages_with_only_one_language(self):
         url = reverse_lazy('domestic:campaigns', kwargs={'page_slug': 'test-article-one'})


### PR DESCRIPTION
## What
Bug on campaign site pages : Any changes are published live on CMS but changes are not reflected on the live page 
## Why
Due to multisite the live pages are linking to the BGS cms pages . The change makes sure the pages are picked up from the correct root site.

_Tick or delete as appropriate:_

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-754
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
