### PR TITLE
Bug greatuk 2147 wagtail redirect should be all sites

### DIFF
--- a/core/management/commands/update_redirects.py
+++ b/core/management/commands/update_redirects.py
@@ -25,9 +25,8 @@ class Command(BaseCommand):
         redirect.redirect_link = redirect_path
 
     def create_redirect(self, old_path, redirect_path):
-        # site=None applies redirect to all sites
         redirect = Redirect.objects.create(
-            old_path=old_path, is_permanent=True, redirect_link=redirect_path, site=None
+            old_path=old_path, is_permanent=True, redirect_link=redirect_path, site=self.site
         )
         return redirect
 
@@ -35,6 +34,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         dry_run = options['dry_run']
         redirect_file_name = options['redirect_file_name']
+
+        self.site = None # site=None applies redirect to all sites
 
         self.stdout.write(self.style.SUCCESS('Updating Redirects'))
 

--- a/core/management/commands/update_redirects.py
+++ b/core/management/commands/update_redirects.py
@@ -12,10 +12,7 @@ from wagtail.models import Site
 class Command(BaseCommand):
     help = 'Updates Redirects for BGS go-live'
 
-    site_str = 'Great.gov.uk'
-
     def add_arguments(self, parser):
-        parser.add_argument('--site_hostname', type=str, required=True, help='Site hostname (e.g., Great.gov.uk)')
         parser.add_argument('--redirect-file-name', type=str, help='redirect-map.csv', default='redirect-map.csv')
         parser.add_argument(
             '--dry_run',
@@ -28,18 +25,16 @@ class Command(BaseCommand):
         redirect.redirect_link = redirect_path
 
     def create_redirect(self, old_path, redirect_path):
+        # site=None applies redirect to all sites
         redirect = Redirect.objects.create(
-            old_path=old_path, is_permanent=True, redirect_link=redirect_path, site=self.site
+            old_path=old_path, is_permanent=True, redirect_link=redirect_path, site=None
         )
         return redirect
 
     @transaction.atomic
     def handle(self, *args, **options):
         dry_run = options['dry_run']
-        site_hostname = options['site_hostname']
         redirect_file_name = options['redirect_file_name']
-
-        self.site = Site.objects.get(hostname=site_hostname)
 
         self.stdout.write(self.style.SUCCESS('Updating Redirects'))
 


### PR DESCRIPTION
## What
Wagtail redirect `from` must be url path (hence redirectmap .csv update) not full_path. Set `site=None` to apply redirect across sites.

ref: https://github.com/wagtail/wagtail/blob/main/wagtail/contrib/redirects/models.py#L112 

## Why

This is required for redirects to work

### Workflow

- [ ] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-2147
- [ ] Jira ticket has the correct status.
- [ ] A clear/description pull request messaged added.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after
- [ ] Documentation has been updated as necessary
- [ ] Where a PR contains code changes developed or maintained by multiple squads a representative from those squads should review the PR.

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] I have checked that my PR is using the latest package versions of: great-components, directory-constants, directory-healthcheck, directory-validators, directory-components, directory-api-client, directory-ch-client, django-staff-sso-client, directory-forms-api-client, directory-sso-api-client, sigauth

### Security
- [ ] Frontend assets have been re-compiled
- [ ] Checked for potential security vulnerabilities
- [ ] Ensured any sensitive data is handled appropriately

### Performance
- [ ] Evaluated the performance impact of the changes
- [ ] Ensured that changes do not negatively affect application scalability.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
