### PR TITLE
GREATUK-2194: use reelative path for bgs guide journey results page market widget

### DIFF
--- a/contact/templates/domestic/contact/export-support/includes/market-widget.html
+++ b/contact/templates/domestic/contact/export-support/includes/market-widget.html
@@ -53,7 +53,7 @@
             {% endif %}
 
             <div class="govuk-!-margin-top-2">
-                <a href="{{ market.get_full_url }}" class="govuk-link great-ds-link" target="_blank">
+                <a href="{% if current_website_name and current_website_name == 'business.gov.uk' %}/export-from-uk/markets/{{ market.slug }}{% else %}{{ market.get_full_url }}{% endif %}" class="govuk-link great-ds-link" target="_blank">
                     <i class="fa fa-arrow-circle-right" aria-hidden="true"></i> 
                     <span>Read more about {{ market_name }}</span>
                 </a>


### PR DESCRIPTION
## What
Make guide journey results page market widget url conditional for bgs
## Why
Broken url for market page

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
