### PR TITLE
Bug greatuk 1786 duplicate learn to export topics

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1011,8 +1011,12 @@ class DetailPage(settings.FEATURE_DEA_V2 and CMSGenericPageAnonymous or CMSGener
     )
 
     def get_steps(self):
+        # Get Topics
         topics = CuratedListPage.objects.live()
-        return [{'text': page.title, 'url': page.url} for page in topics]
+
+        # Filter only by domain specific results - this remove bgs duplicates.
+        domain = urlparse(self.url).netloc
+        return [{'text': page.title, 'url': page.url} for page in topics if domain in page.url]
 
     def get_lesson_category_name(self):
         parent_page = self.get_parent()

--- a/domestic/urls.py
+++ b/domestic/urls.py
@@ -61,7 +61,7 @@ urlpatterns = [
         name='uk-export-contact',
     ),
     path(
-        'Well',
+        'uk-export-contact-form-success/',
         skip_ga360(domestic.views.ukef.SuccessPageView.as_view()),
         name='uk-export-contact-success',
     ),
@@ -95,7 +95,6 @@ urlpatterns = [
         name='campaigns',
     ),
 ]
-
 
 if settings.FEATURE_BGS_CHAT:
     urlpatterns += [path('chat/', domestic.views.chat.bgs_chat_embed, name='bgs-chat-embed')]

--- a/domestic/urls.py
+++ b/domestic/urls.py
@@ -61,7 +61,7 @@ urlpatterns = [
         name='uk-export-contact',
     ),
     path(
-        'uk-export-contact-form-success/',
+        'Well',
         skip_ga360(domestic.views.ukef.SuccessPageView.as_view()),
         name='uk-export-contact-success',
     ),
@@ -95,6 +95,7 @@ urlpatterns = [
         name='campaigns',
     ),
 ]
+
 
 if settings.FEATURE_BGS_CHAT:
     urlpatterns += [path('chat/', domestic.views.chat.bgs_chat_embed, name='bgs-chat-embed')]


### PR DESCRIPTION
This ticket resolved a bug in learn to export where duplicate links are being shows for duplicate bgs / non bgs pages. 

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-2072
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
