### PR TITLE
BGST-375 refactor use of exception for getting triage data

### DIFF
--- a/domestic_growth/helpers.py
+++ b/domestic_growth/helpers.py
@@ -73,8 +73,8 @@ def get_triage_data_with_sectors(request: HttpRequest) -> dict:
 
 
 def get_triage_data(model: Model, triage_uuid: str) -> Model:
-    if model.objects.filter(triage_uuid=triage_uuid).exists():
-        return model.objects.get(triage_uuid=triage_uuid)
+    triage_record = model.objects.filter(triage_uuid=triage_uuid)
+    return triage_record[0] if triage_record else None
 
 
 def get_triage_uuid(request: HttpRequest) -> str:

--- a/domestic_growth/helpers.py
+++ b/domestic_growth/helpers.py
@@ -73,11 +73,8 @@ def get_triage_data_with_sectors(request: HttpRequest) -> dict:
 
 
 def get_triage_data(model: Model, triage_uuid: str) -> Model:
-    try:
+    if model.objects.filter(triage_uuid=triage_uuid).exists():
         return model.objects.get(triage_uuid=triage_uuid)
-    except (AttributeError, model.DoesNotExist) as e:
-        sentry_sdk.capture_exception(e)
-        return None
 
 
 def get_triage_uuid(request: HttpRequest) -> str:

--- a/domestic_growth/views.py
+++ b/domestic_growth/views.py
@@ -60,7 +60,8 @@ class BaseTriageFormView(FormView):
     def get_url_with_optional_triage_uuid_param(self, url: str, params: dict = {}) -> HttpUrl:
         """
         Accepts a success url and if we are using a uuid as opposed to a session_key appends a
-        query string parameter
+        query string parameter. An exception is thrown if we try and instantiate UUID with
+        a string that is not valid.
         """
         try:
             if type(self.triage_uuid) is UUID or type(UUID(self.triage_uuid)) is UUID:


### PR DESCRIPTION
## What
Refactor use of exception when checking if a triage record exists.
## Why
1. Using exceptions for a normal user journey results in increased noise in Sentry.
2. Refactor to a more typical django pattern.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/BGST-375
- [ ] Jira ticket has the correct status. (Using an old Jira ticket that was for triage qa emends)
- [x] A clear/description pull request messaged added.

### Performance
- [x] Evaluated the performance impact of the changes

We are using `bool(queryset)` rather than `exists()` to avoid querying the database twice as per [docs](https://docs.djangoproject.com/en/5.2/ref/models/querysets/#exists)

- [x] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
