### PR TITLE
BGST-409 fix dev deploy failing

### DIFF
--- a/.copilot/image_build_run.sh
+++ b/.copilot/image_build_run.sh
@@ -9,7 +9,7 @@ echo "Running image_build_run.sh"
 export BUILD_STEP='true'
 
 # shellcheck disable=SC2046
-export $(grep -v '^#' ./config/env/test | xargs)
+export $(grep -v '^#' test.env | sed 's/ *#.*//' | xargs)
 export APP_ENVIRONMENT='local'
 export REDIS_URL='redis://localhost:6379'
 export BASE_URL='http://greatcms.trade.great:8020'


### PR DESCRIPTION
## What
Fixes failing build whilst maintaining functionality for comments, e.g. `#  /PS-IGNORE` to be in environment file.
## Why
Pre-commit secret hooks flagged potential secrets which was resolved via adding `#  /PS-IGNORE` in [this PR](https://github.com/uktrade/great-cms/pull/4064). This broke the build script / automated deployment as comments could not be parsed. This PR adds code to rectify as recommended in [this Slack request](https://ditdigitalteam.slack.com/archives/C070P5A4EV8/p1746520764392149).

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/BGST-409
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
