### PR TITLE
bug-GREATUK-2107-allow-invest-child-of-bgs-landing

### DIFF
--- a/international/models.py
+++ b/international/models.py
@@ -11,6 +11,7 @@ class GreatInternationalHomePage(cms_panels.GreatInternationalHomePagePanels, Ba
 
     parent_page_types = [
         'domestic.GreatDomesticHomePage',
+        'domestic_growth.DomesticGrowthHomePage',
     ]
 
     template = 'international/index.html'

--- a/tests/unit/international/test_models.py
+++ b/tests/unit/international/test_models.py
@@ -2,11 +2,12 @@ from wagtail.test.utils import WagtailPageTests
 
 from domestic.models import GreatDomesticHomePage
 from international.models import GreatInternationalHomePage
+from domestic_growth.models import DomesticGrowthHomePage
 
 
 class GreatInternationalHomePageTests(WagtailPageTests):
     def test_allowed_parents(self):
         self.assertAllowedParentPageTypes(
             GreatInternationalHomePage,
-            {GreatDomesticHomePage},
+            {GreatDomesticHomePage, DomesticGrowthHomePage},
         )


### PR DESCRIPTION
## What
Allow International / Invest in UK to be a child of the BGS landing page.
## Why
So international and its child services can be moved in wagtail UI

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-2107
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [x] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [x] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [x] Evaluated the performance impact of the changes
- [x] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
