### PR TITLE
bug GREATUK-1992 EYB article links not aware of BGS

### DIFF
--- a/international_online_offer/models.py
+++ b/international_online_offer/models.py
@@ -20,7 +20,7 @@ from core.helpers import international_url
 from core.mixins import HCSATNonFormPageMixin
 from core.models import CMSGenericPage, TimeStampedModel
 from domestic.models import BaseContentPage
-from international_investment.models import InvestmentOpportunityArticlePage
+from international_investment.models import InvestmentIndexPage, InvestmentOpportunityArticlePage
 from international_online_offer import services
 from international_online_offer.core import (
     choices,
@@ -496,6 +496,7 @@ class EYBGuidePage(WagtailCacheMixin, BaseContentPage, EYBHCSAT):
         # Get any EYB articles that have been tagged with any of the filter tags setup by content team
         all_articles = (
             EYBArticlePage.objects.live()
+            .descendant_of(self)
             .filter(
                 Q(tags__name=filter_tags.FINANCE_AND_SUPPORT)
                 | Q(tags__name=filter_tags.FIND_EXPERT_TALENT)
@@ -517,6 +518,7 @@ class EYBGuidePage(WagtailCacheMixin, BaseContentPage, EYBHCSAT):
 
             sector_articles = (
                 EYBArticlePage.objects.live()
+                .descendant_of(self)
                 .filter(tags__name__iexact=user_sector_no_commas)
                 .order_by('article_title')
                 .distinct('article_title')
@@ -524,6 +526,7 @@ class EYBGuidePage(WagtailCacheMixin, BaseContentPage, EYBHCSAT):
 
             dbt_sector_articles = (
                 EYBArticlePage.objects.live()
+                .descendant_of(self)
                 .filter(dbt_sectors__contains=[triage_data.sector])
                 .order_by('article_title')
                 .distinct('article_title')
@@ -532,8 +535,14 @@ class EYBGuidePage(WagtailCacheMixin, BaseContentPage, EYBHCSAT):
             all_articles = all_articles.union(sector_articles).union(dbt_sector_articles)
 
         # Get first three investment opportunities A-Z by sector
+        # Get the international home page (assumed to be self's parent)
+        international_home = self.get_parent().get_parent()
+        # Get the investment home page (a child of international_home of type InvestmentIndexPage)
+        investment_home = international_home.get_children().type(InvestmentIndexPage).live().first()
+
         investment_opportunities = (
             InvestmentOpportunityArticlePage.objects.live()
+            .descendant_of(investment_home)
             .filter(dbt_sectors__contains=[triage_data.sector])
             .order_by('article_title')
             .distinct('article_title')[:3]
@@ -542,6 +551,7 @@ class EYBGuidePage(WagtailCacheMixin, BaseContentPage, EYBHCSAT):
         # Get first three trade events A-Z by sector
         trade_events = (
             IOOTradeShowPage.objects.live()
+            .descendant_of(self)
             .filter(tags__name__iexact=triage_data.sector.replace(',', ''))
             .order_by('tradeshow_title')
             .distinct('tradeshow_title')[:3]


### PR DESCRIPTION
## What
EYB articles are exposed in the template using article.url. When getting the articles to show via the django query we need to cater for the fact that in doing multi site for BGS there are duplicate articles sitting in wagtail (BGS root and domestic). The reason in some cases the wrong .url is shown in the ui is beacuse the query gets the first article it finds and not the one for the section of wagtail its stored in. This code will use the parent / child setup to ensure the correct article is surfaced.
## Why
Bug in Prod

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREAT-1992
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
