### PR TITLE
BGST-430 use caching for triage data

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -63,6 +63,10 @@ app.conf.beat_schedule = {
         'task': 'international_online_offer.tasks.email_eyb_users_with_incomplete_triage',
         'schedule': crontab(minute=0, hour=12),
     },
+    'domestic_growth_move_incomplete_triage_data_from_cache_to_db': {
+        'task': 'domestic_growth.tasks.move_incomplete_triage_data_from_cache_to_db',
+        'schedule': crontab(minute=55, hour=23),
+    },
 }
 
 if settings.FEATURE_REDIS_USE_SSL:

--- a/domestic_growth/management/commands/move_triage_data_from_cache_to_db.py
+++ b/domestic_growth/management/commands/move_triage_data_from_cache_to_db.py
@@ -1,0 +1,27 @@
+from django.core.cache import cache
+from django.core.management import BaseCommand
+from django.db.models.base import Model
+
+from domestic_growth.helpers import persist_to_db
+from domestic_growth.models import ExistingBusinessTriage, StartingABusinessTriage
+
+
+class Command(BaseCommand):
+    help = 'Moves incomplete triage data (e.g. if user drops off) from cache to db'
+
+    def handle(self, *args, **options):
+        starting_a_business_triage_cache_keys = cache.iter_keys('bgs:StartingABusinessTriage:*')
+
+        for key in starting_a_business_triage_cache_keys:
+            self.save(key, StartingABusinessTriage)
+            cache.delete(key)
+
+        existing_business_triage_keys = cache.iter_keys('bgs:ExistingBusinessTriage:*')
+
+        for key in existing_business_triage_keys:
+            self.save(key, ExistingBusinessTriage)
+            cache.delete(key)
+
+    def save(self, key: str, model: Model):
+        triage_uuid = key[key.find(':', 7) + 1 :]  # NOQA: E203
+        persist_to_db(key, model, triage_uuid)

--- a/domestic_growth/tasks.py
+++ b/domestic_growth/tasks.py
@@ -1,0 +1,8 @@
+from django.core.management import call_command
+
+from config.celery import app
+
+
+@app.task
+def move_incomplete_triage_data_from_cache_to_db():
+    call_command('move_triage_data_from_cache_to_db')

--- a/domestic_growth/views.py
+++ b/domestic_growth/views.py
@@ -336,7 +336,7 @@ class ExistingBusinessCurrentlyExportFormView(BaseTriageFormView):
 
     def get_success_url(self):
 
-        triage_data = ExistingBusinessTriage.objects.get(triage_uuid=self.triage_uuid)
+        triage_data = ExistingBusinessTriage.objects.filter(triage_uuid=self.triage_uuid).first()
 
         success_url = ESTABLISHED_GUIDE_URL
 

--- a/tests/unit/domestic_growth/test_commands.py
+++ b/tests/unit/domestic_growth/test_commands.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+
+from domestic_growth.models import ExistingBusinessTriage, StartingABusinessTriage
+
+
+@mock.patch(
+    'domestic_growth.management.commands.move_triage_data_from_cache_to_db.cache.iter_keys',
+    side_effect=[
+        [':1:bgs:StartingABusinessTriage:1234', ':1:bgs:StartingABusinessTriage:5678'],
+        [':1:bgs:ExistingBusinessTriage:1234', ':1:bgs:ExistingBusinessTriage:5678'],
+    ],
+    create=True,
+)
+@mock.patch(
+    'domestic_growth.helpers.cache.get',
+    side_effect=[
+        {'triage_uuid': '1234', 'postcode': 'BT1A6K'},
+        {'triage_uuid': '5678', 'sector_id': 'SL0003'},
+        {'triage_uuid': '1234', 'postcode': 'BT1A6K'},
+        {'triage_uuid': '5678', 'sector_id': 'SL0003'},
+    ],
+)
+@pytest.mark.django_db
+def test_move_cached_triage_data_to_db(mock_helper_cache, mock_command_cache):
+
+    call_command('move_triage_data_from_cache_to_db')
+    assert StartingABusinessTriage.objects.count() == 2
+
+    assert StartingABusinessTriage.objects.get(triage_uuid='1234').postcode == 'BT1A6K'
+    assert StartingABusinessTriage.objects.get(triage_uuid='5678').sector_id == 'SL0003'
+
+    assert ExistingBusinessTriage.objects.count() == 2
+
+    assert ExistingBusinessTriage.objects.get(triage_uuid='1234').postcode == 'BT1A6K'
+    assert ExistingBusinessTriage.objects.get(triage_uuid='5678').sector_id == 'SL0003'
+
+
+@mock.patch(
+    'domestic_growth.management.commands.move_triage_data_from_cache_to_db.cache.iter_keys',
+    return_value=[],
+    create=True,
+)
+@mock.patch('domestic_growth.helpers.cache.get', return_value={})
+@pytest.mark.django_db
+def test_move_cached_triage_data_to_db_no_data(mock_helper_cache, mock_command_cache):
+    call_command('move_triage_data_from_cache_to_db')
+    assert StartingABusinessTriage.objects.count() == 0
+    assert ExistingBusinessTriage.objects.count() == 0


### PR DESCRIPTION
## What
1. Triage data is stored in the cache as the user progresses
2. On the final question for each triage the answers are moved from the cache and persisted in the db
3. A management command is scheduled to run daily that will take partially completed triage responses and persist in db
4. To further reduce db load, the db is only queried on form initialisation if an `edit=true` query parameter exists.

## Why
DB load raised as high-priority item in BGS threat modelling report.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/BGST-430
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
Normal flow
1. Start BGS triage
2. Complete first question
3. Connect to redis
4. View keys - you should see a key in the format e.g. '1:bgs:StartingABusinessTriage:{triage_uuid}
5. View data for key - it should be a dictionary with the answer to the first question
6. Complete the triage
7. Key from point 4 should now not be present
8. Data is persisted in DB

Partial flow (user drops off mid-triage)
1. Start BGS triage
2. Complete first question
3. Connect to redis
4. View keys - you should see a key in the format e.g. '1:bgs:StartingABusinessTriage:{triage_uuid}
5. View data for key - it should be a dictionary with the answer to the first question
6. Run management command `move_triage_data_from_cache_to_db`
7. Key from point 4 should now not be present
8. Partial triage record persisted in DB

- [ ] Documentation has been updated as necessary

Added a comment on [documentation ticket](https://uktrade.atlassian.net/jira/software/c/projects/BGST/boards/1946/timeline?assignee=63e399f1a5d0c826306d2585&selectedIssue=BGST-366)

- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Performance
- [x] Evaluated the performance impact of the changes

The impact of this is to move from 2 db queries per triage page (one for initialising the form and one on form success to `update_or_create`) to a maximum of 1 and in most cases 0 aside from the end triage question.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
